### PR TITLE
bf: add backbeat producer init container

### DIFF
--- a/charts/backbeat/templates/producer/deployment.yaml
+++ b/charts/backbeat/templates/producer/deployment.yaml
@@ -15,6 +15,15 @@ spec:
         app: {{ template "backbeat.name" . }}
         release: {{ .Release.Name }}
     spec:
+      initContainers:
+      - name: check-dependencies-readiness
+        image: gcr.io/google_samples/k8szk:v3
+        env:
+          - name: QUORUM_HOST
+            value: "{{ .Release.Name }}-zenko-quorum"
+        command: ['sh', '-c',
+          'until echo dump | nc $QUORUM_HOST 2181 | grep brokers;
+          do echo waiting for zenko-quorum and zenko-queue; sleep 5; done;']
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
This will prevent the backbeat-producer from hanging while opening the zookeeper connection by using an init container that will check if there are any Kafka brokers ready.