### PR TITLE
bf: ZENKO-423 Remove deep healthcheck from livenessProbe

### DIFF
--- a/charts/cloudserver-front/templates/deployment.yaml
+++ b/charts/cloudserver-front/templates/deployment.yaml
@@ -95,7 +95,7 @@ spec:
           args: ['npm', 'run', 'start_s3server']
           livenessProbe:
             httpGet:
-              path: /_/healthcheck/deep
+              path: /_/healthcheck
               port: http
           resources:
 {{ toYaml .Values.resources | indent 12 }}


### PR DESCRIPTION
- LivenessProbe is for checking if the service is up: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/ 
- We do not need deep health check for that because deep health check also checks the backend.
- Use Case for bug: If someone deletes their AWS bucket which was configured in orbit, kubernetes will try to restart the cloud server container because /_/healthcheck/deep will respond with an error.
- To check the service status we only need /_/healthcheck