### PR TITLE
ft: helm chart for Redis Sentinel

### DIFF
--- a/charts/backbeat/templates/api/deployment.yaml
+++ b/charts/backbeat/templates/api/deployment.yaml
@@ -33,7 +33,7 @@ spec:
             - name: KAFKA_HOSTS
               value: "{{- printf "%s-zenko-queue:9092" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: REDIS_HOST
-              value: "{{- printf "%s-%s" .Release.Name "redis" | trunc 63 | trimSuffix "-" -}}"
+              value: "{{- printf "%s-%s" .Release.Name "redis-ha-master-svc" | trunc 63 | trimSuffix "-" -}}"
             - name: REDIS_PORT
               value: "6379"
             - name: HEALTHCHECKS_ALLOWFROM

--- a/charts/backbeat/templates/replication/consumer_deployment.yaml
+++ b/charts/backbeat/templates/replication/consumer_deployment.yaml
@@ -47,7 +47,7 @@ spec:
             - name: MONGODB_HOSTS
               value: "{{ .Release.Name }}-mongodb-replicaset-0.{{ .Release.Name }}-mongodb-replicaset:27017,{{ .Release.Name }}-mongodb-replicaset-1.{{ .Release.Name }}-mongodb-replicaset:27017,{{ .Release.Name }}-mongodb-replicaset-2.{{ .Release.Name }}-mongodb-replicaset:27017"
             - name: REDIS_HOST
-              value: "{{- printf "%s-%s" .Release.Name "redis" | trunc 63 | trimSuffix "-" -}}"
+              value: "{{- printf "%s-%s" .Release.Name "redis-ha-master-svc" | trunc 63 | trimSuffix "-" -}}"
             - name: REDIS_PORT
               value: "6379"
           # TODO livenessProbe:

--- a/charts/backbeat/templates/replication/producer_deployment.yaml
+++ b/charts/backbeat/templates/replication/producer_deployment.yaml
@@ -32,7 +32,7 @@ spec:
             - name: MONGODB_HOSTS
               value: "{{ .Release.Name }}-mongodb-replicaset-0.{{ .Release.Name }}-mongodb-replicaset:27017,{{ .Release.Name }}-mongodb-replicaset-1.{{ .Release.Name }}-mongodb-replicaset:27017,{{ .Release.Name }}-mongodb-replicaset-2.{{ .Release.Name }}-mongodb-replicaset:27017"
             - name: REDIS_HOST
-              value: "{{- printf "%s-%s" .Release.Name "redis" | trunc 63 | trimSuffix "-" -}}"
+              value: "{{- printf "%s-%s" .Release.Name "redis-ha-master-svc" | trunc 63 | trimSuffix "-" -}}"
             - name: REDIS_PORT
               value: "6379"
           # TODO livenessProbe:

--- a/charts/cloudserver-front/templates/deployment.yaml
+++ b/charts/cloudserver-front/templates/deployment.yaml
@@ -31,6 +31,8 @@ spec:
               value: "{{- printf "%s-%s" .Release.Name "s3-data" | trunc 63 | trimSuffix "-" -}}"
             - name: REDIS_HOST
               value: "{{- printf "%s-%s" .Release.Name "redis" | trunc 63 | trimSuffix "-" -}}"
+            - name: REDIS_PORT
+              value: "6379"
             - name: CRR_METRICS_HOST
               value: "{{- printf "%s-%s" .Release.Name "backbeat-api" | trunc 63 | trimSuffix "-" -}}"
             - name: CRR_METRICS_PORT

