### PR TITLE
ft: Unify charts with Orbit

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -35,10 +35,10 @@ One option to highlight is the ability to enable integration with the
 [Orbit] management UI (which is disabled by default) and set a custom
 Orbit API endpoint (for development purposes). 
 
-To enable Orbit use:
+To disable Orbit use:
 
 ```shell
---set cloudserver-front.orbit.enabled=true
+--set cloudserver-front.orbit.enabled=false
 ```
 
 If a custom Orbit endpoint is required use:

--- a/charts/cloudserver-front/values.yaml
+++ b/charts/cloudserver-front/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 orbit:
-  enabled: false
+  enabled: true
   endpoint: https://api.zenko.io
 # When 'orbit.enabled' is 'true', these aren't used, please use
 # https://zenko.io to manage your deployment

--- a/charts/single-node-values.yml
+++ b/charts/single-node-values.yml
@@ -2,9 +2,6 @@ ingress:
   enabled: true
   hosts:
     - ""
-cloudserver-front:
-  orbit:
-    enabled: true
 
 zenko-zookeeper:
   servers: 1

--- a/charts/zenko/values.yaml
+++ b/charts/zenko/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 ingress:
-  enabled: false
+  enabled: true
   # Used to create an Ingress record.
   # This must match the 'cloudserver-front' 'endpoint', unless your client
   # supports different hostnames.


### PR DESCRIPTION
This allows Orbit to be enabled by default which is our normal for swarm and cloudserver.