### PR TITLE
Bf/minikube fixes

### DIFF
--- a/charts/minikube.md
+++ b/charts/minikube.md
@@ -11,7 +11,7 @@ start minikube with at least version 1.9 of kubernetes and perferably with 4GB o
 default value of 2GB should work, we recommend 4GB or more) and enable the minikube ingress addon for communication.
 ```shell
 minikube start --kubernetes-version=v1.9.0 --memory 4096
-minkube addon enable ingress
+minikube addon enable ingress
 ```
 ###### For installations requiring Role Based Access Control see [RBAC](#installation-using-rbac)
 

--- a/charts/single-node-values.yml
+++ b/charts/single-node-values.yml
@@ -4,7 +4,7 @@ ingress:
     - ""
 cloudserver-front:
   orbit:
-    enabled: false
+    enabled: true
 
 zenko-zookeeper:
   servers: 1


### PR DESCRIPTION
Fixed a typo in the minikube doc.

Also it seems like we set the single-node-vaules orbit.enabled=true but infact would want the default in the single to be enabled.


We could instead have the defaults of zenko/values.yml to have orbit enabled by default just like the Docker Swarm stack.