--- a/charts/minikube.md
+++ b/charts/minikube.md
@@ -6,7 +6,7 @@
 - [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 
 The following assumes you have minikube (which requires virtualbox or other virtualization options),
-kubectl, and helm installed (see links above). Once minikube, kubectl, and helm are installed, 
+kubectl, and helm installed (see links above). Once minikube, kubectl, and helm are installed,
 start minikube with at least version 1.9 of kubernetes and perferably with 4GB of RAM (although the
 default value of 2GB should work, we recommend 4GB or more) and enable the minikube ingress addon for communication.
 #### NOTE the listed versions are known to be working properly as some edge release versions may have issues properly deploying
@@ -16,7 +16,7 @@ minikube addons enable ingress
 ```
 ###### For installations requiring Role Based Access Control see [RBAC](#installation-using-rbac)
 
-Once minikube has started, run the helm initialization. 
+Once minikube has started, run the helm initialization.
 ```
 helm init --wait
 ```
@@ -53,6 +53,7 @@ With your dependencies built, you can run the following shell command to deploy 
 helm install --name zenko \
   --set prometheus.rbac.create=false \
   --set zenko-queue.rbac.enabled=false \
+  --set redis-ha.rbac.create=false \
   -f single-node-values.yml zenko
 ```
 #### NOTE that Orbit is enabled by default with these values
@@ -63,7 +64,7 @@ minikube dashboard
 ```
 #### NOTE that once you helm install, it may take several minutes for all the pods to load and stabilize
 
-The endpoint can now be accessed via the kubernetes cluster ip (run ```minikube ip``` to display the cluster ip) 
+The endpoint can now be accessed via the kubernetes cluster ip (run ```minikube ip``` to display the cluster ip)
 
 
 ## Installation Using RBAC

--- a/charts/single-node-values.yml
+++ b/charts/single-node-values.yml
@@ -19,3 +19,7 @@ mongodb-replicaset:
   replicaSet: rs0
   replicas: 3
 
+redis-ha:
+  replicas:
+    servers: 1
+    sentinels: 1

--- a/charts/zenko/requirements.lock
+++ b/charts/zenko/requirements.lock
@@ -14,6 +14,9 @@ dependencies:
 - name: zookeeper
   repository: http://storage.googleapis.com/kubernetes-charts-incubator
   version: 1.0.0
+- name: redis-ha
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 2.1.2
 - name: backbeat
   repository: file://../backbeat
   version: 0.1.0
@@ -23,5 +26,5 @@ dependencies:
 - name: cloudserver-front
   repository: file://../cloudserver-front
   version: 0.1.4
-digest: sha256:5f8749b142c214886ed8e9856772ebb12b173e2c05544854ef585b919ceffc39
-generated: 2018-05-16T13:51:44.863302-07:00
+digest: sha256:4fbe68bcb4a27d60e6a2a66dfe8584738a8cd89a42ce120adffce7186f2212cf
+generated: 2018-05-17T14:35:52.598131847-07:00

--- a/charts/zenko/requirements.yaml
+++ b/charts/zenko/requirements.yaml
@@ -14,10 +14,12 @@ dependencies:
   repository: "http://storage.googleapis.com/kubernetes-charts-incubator"
   alias: zenko-queue
 - name: zookeeper
-  version: "1.0.0" 
+  version: "1.0.0"
   repository: "http://storage.googleapis.com/kubernetes-charts-incubator"
   alias: zenko-quorum
-
+- name: redis-ha
+  version: "2.1.2"
+  repository: "https://kubernetes-charts.storage.googleapis.com/"
 
 # Charts managed in this repository
 - name: backbeat

--- a/charts/zenko/values.yaml
+++ b/charts/zenko/values.yaml
@@ -67,7 +67,7 @@ zenko-queue:
     "auto.create.topics.enable": true     # - enable auto creation of topic on the server
     "min.insync.replicas": 2              # - min number of replicas that must acknowledge a write
   prometheus:
-    jmx: 
+    jmx:
       enabled: true
     kafka:
       enabled: true
@@ -88,3 +88,10 @@ redis:
     enabled: false
   metrics:
     enabled: true
+
+redis-ha:
+  rbac:
+    create: true
+  replicas:
+    servers: 3
+    sentinels: 3


### PR DESCRIPTION
This PR adds redis sentinel to the Zenko stack. It is used (currently) by backbeat replication and backbeat api.