### PR TITLE
FT: expose UtAPI port in CloudServer

### DIFF
--- a/swarm-production/docker-stack.yml
+++ b/swarm-production/docker-stack.yml
@@ -41,6 +41,7 @@ services:
     image: scality/s3server
     ports:
       - "8000"
+      - "8100:8100"
     networks:
       - backend
       - frontend-dmz


### PR DESCRIPTION
 - In current deployments, the 8100 port is not exposed by default in
 production stacks. This is limiting as it requires either executing
 commands from inside the CloudServer frontend container, or deploying
 an extra UTAPI service. This commit exposes the UTAPI port by default.