### PR TITLE
E2E: Basic networking sanity checks

### DIFF
--- a/tests/docker-entrypoint.sh
+++ b/tests/docker-entrypoint.sh
@@ -16,4 +16,4 @@ else
 fi
 
 # Disable cache to run in a read-only container
-exec pytest -p no:cacheprovider "${PYTEST_XDIST_ARGS}" "$@"
+exec pytest -p no:cacheprovider -ra "${PYTEST_XDIST_ARGS}" "$@"

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -38,4 +38,5 @@ exclude = .tox,dist,*egg,build,venv
 [MESSAGES CONTROL]
 # C0111: Missing %s docstring -- not required for tests
 # W0621: Redefining name %r from outer scope -- required for pytest fixtures
-disable=C0111,W0621
+# W0511: TODO and related comments
+disable=C0111,W0621,W0511

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -19,7 +19,7 @@ commands =
 deps =
     pylint==1.8.4
 commands =
-    pylint --rcfile={toxinidir}/tox.ini zenko_e2e
+    pylint -j 2 --rcfile={toxinidir}/tox.ini zenko_e2e
 
 [testenv:pip-compile]
 skip_install = true

--- a/tests/zenko_e2e/cloudserver/test_networking.py
+++ b/tests/zenko_e2e/cloudserver/test_networking.py
@@ -1,0 +1,40 @@
+import socket
+
+import requests
+import requests.exceptions
+
+import pytest
+
+
+S3_ENDPOINTS = [
+    's3.us-east-2.amazonaws.com',
+    's3-us-east-2.amazonaws.com',
+    # TODO Extend this list, based on
+    # https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
+]
+
+
+@pytest.mark.nondestructive
+@pytest.mark.conformance
+@pytest.mark.parametrize('s3_endpoint', S3_ENDPOINTS)
+def test_resolve_s3_endpoint(s3_endpoint):
+    try:
+        socket.gethostbyname(s3_endpoint)
+    except socket.gaierror as exc:
+        # Note: we use xfail here because it *may* be fine for resolving to
+        # fail in some very restricted networks.
+        # However, we want to report this when running conformance or
+        # nondestructive testing.
+        pytest.xfail('Failed to resolve host: {!r}'.format(exc))
+
+
+@pytest.mark.nondestructive
+@pytest.mark.conformance
+@pytest.mark.parametrize('s3_endpoint', S3_ENDPOINTS)
+def test_tls_connect_s3_endpoint(s3_endpoint):
+    try:
+        requests.get('https://{}/'.format(s3_endpoint), verify=True)
+    except socket.gaierror as exc:
+        pytest.xfail('Failed to resolve host: {!r}'.format(exc))
+    except requests.exceptions.ConnectionError as exc:
+        pytest.xfail('Failed to connect to host: {!r}'.format(exc))


### PR DESCRIPTION
These commits add a couple of new E2E tests, which simply validate the cluster is able to resolve Amazon S3 endpoints, and can connect to them, without TLS certificate problems.

As noted in the code, the tests use `xfail` in specific conditions: as an example, failure to resolve is not necessarily a problem in very constrained environments. We do, however, want to be made aware of this, especially when troubleshooting.