### PR TITLE
bf: update to latest backbeat image

### DIFF
--- a/charts/backbeat/values.yaml
+++ b/charts/backbeat/values.yaml
@@ -6,7 +6,7 @@ orbit:
 
 image:
   repository: zenko/backbeat
-  tag: 0.2.1
+  tag: 0.2.2
   pullPolicy: IfNotPresent
 
 api:


### PR DESCRIPTION
Updating backbeat to this new image will prevent the replication populator pod from hanging when unable to connect to Kafka. Instead, this pod will crash, and Kubernetes will restart accordingly.