### PR TITLE
ft: add service tests

### DIFF
--- a/charts/backbeat/templates/tests/test-api-service.yml
+++ b/charts/backbeat/templates/tests/test-api-service.yml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ template "backbeat.fullname" . }}-api-service-test
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+  - name: "{{ .Release.Name }}-api"
+    image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+    env:
+      - name: BACKBEAT_API_SERVICE
+        value: "{{ template "backbeat.fullname" . }}-api"
+    command:
+      - sh
+      - -c
+      - curl http://${BACKBEAT_API_SERVICE}:8900/_/metrics/crr/all
+  restartPolicy: Never

--- a/charts/cloudserver-front/templates/tests/test-cloudserver-front-service.yml
+++ b/charts/cloudserver-front/templates/tests/test-cloudserver-front-service.yml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ template "cloudserver-front.fullname" . }}-test
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+  - name: "{{ .Release.Name }}"
+    image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+    env:
+      - name: CLOUDSERVER_FRONT_SERVICE
+        value: "{{ template "cloudserver-front.fullname" . }}"
+    command:
+      - sh
+      - -c
+      - curl http://${CLOUDSERVER_FRONT_SERVICE}
+  restartPolicy: Never

--- a/charts/s3-data/templates/tests/test-s3-data-service.yml
+++ b/charts/s3-data/templates/tests/test-s3-data-service.yml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ template "s3-data.fullname" . }}-test
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+  - name: "{{ .Release.Name }}"
+    image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+    env:
+      - name: S3_DATA_SERVICE
+        value: {{ template "s3-data.fullname" . }}
+    command:
+      - sh
+      - -c
+      - curl http://${S3_DATA_SERVICE}:9991
+  restartPolicy: Never


### PR DESCRIPTION
These are very basic service tests. They essentially test that service works as an endpoint that properly connects to the underlying pods. These tests can be useful for catching bad port configurations.

An example of an official Kubernetes chart service test: https://github.com/kubernetes/charts/blob/master/stable/redis-ha/templates/tests/test-redis-sentinel-service.yaml

These tests are run as part of helm test. So to execute them just do:
```helm test zenko``` (assuming zenko is the name of your release) **OR**
```helm test zenko --cleanup``` to cleanup containers automatically.