### PR TITLE
Storageclass local-storage is enabled by default on new dev platform

### DIFF
--- a/charts/value-dev.yml
+++ b/charts/value-dev.yml
@@ -1,11 +1,4 @@
 zenko-zookeeper:
-  storage:
-    data:
-      storageClass: local-storage
-      size: 1Gi
-    log:
-      storageClass: local-storage
-      size: 10Gi
 
 kafka:
   replicas: 3
@@ -13,32 +6,13 @@ kafka:
      "offsets.topic.replication.factor": 3
   persistentVolume:
     enabled: true
-    storageClass: local-storage
-    size: 20G
 
 s3-data:
   persistentVolume:
     enabled: true
-    storageClass: local-storage
-    size: 20G
     accessModes:
     - ReadWriteOnce
 
 s3-metadata:
   persistentVolume:
     enabled: true
-    storageClass: local-storage
-    size: 20G
-
-prometheus:
-  server:
-    persistentVolume:
-      storageClass: local-storage
-  alertmanager:
-    persistentVolume:
-      storageClass: local-storage
-
-mongodb-replicaset:
-  replicas: 3
-  persistentVolume:
-    storageClass: local-storage


### PR DESCRIPTION
All this stuff is not needed anymore...(But everyone need delete and recreate their cluster)

Note: not sure for zookeeper storage size, why 1G ?