### PR TITLE
ft: add proxy support for egress to clouds

### DIFF
--- a/charts/cloudserver-front/templates/deployment.yaml
+++ b/charts/cloudserver-front/templates/deployment.yaml
@@ -43,6 +43,21 @@ spec:
               value: "{{ .Release.Name }}-cloudserver-front,{{ .Values.endpoint }}"
             - name: HEALTHCHECKS_ALLOWFROM
               value: "{{ .Values.allowHealthchecksFrom }}"
+{{- if .Values.proxy.http }}
+            - name: http_proxy
+              value: "{{ .Values.proxy.http }}"
+            - name: HTTP_PROXY
+              value: "{{ .Values.proxy.http }}"
+            - name: https_proxy
+              value: "{{- if .Values.proxy.https }}{{ .Values.proxy.https }}{{- else }}{{ .Values.proxy.http }}{{- end }}"
+            - name: HTTPS_PROXY
+              value: "{{- if .Values.proxy.https }}{{ .Values.proxy.https }}{{- else }}{{ .Values.proxy.http }}{{- end }}"
+{{- else if .Values.proxy.https }}
+            - name: https_proxy
+              value: "{{ .Values.proxy.https }}"
+            - name: HTTPS_PROXY
+              value: "{{ .Values.proxy.https }}"
+{{- end }}
 {{- if .Values.mongodb.enabled }}
             - name: S3METADATA
               value: "mongodb"

--- a/charts/cloudserver-front/values.yaml
+++ b/charts/cloudserver-front/values.yaml
@@ -33,6 +33,13 @@ image:
   tag: 0.2.1
   pullPolicy: IfNotPresent
 
+proxy:
+  # If you want to use an HTTP proxy, add the respective endpoints after
+  # 'http:' and/or 'https:'. If the HTTP proxy endpoint is set but the HTTPS
+  # one isn't, the HTTP proxy will be used for HTTPS traffic as well.
+  http: ""
+  https: ""
+
 service:
   type: ClusterIP
   port: 80


### PR DESCRIPTION
This adds the ability to specify optional HTTP and HTTPS proxy endpoints for Cloudserver on its values.yml.