### PR TITLE
ft: setting up latest stage ci job

### DIFF
--- a/eve/ci-values.yml
+++ b/eve/ci-values.yml
@@ -1,0 +1,40 @@
+
+ingress:
+  enabled: true
+
+prometheus:
+  rbac:
+    create: false
+  serviceAccounts:
+    alertmanager:
+      name: default
+      create: false
+    nodeExporter:
+      name: default
+      create: false
+    kubeStateMetrics:
+      name: default
+      create: false
+    pushgateway:
+      name: default
+      create: false
+    server:
+      name: default
+      create: false
+
+zenko-queue:
+  rbac:
+    enabled: false
+
+redis-ha:
+  rbac:
+    create: false
+  serviceAccount:
+    create: false
+    name: default
+
+cloudserver-front:
+  image:
+    pullPolicy: Always
+  ci:
+    enabled: true

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -29,6 +29,60 @@ models:
       GCP_CRR_SRC_BUCKET_NAME: zenko-gcp-crr-src-bucket
       GCP_CRR_MPU_BUCKET_NAME: zenko-gcp-crr-mpu-bucket
       MULTI_CRR_SRC_BUCKET: zenko-multi-crr-src-bucket
+  - ShellCommand: &install_tiller
+      name: install helm (tiller into kubernetes)
+      command: >-
+        helm init --wait
+      haltOnFailure: true
+      env:
+        <<: *global_env
+  - ShellCommand: &helm_repos
+      name: Install needed helm repos
+      command: |-
+        helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
+      haltOnFailure: true
+      env:
+        TILLER_NAMESPACE: '%(prop:testNamespace)s'
+  - ShellCommandWithSecrets: &start_orbit_simulator
+      name: Start orbit simulator
+      command: >-
+        git clone git@github.com:scality/orbit-simulator.git &&
+        helm upgrade ciutil
+        --install orbit-simulator/charts/orbit-simulator
+        --set simulator.shim.cloudserver_release=$(echo ${ZENKO_HELM_RELEASE})
+        --wait $(./ci_env.sh set)
+      workdir: build/eve/workers
+      haltOnFailure: true
+      env:
+        <<: *global_env
+  - ShellCommand: &helm_build_dep
+      name: Retrieve dependency
+      command: >-
+         helm dep build charts/zenko
+      haltOnFailure: true
+      env:
+        <<: *global_env
+  - ShellCommandWithSecrets: &test_zenko
+      name: Test zenko
+      command: >-
+        sleep 90 &&
+        make end2end
+      workdir: build/tests
+      env:
+        <<: *global_env
+  - ShellCommand: &dump_logs
+      name: Dump logs
+      command: make dump-logs
+      workdir: build/tests
+      env:
+        <<: *global_env
+  - Git: &git_pull
+      name: git pull
+      repourl: "%(prop:git_reference)s"
+      mode: full
+      method: clobber
+      retryFetch: true
+      haltOnFailure: true
 
 stages:
   pre-merge:
@@ -42,7 +96,7 @@ stages:
         - helm_test_kube_1.9.6
 
   helm_test_kube_1.9.6:
-    worker:
+    worker: &kube_cluster
       <<: *pod
       service:
         requests:
@@ -50,91 +104,77 @@ stages:
         namespaces:
         - "testNamespace"    # <<< the default namespace for that stage
     steps:
-    - ShellCommand:
+    - ShellCommand: &fix_curl # Workaround, to be removed
         name: Install curl
         command: |-
           apk --update upgrade
           apk --update add curl
-    - Git: &git_pull
-        name: git pull
-        repourl: "%(prop:git_reference)s"
-        mode: full
-        method: clobber
-        retryFetch: true
-        haltOnFailure: true
-    - ShellCommand: &install_tiller
-        name: install helm (tiller into kubernetes)
-        command: >-
-          helm init --wait
-        haltOnFailure: true
-        env:
-          <<: *global_env
-    - ShellCommand:
-        name: Install needed helm repos
-        command: |-
-          helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
-        haltOnFailure: true
-        env:
-          TILLER_NAMESPACE: '%(prop:testNamespace)s'
-    - ShellCommandWithSecrets:
-        name: Start orbit simulator
-        command: >-
-          git clone git@github.com:scality/orbit-simulator.git &&
-          helm upgrade ciutil
-          --install orbit-simulator/charts/orbit-simulator
-          --set simulator.shim.cloudserver_release=$(echo ${ZENKO_HELM_RELEASE})
-          --wait $(./ci_env.sh set)
-        workdir: build/eve/workers
-        haltOnFailure: true
-        env:
-          <<: *global_env
-    - ShellCommand:
-        name: Retrieve dependency
-        command: >-
-           helm dep build charts/zenko
-        haltOnFailure: true
-        env:
-          <<: *global_env
+    - Git: *git_pull
+    - ShellCommand: *install_tiller
+    - ShellCommand: *helm_repos
+    - ShellCommandWithSecrets: *start_orbit_simulator
+    - ShellCommand: *helm_build_dep
     - ShellCommandWithSecrets:
         name: Install Zenko !
         command: >-
           helm upgrade zenko-test --namespace %(prop:testNamespace)s
           --install charts/zenko
