### PR TITLE
ft: Change default replicas

### DIFF
--- a/charts/zenko/values.yaml
+++ b/charts/zenko/values.yaml
@@ -53,10 +53,10 @@ prometheus:
 
 mongodb-replicaset:
   replicaSet: rs0
-  replicas: 5
+  replicas: 3
 
 kafka:
-  replicas: 5
+  replicas: 3
   prometheusExport:
     enabled: true
 


### PR DESCRIPTION
ZENKO-325
Changes the replica defaults to be 3 for mongoDB and kafka
(zookeeper already defaults to 3)