### PR TITLE
ZENKO-9 Replicaset Compatibility

### DIFF
--- a/helm/zenko/charts/cloudserver-front/templates/deployment.yaml
+++ b/helm/zenko/charts/cloudserver-front/templates/deployment.yaml
@@ -28,6 +28,16 @@ spec:
               value: "{{- printf "%s-%s" .Release.Name "s3-metadata" | trunc 63 | trimSuffix "-" -}}"
             - name: REDIS_HOST
               value: "{{- printf "%s-%s" .Release.Name "redis" | trunc 63 | trimSuffix "-" -}}"
+{{- if .Values.global.mongodbBackend.enabled }}
+            - name: S3METADATA
+              value: "mongodb"
+            - name: MONGODB_HOST
+              value: "{{ .Release.Name }}-mongodb-replicaset"
+            - name: MONGODB_PORT
+              value: "{{ .Values.global.mongodbBackend.port }}"
+            - name: MONGODB_RS
+              value: "{{ .Values.global.mongodbBackend.replicaSet }}"
+{{- end}}
 {{- if .Values.orbit.enabled }}
             - name: REMOTE_MANAGEMENT_DISABLE
               value: "0"

--- a/helm/zenko/charts/cloudserver-front/values.yaml
+++ b/helm/zenko/charts/cloudserver-front/values.yaml
@@ -13,7 +13,7 @@ credentials:
 
 replicaCount: 1
 image:
-  repository: zenko/cloudserver
+  repository: zenko/cloudserver:0.1.0
   tag: pensieve-0
   pullPolicy: IfNotPresent
 service:

--- a/helm/zenko/charts/mongodb-replicaset/.helmignore
+++ b/helm/zenko/charts/mongodb-replicaset/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/helm/zenko/charts/mongodb-replicaset/Chart.yaml
+++ b/helm/zenko/charts/mongodb-replicaset/Chart.yaml
@@ -1,0 +1,11 @@
+name: mongodb-replicaset
+home: https://github.com/mongodb/mongo
+version: 2.1.4
+description: NoSQL document-oriented database that stores JSON-like documents with
+  dynamic schemas, simplifying the integration of data in content-driven applications.
+icon: https://webassets.mongodb.com/_com_assets/cms/mongodb-logo-rgb-j6w271g1xn.jpg
+sources:
+- https://github.com/mongodb/mongo
+maintainers:
+- name: Anirudh Ramanathan
+  email: ramanathana@google.com