-          --set ingress.enabled=true
-          --set prometheus.rbac.create=false
-          --set prometheus.serviceAccounts.alertmanager.create=false
-          --set prometheus.serviceAccounts.kubeStateMetrics.create=false
-          --set prometheus.serviceAccounts.nodeExporter.create=false
-          --set prometheus.serviceAccounts.pushgateway.create=false
-          --set prometheus.serviceAccounts.server.create=false
-          --set prometheus.serviceAccounts.alertmanager.name=default
-          --set prometheus.serviceAccounts.kubeStateMetrics.name=default
-          --set prometheus.serviceAccounts.nodeExporter.name=default
-          --set prometheus.serviceAccounts.pushgateway.name=default
-          --set prometheus.serviceAccounts.server.name=default
-          --set zenko-queue.rbac.enabled=false
-          --set redis-ha.rbac.create=false
-          --set redis-ha.serviceAccount.create=false
-          --set redis-ha.serviceAccount.name=default
-          --set cloudserver-front.image.pullPolicy=Always
-          --set cloudserver-front.ci.enabled=true
+          -f eve/ci-values.yml
           --timeout 700
           --wait $(./eve/workers/ci_env.sh set)
         haltOnFailure: true
         env:
           <<: *global_env
-    - ShellCommandWithSecrets:
-        name: Test zenko
-        command: >-
-          sleep 90 &&
-          make end2end
-        workdir: build/tests
-        env:
-          <<: *global_env
-    - ShellCommand:
-        name: Dump logs
-        command: make dump-logs
-        workdir: build/tests
-        env:
-          <<: *global_env
+    - ShellCommandWithSecrets: *test_zenko
+    - ShellCommand: *dump_logs
     - Upload: *upload_artifacts
+
+  latest:
+    worker: *kube_cluster
+    steps:
+      - ShellCommand: *fix_curl
+      - Git: *git_pull
+      - ShellCommand: *install_tiller
+      - ShellCommand: *helm_repos
+      - ShellCommandWithSecrets: *start_orbit_simulator
+      - SetProperty:
+          name: set cloudserver branch
+          property: cloudserver_branch
+          value: development/8.0
+      - SetProperty:
+          name: set backbeat branch
+          property: backbeat_branch
+          value: development/8.0
+      - SetPropertyFromCommand:
+          name: retrieve cloudserver latest sha1
+          property: cloudserver_sha1
+          command: >-
+            git ls-remote git@github.com:scality/s3.git
+            --branch '%(prop:cloudserver_branch)s' | cut -c1-7
+      - SetPropertyFromCommand:
+          name: retrieve backbeat latest sha1
+          property: backbeat_sha1
+          command: >-
+            git ls-remote git@github.com:scality/backbeat.git
+            --branch '%(prop:backbeat_branch)s' | cut -c1-7
+      - ShellCommand: *helm_build_dep
+      - ShellCommandWithSecrets:
+          name: Install Latest Zenko !
+          command: >-
+            helm upgrade zenko-test --namespace %(prop:testNamespace)s
+            --install charts/zenko
+            -f eve/ci-values.yml
+            --set cloudserver-front.image.tag='%(prop:cloudserver_sha1)s'
+            --set cloudserver-front.image.repository=%(secret:private_registry_url)s/zenko/cloudserver
+            --set backbeat.image.tag='%(prop:backbeat_sha1)s'
+            --set backbeat.image.repository=%(secret:private_registry_url)s/zenko/backbeat
+            --set s3-data.image.tag='%(prop:cloudserver_sha1)s'
+            --set s3-data.image.repository=%(secret:private_registry_url)s/zenko/cloudserver
+            --timeout 600
+            --wait $(./eve/workers/ci_env.sh set)
+          haltOnFailure: true
+          env:
+            <<: *global_env
+      - ShellCommandWithSecrets: *test_zenko
+      - ShellCommand: *dump_logs
+      - Upload: *upload_artifacts


### PR DESCRIPTION
# Adding latest stage

This stage tests the latest version of zenko's components (pushed into a private registry)

So as asked, I've renamed the build stage. to `latest` I can rename it if someone has a better idea. I'm not triggering automatically but we can do it. I just don't know where you want to trigger. I'm open to any suggestion, modifications, or even trash this code :D. Just ask ;)
