### PR TITLE
Chart: Update zenko-zookeeper to 0.0.7

### DIFF
--- a/charts/zenko/requirements.lock
+++ b/charts/zenko/requirements.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: zenko-zookeeper
   repository: https://scality.github.io/zenko-zookeeper/charts
-  version: 0.0.6
+  version: 0.0.7
 - name: prometheus
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 5.3.1
@@ -26,5 +26,5 @@ dependencies:
 - name: cloudserver-front
   repository: file://../cloudserver-front
   version: 0.1.3
-digest: sha256:b21dd6b0764fe5ebeb1a57f2b96d7c2a2d72393dc19065e0542956eab6c5839f
-generated: 2018-03-23T10:10:50.804489243-07:00
+digest: sha256:aa580b90ae2f0946f66999954a1a2b0c5b96c59389ad88ea9bd85c625ca01302
+generated: 2018-04-12T17:47:26.609705124+02:00

--- a/charts/zenko/requirements.yaml
+++ b/charts/zenko/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 # Upstream `zenko-*` Charts
 - name: zenko-zookeeper
-  version: "0.0.6"
+  version: "0.0.7"
   repository: "https://scality.github.io/zenko-zookeeper/charts"
 
 # Upstream Kubernetes Charts


### PR DESCRIPTION
No change in Zookeeper version, only some changes in the Chart:

- Enable `Parallel` Pod management, speeding up deployment
- Use the `RollingUpdate` strategy on the Deployment
- Unify JVM heap allocation and Kubernetes memory resource requests

See: https://github.com/scality/zenko-zookeeper/compare/v0.0.6...v0.0.7