### PR TITLE
bf: fix replication on k8s

### DIFF
--- a/charts/backbeat/templates/consumer/deployment.yaml
+++ b/charts/backbeat/templates/consumer/deployment.yaml
@@ -42,10 +42,6 @@ spec:
               value: service-replication
             - name: EXTENSIONS_REPLICATION_DEST_BOOTSTRAPLIST
               value: "{{- printf "%s-cloudserver-front:80" .Release.Name | trunc 63 | trimSuffix "-" -}}"
-            - name: QUEUE_POPULATOR_DMD_HOST
-              value: "{{- printf "%s-s3-metadata" .Release.Name | trunc 63 | trimSuffix "-" -}}"
-            - name: QUEUE_POPULATOR_DMD_PORT
-              value: "9993"
             - name: MONGODB_HOSTS
               value: "{{ .Release.Name }}-mongodb-replicaset-0.{{ .Release.Name }}-mongodb-replicaset:27017,{{ .Release.Name }}-mongodb-replicaset-1.{{ .Release.Name }}-mongodb-replicaset:27017,{{ .Release.Name }}-mongodb-replicaset-2.{{ .Release.Name }}-mongodb-replicaset:27017"
           # TODO livenessProbe:

--- a/charts/backbeat/templates/producer/deployment.yaml
+++ b/charts/backbeat/templates/producer/deployment.yaml
@@ -27,10 +27,6 @@ spec:
               value: "{{- printf "%s-zenko-zookeeper:2181" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: KAFKA_HOSTS
               value: "{{- printf "%s-kafka-0.%s-kafka:9092" .Release.Name .Release.Name | trunc 63 | trimSuffix "-" -}}"
-            - name: QUEUE_POPULATOR_DMD_HOST
-              value: "{{- printf "%s-s3-metadata" .Release.Name | trunc 63 | trimSuffix "-" -}}"
-            - name: QUEUE_POPULATOR_DMD_PORT
-              value: "9993"
             - name: MONGODB_HOSTS
               value: "{{ .Release.Name }}-mongodb-replicaset-0.{{ .Release.Name }}-mongodb-replicaset:27017,{{ .Release.Name }}-mongodb-replicaset-1.{{ .Release.Name }}-mongodb-replicaset:27017,{{ .Release.Name }}-mongodb-replicaset-2.{{ .Release.Name }}-mongodb-replicaset:27017"
           # TODO livenessProbe:

--- a/charts/backbeat/values.yaml
+++ b/charts/backbeat/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: zenko/backbeat
-  tag: 0.1.4
+  tag: 0.2.0
   pullPolicy: IfNotPresent
 
 consumer:


### PR DESCRIPTION
This fixes replication not working on k8s. The reason being that the s3-metadata host isn't used anymore (MongoDB is used instead).