### PR TITLE
bf: fix rep status w/ orbit

### DIFF
--- a/charts/backbeat/templates/replication/status_deployment.yaml
+++ b/charts/backbeat/templates/replication/status_deployment.yaml
@@ -30,6 +30,8 @@ spec:
               value: "{{- printf "%s-zenko-quorum:2181" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: KAFKA_HOSTS
               value: "{{- printf "%s-zenko-queue:9092" .Release.Name | trunc 63 | trimSuffix "-" -}}"
+            - name: MONGODB_HOSTS
+              value: "{{ .Release.Name }}-mongodb-replicaset-0.{{ .Release.Name }}-mongodb-replicaset:27017,{{ .Release.Name }}-mongodb-replicaset-1.{{ .Release.Name }}-mongodb-replicaset:27017,{{ .Release.Name }}-mongodb-replicaset-2.{{ .Release.Name }}-mongodb-replicaset:27017"
             - name: EXTENSIONS_REPLICATION_SOURCE_AUTH_TYPE
               value: service
             - name: EXTENSIONS_REPLICATION_SOURCE_AUTH_ACCOUNT


### PR DESCRIPTION
ZENKO-420
Fixes bug that causes the replication status pod to perpetually crash
only with Orbit management enabled. However completely functional without management.