### PR TITLE
DOC: Highlight default port should not be explicit

### DIFF
--- a/swarm-production/README.md
+++ b/swarm-production/README.md
@@ -115,6 +115,8 @@ mode, we can use any of the swarm nodes as the endpoint.
 Note that here we are using the default `zenko` host name, you should use
 the `ENDPOINT` variable configured above if applicable, or whatever the
 `hostname -f` command returns.
+ > IMPORTANT: when using default port 80, it should never be specified after the
+ > endpoint address. If using a custom port, it must be specified.
 
 ```shell
 $ export AWS_ACCESS_KEY_ID=deployment-specific-access-key

--- a/swarm-testing/README.md
+++ b/swarm-testing/README.md
@@ -33,16 +33,17 @@ ei95xqodynoc  zenko-testing_s3  replicated  1/1       scality/s3server:latest
 
 Using [awscli](https://aws.amazon.com/cli/), we can perform S3 operations
 on our Zenko stack:
-
+ > IMPORTANT: when using default port 80, it should never be specified after the
+ > endpoint address. If using a custom port, it must be specified.
 ```
 $ export AWS_ACCESS_KEY_ID=accessKey1
 $ export AWS_SECRET_ACCESS_KEY=verySecretKey1
-$ aws s3 --endpoint http://localhost:80 mb s3://bucket1 --region=us-east-1
+$ aws s3 --endpoint http://localhost mb s3://bucket1 --region=us-east-1
 make_bucket: bucket1
-$ aws s3 --endpoint http://localhost:80 ls
+$ aws s3 --endpoint http://localhost ls
 2017-06-15 16:42:58 bucket1
-$ aws s3 --endpoint http://localhost:80 cp README.md s3://bucket1
+$ aws s3 --endpoint http://localhost cp README.md s3://bucket1
 upload: ./README.md to s3://bucket1/README.md
-$ aws s3 --endpoint http://localhost:80 ls s3://bucket1
+$ aws s3 --endpoint http://localhost ls s3://bucket1
 2017-06-15 17:36:10       1484 README.md
 ```


### PR DESCRIPTION
 When using aws cli with Zenko, if the port is still the default 80, it
 should not be specified under the `--endpoint` option.