--- a/helm/zenko/charts/mongodb-replicaset/README.md
+++ b/helm/zenko/charts/mongodb-replicaset/README.md
@@ -1,0 +1,290 @@
+# MongoDB Helm Chart
+
+## Prerequisites Details
+* Kubernetes 1.6+ with Beta APIs enabled.
+* PV support on the underlying infrastructure.
+
+## StatefulSet Details
+* https://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/
+
+## StatefulSet Caveats
+* https://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/#limitations
+
+## Chart Details
+
+This chart implements a dynamically scalable [MongoDB replica set](https://docs.mongodb.com/manual/tutorial/deploy-replica-set/)
+using Kubernetes StatefulSets and Init Containers.
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+$ helm install --name my-release stable/mongodb-replicaset
+```
+
+## Configuration
+
+The following tables lists the configurable parameters of the mongodb chart and their default values.
+
+| Parameter                       | Description                                                               | Default                                             |
+| ------------------------------- | ------------------------------------------------------------------------- | --------------------------------------------------- |
+| `replicaSet`                    | Name of the replica set                                                   | rs0                                                 |
+| `replicas`                      | Number of replicas in the replica set                                     | 3                                                   |
+| `port`                          | MongoDB port                                                              | 27017                                               |
+| `installImage.name`             | Image name for the init container that establishes the replica set        | gcr.io/google_containers/mongodb-install            |
+| `installImage.tag`              | Image tag for the init container that establishes the replica set         | 0.3                                                 |
+| `installImage.pullPolicy`       | Image pull policy for the init container that establishes the replica set | IfNotPresent                                        |
+| `image.name`                    | MongoDB image name                                                        | mongo                                               |
+| `image.tag`                     | MongoDB image tag                                                         | 3.4                                                 |
+| `image.pullPolicy`              | MongoDB image pull policy                                                 | IfNotPresent                                        |
+| `podAnnotations`                | Annotations to be added to MongoDB pods                                   | {}                                                  |
+| `resources`                     | Pod resource requests and limits                                          | {}                                                  |
+| `persistentVolume.enabled`      | If `true`, persistent volume claims are created                           | `true`                                              |
+| `persistentVolume.storageClass` | Persistent volume storage class                                           | `volume.alpha.kubernetes.io/storage-class: default` |
+| `persistentVolume.accessMode`   | Persistent volume access modes                                            | [ReadWriteOnce]                                     |
+| `persistentVolume.size`         | Persistent volume size                                                    | 10Gi                                                |
+| `persistentVolume.annotations`  | Persistent volume annotations                                             | {}                                                  |
+| `tls.enabled`                   | Enable MongoDB TLS support including authentication                       | `false`                                             |
+| `tls.cacert`                    | The CA certificate used for the members                                   | Our self signed CA certificate                      |
+| `tls.cakey`                     | The CA key used for the members                                           | Our key for the self signed CA certificate          |
+| `auth.enabled`                  | If `true`, keyfile access control is enabled                              | `false`                                             |
+| `auth.key`                      | key for internal authentication                                           |                                                     |
+| `auth.existingKeySecret`        | If set, an existing secret with this name for the key is used             |                                                     |
+| `auth.adminUser`                | MongoDB admin user                                                        |                                                     |
+| `auth.adminPassword`            | MongoDB admin password                                                    |                                                     |
+| `auth.existingAdminSecret`      | If set, and existing secret with this name is used for the admin user     |                                                     |
+| `serviceAnnotations`            | Annotations to be added to the service                                    | {}                                                  |
+| `configmap`                     | Content of the MongoDB config file                                        | See below                                           |
+| `nodeSelector`                  | Node labels for pod assignment                                            | {}                                                  |
+
+*MongoDB config file*
+
+The MongoDB config file `mongod.conf` is configured via the `configmap` configuration value. The defaults from 
+`values.yaml` are the following:
+
+```yaml
+configmap:
+  storage:
+    dbPath: /data/db
+  net:
+    port: 27017
+  replication:
+    replSetName: rs0
+```
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install --name my-release -f values.yaml stable/mongodb-replicaset
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+Once you have all 3 nodes in running, you can run the "test.sh" script in this directory, which will insert a key into the primary and check the secondaries for output. This script requires that the `$RELEASE_NAME` environment variable be set, in order to access the pods.
+
+## Authentication
+
+By default, this chart creates a MongoDB replica set without authentication. Authentication can be enabled using the 
+parameter `auth.enabled`. Once enabled, keyfile access control is set up and an admin user with root privileges
+is created. User credentials and keyfile may be specified directly. Alternatively, existing secrets may be provided. 
+The secret for the admin user must contain the keys `user` and `password`, that for the key file must contain `key.txt`.
+
+## TLS support
+
+To enable full TLS encryption set `tls.enabled` to `true`. It is recommended to create your own CA by executing:
+
+```console
+$ openssl genrsa -out ca.key 2048
+$ openssl req -x509 -new -nodes -key ca.key -days 10000 -out ca.crt -subj "/CN=mydomain.com"
+```
+
+After that paste the base64 encoded (`cat ca.key | base64 -w0`) cert and key into the fields `tls.cacert` and
+`tls.cakey`. Adapt the configmap for the replicaset as follows:
+
+```yml
+configmap:
+  storage:
+    dbPath: /data/db
+  net:
+    port: 27017
+    ssl:
+      mode: requireSSL
+      CAFile: /ca/tls.crt
+      PEMKeyFile: /work-dir/mongo.pem
+  replication:
+    replSetName: rs0
+  security:
+    authorization: enabled
+    clusterAuthMode: x509
+    keyFile: /keydir/key.txt
+```
+
+To access the cluster you need one of the certificates generated during cluster setup in `/work-dir/mongo.pem` of the
+certain container or you generate your own one via:
+
+```console
+$ cat >openssl.cnf <<EOL
+[req]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+[req_distinguished_name]
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = $HOSTNAME1
+DNS.1 = $HOSTNAME2
+EOL
+$ openssl genrsa -out mongo.key 2048
+$ openssl req -new -key mongo.key -out mongo.csr -subj "/CN=$HOSTNAME" -config openssl.cnf
+$ openssl x509 -req -in mongo.csr \
+    -CA $MONGOCACRT -CAkey $MONGOCAKEY -CAcreateserial \
+    -out mongo.crt -days 3650 -extensions v3_req -extfile openssl.cnf
+$ rm mongo.csr
+$ cat mongo.crt mongo.key > mongo.pem
+$ rm mongo.key mongo.crt
+```
+
+Please ensure that you exchange the `$HOSTNAME` with your actual hostname and the `$HOSTNAME1`, `$HOSTNAME2`, etc. with
+alternative hostnames you want to allow access to the MongoDB replicaset. You should now be able to authenticate to the
+mongodb with your `mongo.pem` certificate:
+
+```console
+$ mongo --ssl --sslCAFile=ca.crt --sslPEMKeyFile=mongo.pem --eval "db.adminCommand('ping')"
+```
+
+## Deep dive
+
+Because the pod names are dependent on the name chosen for it, the following examples use the
+environment variable `RELEASENAME`. For example, if the helm release name is `messy-hydra`, one would need to set the following before proceeding. The example scripts below assume 3 pods only.
+
+```console
+export RELEASE_NAME=messy-hydra
+```
+
+### Cluster Health
+
+```console
+$ for i in 0 1 2; do kubectl exec $RELEASE_NAME-mongodb-replicaset-$i -- sh -c 'mongo --eval="printjson(db.serverStatus())"'; done
+```
+
+### Failover
+
+One can check the roles being played by each node by using the following:
+```console
+$ for i in 0 1 2; do kubectl exec $RELEASE_NAME-mongodb-replicaset-$i -- sh -c 'mongo --eval="printjson(rs.isMaster())"'; done
+
+MongoDB shell version: 3.4.5
+connecting to: mongodb://127.0.0.1:27017
+MongoDB server version: 3.4.5
+{
+	"hosts" : [
+		"messy-hydra-mongodb-0.messy-hydra-mongodb.default.svc.cluster.local:27017",
+		"messy-hydra-mongodb-1.messy-hydra-mongodb.default.svc.cluster.local:27017",
+		"messy-hydra-mongodb-2.messy-hydra-mongodb.default.svc.cluster.local:27017"
+	],
+	"setName" : "rs0",
+	"setVersion" : 3,
+	"ismaster" : true,
+	"secondary" : false,
+	"primary" : "messy-hydra-mongodb-0.messy-hydra-mongodb.default.svc.cluster.local:27017",
+	"me" : "messy-hydra-mongodb-0.messy-hydra-mongodb.default.svc.cluster.local:27017",
+	"electionId" : ObjectId("7fffffff0000000000000001"),
+	"maxBsonObjectSize" : 16777216,
+	"maxMessageSizeBytes" : 48000000,
+	"maxWriteBatchSize" : 1000,
+	"localTime" : ISODate("2016-09-13T01:10:12.680Z"),
+	"maxWireVersion" : 4,
+	"minWireVersion" : 0,
+	"ok" : 1
+}
+
+
+```
+This lets us see which member is primary.
+
+Let us now test persistence and failover. First, we insert a key (in the below example, we assume pod 0 is the master):
+```console
+$ kubectl exec $RELEASE_NAME-mongodb-replicaset-0 -- mongo --eval="printjson(db.test.insert({key1: 'value1'}))"
+
+MongoDB shell version: 3.4.5
+connecting to: mongodb://127.0.0.1:27017
+{ "nInserted" : 1 }
+```
+
+Watch existing members:
+```console
+$ kubectl run --attach bbox --image=mongo:3.4 --restart=Never --env="RELEASE_NAME=$RELEASE_NAME" -- sh -c 'while true; do for i in 0 1 2; do echo $RELEASE_NAME-mongodb-replicaset-$i $(mongo --host=$RELEASE_NAME-mongodb-replicaset-$i.$RELEASE_NAME-mongodb-replicaset --eval="printjson(rs.isMaster())" | grep primary); sleep 1; done; done';
+
+Waiting for pod default/bbox2 to be running, status is Pending, pod ready: false
+If you don't see a command prompt, try pressing enter.
+messy-hydra-mongodb-2 "primary" : "messy-hydra-mongodb-0.messy-hydra-mongodb.default.svc.cluster.local:27017",
+messy-hydra-mongodb-0 "primary" : "messy-hydra-mongodb-0.messy-hydra-mongodb.default.svc.cluster.local:27017",
+messy-hydra-mongodb-1 "primary" : "messy-hydra-mongodb-0.messy-hydra-mongodb.default.svc.cluster.local:27017",
+messy-hydra-mongodb-2 "primary" : "messy-hydra-mongodb-0.messy-hydra-mongodb.default.svc.cluster.local:27017",
+messy-hydra-mongodb-0 "primary" : "messy-hydra-mongodb-0.messy-hydra-mongodb.default.svc.cluster.local:27017",
+
+```
+
+Kill the primary and watch as a new master getting elected.
+```console
+$ kubectl delete pod $RELEASE_NAME-mongodb-replicaset-0
+
+pod "messy-hydra-mongodb-0" deleted
+```
+
+Delete all pods and let the statefulset controller bring it up.
+```console
+$ kubectl delete po -l "app=mongodb-replicaset,release=$RELEASE_NAME"
+$ kubectl get po --watch-only
+NAME                    READY     STATUS        RESTARTS   AGE
+messy-hydra-mongodb-0   0/1       Pending   0         0s
+messy-hydra-mongodb-0   0/1       Pending   0         0s
+messy-hydra-mongodb-0   0/1       Pending   0         7s
+messy-hydra-mongodb-0   0/1       Init:0/2   0         7s
+messy-hydra-mongodb-0   0/1       Init:1/2   0         27s
+messy-hydra-mongodb-0   0/1       Init:1/2   0         28s
+messy-hydra-mongodb-0   0/1       PodInitializing   0         31s
+messy-hydra-mongodb-0   0/1       Running   0         32s
+messy-hydra-mongodb-0   1/1       Running   0         37s
+messy-hydra-mongodb-1   0/1       Pending   0         0s
+messy-hydra-mongodb-1   0/1       Pending   0         0s
+messy-hydra-mongodb-1   0/1       Init:0/2   0         0s
+messy-hydra-mongodb-1   0/1       Init:1/2   0         20s
+messy-hydra-mongodb-1   0/1       Init:1/2   0         21s
+messy-hydra-mongodb-1   0/1       PodInitializing   0         24s
+messy-hydra-mongodb-1   0/1       Running   0         25s
+messy-hydra-mongodb-1   1/1       Running   0         30s
+messy-hydra-mongodb-2   0/1       Pending   0         0s
+messy-hydra-mongodb-2   0/1       Pending   0         0s
+messy-hydra-mongodb-2   0/1       Init:0/2   0         0s
+messy-hydra-mongodb-2   0/1       Init:1/2   0         21s
+messy-hydra-mongodb-2   0/1       Init:1/2   0         22s
+messy-hydra-mongodb-2   0/1       PodInitializing   0         25s
+messy-hydra-mongodb-2   0/1       Running   0         26s
+messy-hydra-mongodb-2   1/1       Running   0         30s
+
+
+...
+messy-hydra-mongodb-0 "primary" : "messy-hydra-mongodb-0.messy-hydra-mongodb.default.svc.cluster.local:27017",
+messy-hydra-mongodb-1 "primary" : "messy-hydra-mongodb-0.messy-hydra-mongodb.default.svc.cluster.local:27017",
+messy-hydra-mongodb-2 "primary" : "messy-hydra-mongodb-0.messy-hydra-mongodb.default.svc.cluster.local:27017",
+```
+
+Check the previously inserted key:
+```console
+$ kubectl exec $RELEASE_NAME-mongodb-replicaset-1 -- mongo --eval="rs.slaveOk(); db.test.find({key1:{\$exists:true}}).forEach(printjson)"
+
+MongoDB shell version: 3.4.5
+connecting to: mongodb://127.0.0.1:27017
+{ "_id" : ObjectId("57b180b1a7311d08f2bfb617"), "key1" : "value1" }
+```
+
+### Scaling
+
+Scaling should be managed by `helm upgrade`, which is the recommended way.

--- a/helm/zenko/charts/mongodb-replicaset/mongodb-up-test.sh
+++ b/helm/zenko/charts/mongodb-replicaset/mongodb-up-test.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+    MONGOCACRT=/ca/tls.crt
+    MONGOPEM=/work-dir/mongo.pem
+    if [ -f $MONGOPEM ]; then
+        MONGOARGS="--ssl --sslCAFile $MONGOCACRT --sslPEMKeyFile $MONGOPEM"
+    fi
+
+    pod_name() {
+        local full_name="${FULL_NAME?Environment variable FULL_NAME not set}"
+        local index="$1"
+        echo "$full_name-$index.$full_name"
+    }
+
+    replicas() {
+        echo "${REPLICAS?Environment variable REPLICAS not set}"
+    }
+
+    master_pod() {
+        for ((i = 0; i < $(replicas); ++i)); do
+            response=$(mongo "$MONGOARGS" "--host=$(pod_name $i)" "--eval=rs.isMaster().ismaster")
+            if [[ $response =~ "true" ]]; then
+                pod_name "$i"
+                break
+            fi
+        done
+    }
+
+    setup() {
+        local ready=0
+        until [[ $ready -eq $(replicas) ]]; do
+            echo "Waiting for application to become ready" >&2
+            sleep 1
+
+            for ((i = 0; i < $(replicas); ++i)); do
+                response=$(mongo "$MONGOARGS" "--host=$(pod_name $i)" "--eval=rs.status()" || true)
+                if [[ $response =~ .*ok.* ]]; then
+                    ready=$((ready + 1))
+                fi
+            done
+        done
+    }
+
+    @test "Testing mongodb client is accessible" {
+        mongo -h
+        [ "$?" -eq 0 ]
+    }
+
+    @test "Connect mongodb client to mongodb pods" {
+        for ((i = 0; i < $(replicas); ++i)); do
+            response=$(mongo "$MONGOARGS" "--host=$(pod_name $i)" "--eval=rs.status()")
+            if [[ ! $response =~ .*ok.* ]]; then
+                exit 1
+            fi
+        done
+    }
+
+    @test "Write key to master" {
+        response=$(mongo "$MONGOARGS" --host=$(master_pod) "--eval=db.test.insert({\"abc\": \"def\"}).nInserted")
+        if [[ ! $response =~ "1" ]]; then
+            exit 1
+        fi
+    }
+
+    @test "Read key from slaves" {
+        # wait for slaves to catch up
+        sleep 10
+
+        for ((i = 0; i < $(replicas); ++i)); do
+            response=$(mongo "$MONGOARGS" --host=$(pod_name $i) "--eval=rs.slaveOk(); db.test.find({\"abc\":\"def\"})")
+            if [[ ! $response =~ .*def.* ]]; then
+                exit 1
+            fi
+        done
+    }

--- a/helm/zenko/charts/mongodb-replicaset/templates/NOTES.txt
+++ b/helm/zenko/charts/mongodb-replicaset/templates/NOTES.txt
@@ -1,0 +1,14 @@
+1. After the statefulset is created completely, one can check which instance is primary by running:
+
+    $ for ((i = 0; i < {{ .Values.replicas }}; ++i)); do kubectl exec --namespace {{ .Release.Namespace }} {{ template "mongodb-replicaset.fullname" . }}-$i -- sh -c 'mongo --eval="printjson(rs.isMaster())"'; done
+
+2. One can insert a key into the primary instance of the mongodb replica set by running the following:
+    MASTER_POD_NAME must be replaced with the name of the master found from the previous step.
+
+    $ kubectl exec --namespace {{ .Release.Namespace }} MASTER_POD_NAME -- mongo --eval="printjson(db.test.insert({key1: 'value1'}))"
+
+3. One can fetch the keys stored in the primary or any of the slave nodes in the following manner.
+    POD_NAME must be replaced by the name of the pod being queried.
+
+    $ kubectl exec --namespace {{ .Release.Namespace }} POD_NAME -- mongo --eval="rs.slaveOk(); db.test.find().forEach(printjson)"
+

--- a/helm/zenko/charts/mongodb-replicaset/templates/_helpers.tpl
+++ b/helm/zenko/charts/mongodb-replicaset/templates/_helpers.tpl
@@ -1,0 +1,38 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mongodb-replicaset.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "mongodb-replicaset.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name for the admin secret.
+*/}}
+{{- define "mongodb-replicaset.adminSecret" -}}
+    {{- if .Values.auth.existingAdminSecret -}}
+        {{- .Values.auth.existingAdminSecret -}}
+    {{- else -}}
+        {{- template "mongodb-replicaset.fullname" . -}}-admin
+    {{- end -}}
+{{- end -}}
+
+{{/*
+Create the name for the key secret.
+*/}}
+{{- define "mongodb-replicaset.keySecret" -}}
+    {{- if .Values.auth.existingKeySecret -}}
+        {{- .Values.auth.existingKeySecret -}}
+    {{- else -}}
+        {{- template "mongodb-replicaset.fullname" . -}}-keyfile
+    {{- end -}}
+{{- end -}}

--- a/helm/zenko/charts/mongodb-replicaset/templates/mongodb-admin-secret.yaml
+++ b/helm/zenko/charts/mongodb-replicaset/templates/mongodb-admin-secret.yaml
@@ -1,0 +1,15 @@
+{{- if and (.Values.auth.enabled) (not .Values.auth.existingAdminSecret) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: {{ template "mongodb-replicaset.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "mongodb-replicaset.adminSecret" . }}
+type: Opaque
+data:
+  user: {{ .Values.auth.adminUser | b64enc }}
+  password: {{ .Values.auth.adminPassword | b64enc }}
+{{- end -}}

--- a/helm/zenko/charts/mongodb-replicaset/templates/mongodb-ca.yaml
+++ b/helm/zenko/charts/mongodb-replicaset/templates/mongodb-ca.yaml
@@ -1,0 +1,15 @@
+{{- if and (.Values.tls.enabled) -}}
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  labels:
+    app: {{ template "mongodb-replicaset.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "mongodb-replicaset.fullname" . }}-ca
+data:
+  tls.key: {{ .Values.tls.cakey }}
+  tls.crt: {{ .Values.tls.cacert }}
+{{- end -}}

--- a/helm/zenko/charts/mongodb-replicaset/templates/mongodb-configmap.yaml
+++ b/helm/zenko/charts/mongodb-replicaset/templates/mongodb-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "mongodb-replicaset.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "mongodb-replicaset.fullname" . }}
+data:
+  mongod.conf: |
+{{ toYaml .Values.configmap | indent 4 }}

--- a/helm/zenko/charts/mongodb-replicaset/templates/mongodb-keyfile-secret.yaml
+++ b/helm/zenko/charts/mongodb-replicaset/templates/mongodb-keyfile-secret.yaml
@@ -1,0 +1,15 @@
+{{- if and (.Values.auth.enabled) (not .Values.auth.existingKeySecret) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: {{ template "mongodb-replicaset.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "mongodb-replicaset.keySecret" . }}
+type: Opaque
+data:
+  key.txt: {{ .Values.auth.key | b64enc }}
+{{- end -}}
+

--- a/helm/zenko/charts/mongodb-replicaset/templates/mongodb-service.yaml
+++ b/helm/zenko/charts/mongodb-replicaset/templates/mongodb-service.yaml
@@ -1,0 +1,24 @@
+# A headless service to create DNS records
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+  {{- if .Values.serviceAnnotations }}
+{{ toYaml .Values.serviceAnnotations | indent 4 }}
+  {{- end }}
+  labels:
+    app: {{ template "mongodb-replicaset.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "mongodb-replicaset.fullname" . }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: peer
+      port: {{ .Values.port }}
+  selector:
+    app: {{ template "mongodb-replicaset.name" . }}
+    release: {{ .Release.Name }}

--- a/helm/zenko/charts/mongodb-replicaset/templates/mongodb-service.yaml
+++ b/helm/zenko/charts/mongodb-replicaset/templates/mongodb-service.yaml
@@ -18,7 +18,11 @@ spec:
   clusterIP: None
   ports:
     - name: peer
+    {{- if .Values.global.mongodbBackend.enabled }}
+      port: {{ .Values.global.mongodbBackend.port }}
+    {{- else }}
       port: {{ .Values.port }}
+    {{- end }}
   selector:
     app: {{ template "mongodb-replicaset.name" . }}
     release: {{ .Release.Name }}

--- a/helm/zenko/charts/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/helm/zenko/charts/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -1,0 +1,218 @@
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  labels:
+    app: {{ template "mongodb-replicaset.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "mongodb-replicaset.fullname" . }}
+spec:
+  serviceName: {{ template "mongodb-replicaset.fullname" . }}
+  replicas: {{ .Values.replicas }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "mongodb-replicaset.name" . }}
+        release: {{ .Release.Name }}
+      annotations:
+      {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+      {{- end }}
+    spec:
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
+      initContainers:
+        - name: install
+          image: "{{ .Values.installImage.name }}:{{ .Values.installImage.tag }}"
+          args:
+            - --work-dir=/work-dir
+          imagePullPolicy: "{{ .Values.installImage.pullPolicy }}"
+          volumeMounts:
+            - name: workdir
+              mountPath: /work-dir
+            - name: config
+              mountPath: /config
+        - name: bootstrap
+          image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
+          command:
+            - /work-dir/peer-finder
+          args:
+            - -on-start=/work-dir/on-start.sh
+            - "-service={{ template "mongodb-replicaset.fullname" . }}"
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: REPLICA_SET
+              value: {{ .Values.replicaSet }}
+          {{- if .Values.auth.enabled }}
+            - name: AUTH
+              value: "true"
+            - name: ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "mongodb-replicaset.adminSecret" . }}"
+                  key: user
+            - name: ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "mongodb-replicaset.adminSecret" . }}"
+                  key: password
+          {{- end }}
+          volumeMounts:
+            - name: workdir
+              mountPath: /work-dir
+            - name: config
+              mountPath: /config
+          {{- if and (.Values.tls.enabled) }}
+            - name: ca
+              mountPath: /ca
+          {{- end }}
+            - name: datadir
+              mountPath: /data/db
+          {{- if .Values.auth.enabled }}
+            - name: keydir
+              mountPath: /keydir
+              readOnly: true
+          {{- end }}
+      containers:
+        - name: {{ template "mongodb-replicaset.name" . }}
+          image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          ports:
+            - name: peer
+              containerPort: {{ .Values.port }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          command:
+            - mongod
+            - --config=/config/mongod.conf
+          {{- if .Values.auth.enabled }}
+          env:
+            - name: AUTH
+              value: "true"
+            - name: ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "mongodb-replicaset.adminSecret" . }}"
+                  key: user
+            - name: ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "mongodb-replicaset.adminSecret" . }}"
+                  key: password
+          {{- end }}
+          livenessProbe:
+            exec:
+              command:
+                - mongo
+              {{- if and (.Values.tls.enabled) }}
+                - --ssl
+                - --sslCAFile=/ca/tls.crt
+                - --sslPEMKeyFile=/work-dir/mongo.pem
+              {{- end }}
+                - --eval
+                - "db.adminCommand('ping')"
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+                - mongo
+              {{- if and (.Values.tls.enabled) }}
+                - --ssl
+                - --sslCAFile=/ca/tls.crt
+                - --sslPEMKeyFile=/work-dir/mongo.pem
+              {{- end }}
+                - --eval
+                - "db.adminCommand('ping')"
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - name: datadir
+              mountPath: /data/db
+            - name: config
+              mountPath: /config
+          {{- if and (.Values.tls.enabled) }}
+            - name: ca
+              mountPath: /ca
+          {{- end }}
+            - name: workdir
+              mountPath: /work-dir
+          {{- if .Values.auth.enabled }}
+            - name: keydir
+              mountPath: /keydir
+              readOnly: true
+          {{- end }}
+      {{- if eq .Values.podAntiAffinity "hard" }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchLabels:
+                  app: "{{ template "mongodb-replicaset.name" . }}"
+                  release: "{{ .Release.Name }}"
+      {{- else if eq .Values.podAntiAffinity "soft" }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app: "{{ template "mongodb-replicaset.name" . }}"
+                    release: "{{ .Release.Name }}"
+      {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ template "mongodb-replicaset.fullname" . }}
+        {{- if and (.Values.tls.enabled) }}
+        - name: ca
+          secret:
+            defaultMode: 0400
+            secretName: {{ template "mongodb-replicaset.fullname" . }}-ca
+        {{- end }}
+        {{- if .Values.auth.enabled }}
+        - name: keydir
+          secret:
+            defaultMode: 0400
+            secretName: {{ template "mongodb-replicaset.keySecret" . }}
+        {{- end }}
+        - name: workdir
+          emptyDir: {}
+{{- if .Values.persistentVolume.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        annotations:
+        {{- range $key, $value := .Values.persistentVolume.annotations }}
+          {{ $key }}: {{ $value }}
+        {{- end }}
+      spec:
+        accessModes:
+        {{- range .Values.persistentVolume.accessModes }}
+          - {{ . | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.persistentVolume.size | quote }}
+      {{- if .Values.persistentVolume.storageClass }}
+      {{- if (eq "-" .Values.persistentVolume.storageClass) }}
+        storageClassName: ""
+      {{- else }}
+        storageClassName: "{{ .Values.persistentVolume.storageClass }}"
+      {{- end }}
+      {{- end }}
+{{- else }}
+        - name: datadir
+          emptyDir: {}
+{{- end }}

--- a/helm/zenko/charts/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/helm/zenko/charts/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -9,7 +9,11 @@ metadata:
   name: {{ template "mongodb-replicaset.fullname" . }}
 spec:
   serviceName: {{ template "mongodb-replicaset.fullname" . }}
+{{- if .Values.global.mongodbBackend.enabled }}
+  replicas: {{ .Values.global.mongodbBackend.replicas }}
+{{- else }}
   replicas: {{ .Values.replicas }}
+{{- end }}
   template:
     metadata:
       labels:
@@ -50,7 +54,11 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.namespace
             - name: REPLICA_SET
+            {{- if .Values.global.mongodbBackend.enabled }}
+              value: {{ .Values.global.mongodbBackend.replicaSet }}
+            {{- else }}
               value: {{ .Values.replicaSet }}
+            {{- end }}
           {{- if .Values.auth.enabled }}
             - name: AUTH
               value: "true"
@@ -87,7 +95,11 @@ spec:
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           ports:
             - name: peer
+            {{- if .Values.global.mongodbBackend.enabled }}
+              containerPort: {{ .Values.global.mongodbBackend.port }}
+            {{- else }}
               containerPort: {{ .Values.port }}
+            {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           command:

--- a/helm/zenko/charts/mongodb-replicaset/templates/tests/mongodb-up-test-configmap.yaml
+++ b/helm/zenko/charts/mongodb-replicaset/templates/tests/mongodb-up-test-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "mongodb-replicaset.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "mongodb-replicaset.fullname" . }}-tests
+data:
+  mongodb-up-test.sh: |-
+    {{ .Files.Get "mongodb-up-test.sh" }}

--- a/helm/zenko/charts/mongodb-replicaset/templates/tests/mongodb-up-test-pod.yaml
+++ b/helm/zenko/charts/mongodb-replicaset/templates/tests/mongodb-up-test-pod.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: {{ template "mongodb-replicaset.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "mongodb-replicaset.fullname" . }}-test
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  initContainers:
+    - name: test-framework
+      image: dduportal/bats:0.4.0
+      command:
+        - bash
+        - -c
+        - |
+          set -ex
+          # copy bats to tools dir
+          cp -R /usr/local/libexec/ /tools/bats/
+      volumeMounts:
+        - name: tools
+          mountPath: /tools
+  containers:
+    - name: mongo
+      image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
+      command:
+        - /tools/bats/bats
+        - -t
+        - /tests/mongodb-up-test.sh
+      env:
+        - name: FULL_NAME
+          value: {{ template "mongodb-replicaset.fullname" . }}
+        - name: REPLICAS
+          value: "{{ .Values.replicas }}"
+      volumeMounts:
+        - name: tools
+          mountPath: /tools
+        - name: tests
+          mountPath: /tests
+  volumes:
+    - name: tools
+      emptyDir: {}
+    - name: tests
+      configMap:
+        name: {{ template "mongodb-replicaset.fullname" . }}-tests
+  restartPolicy: Never

--- a/helm/zenko/charts/mongodb-replicaset/templates/tests/mongodb-up-test-pod.yaml
+++ b/helm/zenko/charts/mongodb-replicaset/templates/tests/mongodb-up-test-pod.yaml
@@ -34,7 +34,11 @@ spec:
         - name: FULL_NAME
           value: {{ template "mongodb-replicaset.fullname" . }}
         - name: REPLICAS
+        {{- if .Values.global.mongodbBackend.enabled }}
+          value: "{{ .Values.global.mongodbBackend.replicas }}"
+        {{- else }}
           value: "{{ .Values.replicas }}"
+        {{- end }}
       volumeMounts:
         - name: tools
           mountPath: /tools

--- a/helm/zenko/charts/mongodb-replicaset/test.sh
+++ b/helm/zenko/charts/mongodb-replicaset/test.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+# Copyright 2016 The Kubernetes Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+NS="${RELEASE_NAMESPACE:-default}"
+POD_NAME="${RELEASE_NAME:-mongo}-mongodb-replicaset"
+
+MONGOCACRT=/ca/tls.crt
+MONGOPEM=/work-dir/mongo.pem
+if [ -f $MONGOPEM ]; then
+    MONGOARGS="--ssl --sslCAFile $MONGOCACRT --sslPEMKeyFile $MONGOPEM"
+fi
+
+for i in $(seq 0 2); do
+    pod="${POD_NAME}-$i"
+    kubectl exec --namespace $NS $pod -- sh -c 'mongo '"$MONGOARGS"' --eval="printjson(rs.isMaster())"' | grep '"ismaster" : true'
+
+    if [ $? -eq 0 ]; then
+        echo "Found master: $pod"
+        MASTER=$pod
+        break
+    fi
+done
+
+kubectl exec --namespace $NS $MASTER -- mongo "$MONGOARGS" --eval='printjson(db.test.insert({"status": "success"}))'
+
+# TODO: find maximum duration to wait for slaves to be up-to-date with master.
+sleep 2
+
+for i in $(seq 0 2); do
+    pod="${POD_NAME}-$i"
+    if [[ $pod != $MASTER ]]; then
+        echo "Reading from slave: $pod"
+        kubectl exec --namespace $NS $pod -- mongo "$MONGOARGS" --eval='rs.slaveOk(); db.test.find().forEach(printjson)'
+    fi
+done

--- a/helm/zenko/charts/mongodb-replicaset/values.yaml
+++ b/helm/zenko/charts/mongodb-replicaset/values.yaml
@@ -1,0 +1,88 @@
+release: zenko
+replicaSet: rs0
+replicas: 5
+port: 27017
+
+auth:
+  enabled: false
+  # adminUser: username
+  # adminPassword: password
+  # key: keycontent
+  # existingKeySecret:
+  # existingAdminSecret:
+
+# Specs for the Docker image for the init container that establishes the replica set
+installImage:
+  name: gcr.io/google_containers/mongodb-install
+  tag: 0.5
+  pullPolicy: IfNotPresent
+
+# Specs for the MongoDB image
+image:
+  name: mongo
+  tag: 3.4
+  pullPolicy: IfNotPresent
+
+# Annotations to be added to MongoDB pods
+podAnnotations: {}
+
+podAntiAffinity: "soft"
+
+resources: {}
+# limits:
+#   cpu: 500m
+#   memory: 512Mi
+# requests:
+#   cpu: 100m
+#   memory: 256Mi
+
+## Node selector
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+nodeSelector: {}
+
+persistentVolume:
+  enabled: true
+  ## mongodb-replicaset data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+  accessModes:
+    - ReadWriteOnce
+  size: 10Gi
+  annotations: {}
+
+# Annotations to be added to the service
+serviceAnnotations: {}
+
+tls:
+  # Enable or disable MongoDB TLS support
+  enabled: false
+  # Please generate your own TLS CA by generating it via:
+  # $ openssl genrsa -out ca.key 2048
+  # $ openssl req -x509 -new -nodes -key ca.key -days 10000 -out ca.crt -subj "/CN=mydomain.com"
+  # After that you can base64 encode it and paste it here:
+  # $ cat ca.key | base64 -w0
+  # cacert:
+  # cakey:
+
+# Entries for the MongoDB config file
+configmap:
+  storage:
+    dbPath: /data/db
+  net:
+    port: 27017
+    # Uncomment for TLS support
+    # ssl:
+    #   mode: requireSSL
+    #   CAFile: /ca/tls.crt
+    #   PEMKeyFile: /work-dir/mongo.pem
+  replication:
+    replSetName: rs0
+  # Uncomment for TLS support or keyfile access control without TLS
+  # security:
+  #   authorization: enabled
+  #   keyFile: /keydir/key.txt

--- a/helm/zenko/values.yaml
+++ b/helm/zenko/values.yaml
@@ -42,3 +42,16 @@ prometheus:
 
   pushgateway:
     enabled: false
+
+global:
+  # These setting get passed to the mongodb-replicaset helm
+  # Along with the Cloud Server front end for proper communication
+  mongodbBackend: 
+    enabled: true
+    replicaSet: rs0
+    # The 'rs0' is the default mongo replicaset name
+    replicas: 5
+    # The number of replicas to have in the cluster
+    port: 27107
+    # The default port number used by mongo
+


### PR DESCRIPTION
I have left it disabled by default but can be enabled simply in the zenko/values.yml or with the `--set mongodb-replicaset.enabled=true` flag when deploying