### PR TITLE
Fix MongoDB ReplicaSet sub-chart and integration

### DIFF
--- a/helm/zenko/charts/cloudserver-front/templates/deployment.yaml
+++ b/helm/zenko/charts/cloudserver-front/templates/deployment.yaml
@@ -28,13 +28,13 @@ spec:
               value: "{{- printf "%s-%s" .Release.Name "s3-metadata" | trunc 63 | trimSuffix "-" -}}"
             - name: REDIS_HOST
               value: "{{- printf "%s-%s" .Release.Name "redis" | trunc 63 | trimSuffix "-" -}}"
-{{- if .Values.global.mongodbBackend.enabled }}
+{{- if .Values.mongodb.enabled }}
             - name: S3METADATA
               value: "mongodb"
             - name: MONGODB_HOSTS
               value: "{{ .Release.Name }}-mongodb-replicaset-0.{{ .Release.Name }}-mongodb-replicaset:27017,{{ .Release.Name }}-mongodb-replicaset-1.{{ .Release.Name }}-mongodb-replicaset:27017,{{ .Release.Name }}-mongodb-replicaset-2.{{ .Release.Name }}-mongodb-replicaset:27017"
             - name: MONGODB_RS
-              value: "{{ .Values.global.mongodbBackend.replicaSet }}"
+              value: "{{ default "rs0" .Values.mongodb.replicaSet }}"
 {{- end}}
 {{- if .Values.orbit.enabled }}
             - name: REMOTE_MANAGEMENT_DISABLE

