### PR TITLE
feat(chart): add simple test-case to `cloudserver-front`

### DIFF
--- a/charts/cloudserver-front/Chart.yaml
+++ b/charts/cloudserver-front/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: cloudserver-front
-version: 0.1.1
+version: 0.1.2

--- a/charts/cloudserver-front/templates/tests/cloudserver-front-test.yaml
+++ b/charts/cloudserver-front/templates/tests/cloudserver-front-test.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.orbit.enabled }}
+{{- else }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-cloudserver-front-test"
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+  - name: {{ .Release.Name }}-cloudserver-front-test
+    imagePullPolicy: "IfNotPresent"
+    image: "docker.io/mesosphere/aws-cli:1.14.5"
+    command:
+      - sh
+      - -c
+      - "echo \"${{ .Release.Name | upper }}_CLOUDSERVER_FRONT_SERVICE_HOST {{ .Values.endpoint }}\" >> /etc/hosts && aws s3 --endpoint-url=http://{{ .Values.endpoint }}:${{ .Release.Name | upper }}_CLOUDSERVER_FRONT_SERVICE_PORT_CLOUDSERVER_FRONT --region=us-east-1 ls"
+    env:
+      - name: AWS_ACCESS_KEY_ID
+        valueFrom:
+          secretKeyRef:
+            name: {{ template "cloudserver-front.fullname" . }}
+            key: keyId
+      - name: AWS_SECRET_ACCESS_KEY
+        valueFrom:
+          secretKeyRef:
+            name: {{ template "cloudserver-front.fullname" . }}
+            key: secretKey
+  restartPolicy: Never
+{{- end }}

--- a/charts/zenko/requirements.lock
+++ b/charts/zenko/requirements.lock
@@ -25,6 +25,6 @@ dependencies:
   version: 0.1.0
 - name: cloudserver-front
   repository: file://../cloudserver-front
-  version: 0.1.1
-digest: sha256:74d76f0c7584cdcc5b48ee259ae389f3a894f9974f0fe59c90b2c9defc9c474e
-generated: 2018-02-20T18:51:20.161815328-08:00
+  version: 0.1.2
+digest: sha256:25f99c64f1d99acda83f049411973dcfcb82acf5da39c08e3640b8a7f4a02095
+generated: 2018-02-20T20:25:24.498337235-08:00

--- a/charts/zenko/requirements.yaml
+++ b/charts/zenko/requirements.yaml
@@ -29,5 +29,5 @@ dependencies:
   version: "0.1.0"
   repository: "file://../s3-data"
 - name: cloudserver-front
-  version: "0.1.1"
+  version: "0.1.2"
   repository: "file://../cloudserver-front"


### PR DESCRIPTION
This commit adds a very basic Helm test, only enabled when Orbit
integration is disabled, which performs an `ls` against the deployed S3
endpoint using `aws-cli`.