--- a/helm/zenko/charts/mongodb-replicaset/init/Dockerfile
+++ b/helm/zenko/charts/mongodb-replicaset/init/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM alpine:3.4
+MAINTAINER Anirudh Ramanathan <foxish@google.com>
+
+RUN apk update && apk add bash openssl && wget -qO /peer-finder http://storage.googleapis.com/kubernetes-release/pets/peer-finder 
+
+ENTRYPOINT ["/install.sh"]
+
+ADD files/* /
+
+RUN chmod -c 755 /install.sh /on-start.sh /peer-finder

--- a/helm/zenko/charts/mongodb-replicaset/init/Makefile
+++ b/helm/zenko/charts/mongodb-replicaset/init/Makefile
@@ -1,0 +1,27 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+all: push
+
+TAG = 0.5
+PREFIX = gcr.io/google_containers/mongodb-install
+
+container:
+	docker build -t $(PREFIX):$(TAG) .
+
+push: container
+	gcloud docker -- push $(PREFIX):$(TAG)
+
+clean:
+	docker rmi $(PREFIX):$(TAG)

--- a/helm/zenko/charts/mongodb-replicaset/init/files/install.sh
+++ b/helm/zenko/charts/mongodb-replicaset/init/files/install.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# Copyright 2016 The Kubernetes Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This volume is assumed to exist and is shared with the peer-finder
+# init container. It contains on-start/change configuration scripts.
+WORKDIR_VOLUME="/work-dir"
+
+for i in "$@"
+do
+case $i in
+    -c=*|--config=*)
+    CONFIG_VOLUME="${i#*=}"
+    shift
+    ;;
+    -w=*|--work-dir=*)
+    WORKDIR_VOLUME="${i#*=}"
+    shift
+    ;;
+    *)
+    # unknown option
+    ;;
+esac
+done
+
+echo installing config scripts into "${WORKDIR_VOLUME}"
+mkdir -p "${WORKDIR_VOLUME}"
+cp /on-start.sh "${WORKDIR_VOLUME}"/
+cp /peer-finder "${WORKDIR_VOLUME}"/

--- a/helm/zenko/charts/mongodb-replicaset/init/files/on-start.sh
+++ b/helm/zenko/charts/mongodb-replicaset/init/files/on-start.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+
+# Copyright 2016 The Kubernetes Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+replica_set=$REPLICA_SET
+script_name=${0##*/}
+
+if [[ "$AUTH" == "true" ]]; then
+    admin_user="$ADMIN_USER"
+    admin_password="$ADMIN_PASSWORD"
+    admin_auth=(-u "$admin_user" -p "$admin_password")
+fi
+
+function log() {
+    local msg="$1"
+    local timestamp=$(date --iso-8601=ns)
+    echo "[$timestamp] [$script_name] $msg" >> /work-dir/log.txt
+}
+
+function shutdown_mongo() {
+    if [[ $# -eq 1 ]]; then
+        args="timeoutSecs: $1"
+    else
+        args='force: true'
+    fi
+    log "Shutting down MongoDB ($args)..."
+    mongo admin "${admin_auth[@]}" "${ssl_args[@]}" --eval "db.shutdownServer({$args})"
+}
+
+my_hostname=$(hostname)
+log "Bootstrapping MongoDB replica set member: $my_hostname"
+
+log "Reading standard input..."
+while read -ra line; do
+    if [[ "${line}" == *"${my_hostname}"* ]]; then
+        service_name="$line"
+        continue
+    fi
+    peers=("${peers[@]}" "$line")
+done
+
+# Generate the ca cert
+ca_crt=/ca/tls.crt
+if [ -f $ca_crt  ]; then
+    log "Generating certificate"
+    ca_key=/ca/tls.key
+    pem=/work-dir/mongo.pem
+    ssl_args=(--ssl --sslCAFile $ca_crt --sslPEMKeyFile $pem)
+
+cat >openssl.cnf <<EOL
+[req]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+[req_distinguished_name]
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = $(echo -n "$my_hostname" | sed s/-[0-9]*$//)
+DNS.2 = $my_hostname
+DNS.3 = $service_name
+DNS.4 = localhost
+DNS.5 = 127.0.0.1
+EOL
+
+    # Generate the certs
+    openssl genrsa -out mongo.key 2048
+    openssl req -new -key mongo.key -out mongo.csr -subj "/CN=$my_hostname" -config openssl.cnf
+    openssl x509 -req -in mongo.csr \
+        -CA $ca_crt -CAkey $ca_key -CAcreateserial \
+        -out mongo.crt -days 3650 -extensions v3_req -extfile openssl.cnf
+
+    rm mongo.csr
+    cat mongo.crt mongo.key > $pem
+    rm mongo.key mongo.crt
+fi
+
+
+log "Peers: ${peers[@]}"
+
+log "Starting a MongoDB instance..."
+mongod --config /config/mongod.conf >> /work-dir/log.txt 2>&1 &
+
+log "Waiting for MongoDB to be ready..."
+until mongo "${ssl_args[@]}" --eval "db.adminCommand('ping')"; do
+    log "Retrying..."
+    sleep 2
+done
+
+log "Initialized."
+
+# try to find a master and add yourself to its replica set.
+for peer in "${peers[@]}"; do
+    mongo admin --host "$peer" "${admin_auth[@]}" "${ssl_args[@]}" --eval "rs.isMaster()" | grep '"ismaster" : true'
+    if [[ $? -eq 0 ]]; then
+        log "Found master: $peer"
+        log "Adding myself ($service_name) to replica set..."
+        mongo admin --host "$peer" "${admin_auth[@]}" "${ssl_args[@]}" --eval "rs.add('$service_name')"
+        log "Done."
+
+        shutdown_mongo "60"
+        log "Good bye."
+        exit 0
+    fi
+done
+
+# else initiate a replica set with yourself.
+mongo "${ssl_args[@]}" --eval "rs.status()" | grep "no replset config has been received"
+if [[ $? -eq 0 ]]; then
+    log "Initiating a new replica set with myself ($service_name)..."
+    mongo "${ssl_args[@]}" --eval "rs.initiate({'_id': '$replica_set', 'members': [{'_id': 0, 'host': '$service_name'}]})"
+
+    mongo "${ssl_args[@]}" --eval "rs.status()"
+
+    if [[ "$AUTH" == "true" ]]; then
+        # sleep a little while just to be sure the initiation of the replica set has fully
+        # finished and we can create the user
+        sleep 3
+
+        log "Creating admin user..."
+        mongo admin "${ssl_args[@]}" --eval "db.createUser({user: '$admin_user', pwd: '$admin_password', roles: [{role: 'root', db: 'admin'}]})"
+    fi
+
+    log "Done."
+fi
+
+shutdown_mongo
+log "Good bye."

--- a/helm/zenko/charts/mongodb-replicaset/templates/mongodb-service.yaml
+++ b/helm/zenko/charts/mongodb-replicaset/templates/mongodb-service.yaml
@@ -18,11 +18,7 @@ spec:
   clusterIP: None
   ports:
     - name: peer
-    {{- if .Values.global.mongodbBackend.enabled }}
-      port: {{ .Values.global.mongodbBackend.port }}
-    {{- else }}
       port: {{ .Values.port }}
-    {{- end }}
   selector:
     app: {{ template "mongodb-replicaset.name" . }}
     release: {{ .Release.Name }}

--- a/helm/zenko/charts/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/helm/zenko/charts/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -9,11 +9,7 @@ metadata:
   name: {{ template "mongodb-replicaset.fullname" . }}
 spec:
   serviceName: {{ template "mongodb-replicaset.fullname" . }}
-{{- if .Values.global.mongodbBackend.enabled }}
-  replicas: {{ .Values.global.mongodbBackend.replicas }}
-{{- else }}
   replicas: {{ .Values.replicas }}
-{{- end }}
   template:
     metadata:
       labels:
@@ -54,11 +50,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.namespace
             - name: REPLICA_SET
-            {{- if .Values.global.mongodbBackend.enabled }}
-              value: {{ .Values.global.mongodbBackend.replicaSet }}
-            {{- else }}
               value: {{ .Values.replicaSet }}
-            {{- end }}
           {{- if .Values.auth.enabled }}
             - name: AUTH
               value: "true"
@@ -95,11 +87,7 @@ spec:
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           ports:
             - name: peer
-            {{- if .Values.global.mongodbBackend.enabled }}
-              containerPort: {{ .Values.global.mongodbBackend.port }}
-            {{- else }}
               containerPort: {{ .Values.port }}
-            {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           command:

--- a/helm/zenko/charts/mongodb-replicaset/templates/tests/mongodb-up-test-pod.yaml
+++ b/helm/zenko/charts/mongodb-replicaset/templates/tests/mongodb-up-test-pod.yaml
@@ -34,11 +34,7 @@ spec:
         - name: FULL_NAME
           value: {{ template "mongodb-replicaset.fullname" . }}
         - name: REPLICAS
-        {{- if .Values.global.mongodbBackend.enabled }}
-          value: "{{ .Values.global.mongodbBackend.replicas }}"
-        {{- else }}
           value: "{{ .Values.replicas }}"
-        {{- end }}
       volumeMounts:
         - name: tools
           mountPath: /tools

--- a/helm/zenko/charts/mongodb-replicaset/values.yaml
+++ b/helm/zenko/charts/mongodb-replicaset/values.yaml
@@ -1,6 +1,5 @@
-release: zenko
 replicaSet: rs0
-replicas: 5
+replicas: 3
 port: 27017
 
 auth:

--- a/helm/zenko/values.yaml
+++ b/helm/zenko/values.yaml
@@ -27,6 +27,10 @@ cloudserver-front:
     keyId: deployment-specific-access-key
     secretKey: deployment-specific-secret-key
 
+  mongodb:
+    enabled: true
+    replicaSet: rs0
+
 prometheus:
   rbac:
     create: true
@@ -43,15 +47,6 @@ prometheus:
   pushgateway:
     enabled: false
 
-global:
-  # These setting get passed to the mongodb-replicaset helm
-  # Along with the Cloud Server front end for proper communication
-  mongodbBackend: 
-    enabled: true
-    replicaSet: rs0
-    # The 'rs0' is the default mongo replicaset name
-    replicas: 5
-    # The number of replicas to have in the cluster
-    port: 27107
-    # The default port number used by mongo
-
+mongodb-replicaset:
+  replicaSet: rs0
+  replicas: 5


### PR DESCRIPTION
In 6d6ae5bd9f044ad9e5e30b607b1fd6692df7ec24, the MongoDB ReplicaSet Chart from the upstream stable channel was imported, though with some minor modifications.

This commit
- Reverts those modification, such that the imported Chart now matches upstream
- Gets rid of the modifications made to the upstream Chart in 846e48b91485eec58c1a1908e409a91fff47eee3 because they're not necessary
- Changes the top-level Chart's `values.yaml` to get back the desired configuration, and updates changes to the `cloudserver-front` deployment accordingly.

Note `values.yaml` now contains a couple of values which are not strictly required to be present. Instead, later on, we could use 'import values' (https://github.com/kubernetes/helm/blob/master/docs/charts.md#using-the-child-parent-format).