### PR TITLE
feat: extend support without orbit

### DIFF
--- a/charts/backbeat/templates/api/deployment.yaml
+++ b/charts/backbeat/templates/api/deployment.yaml
@@ -25,7 +25,7 @@ spec:
               containerPort: 8900
           env:
             - name: REMOTE_MANAGEMENT_DISABLE
-              value: "{{- if .Values.orbit.enabled }}0{{- else }}1{{- end }}"
+              value: "{{- if .Values.global.orbit.enabled }}0{{- else }}1{{- end }}"
             - name: ZOOKEEPER_AUTO_CREATE_NAMESPACE
               value: "1"
             - name: ZOOKEEPER_CONNECTION_STRING

--- a/charts/backbeat/templates/configmap.yaml
+++ b/charts/backbeat/templates/configmap.yaml
@@ -1,0 +1,50 @@
+{{- if not .Values.global.orbit.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-backbeat-configmap
+  labels:
+    app: {{ template "backbeat.name" . }}
+    chart: {{ template "backbeat.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  authdata.json: |-
+    {
+      "accounts": [
+        {
+          {{ $id := randNumeric 12 }}
+          "name": "Lifecycle",
+          "arn": "{{ printf "arn:aws:iam::%s:root" $id }}",
+          "canonicalID": "http://acs.zenko.io/accounts/service/lifecycle",
+          "displayName": "Lifecycle",
+          "keys": {
+            "access": "",
+            "secret": ""
+          }
+        },
+        {
+          {{ $id := randNumeric 12 }}
+          "name": "Replication",
+          "arn": "{{ printf "arn:aws:iam::%s:root" $id }}",
+          "canonicalID": "http://acs.zenko.io/accounts/service/replication",
+          "displayName": "Replication",
+          "keys": {
+            "access": "",
+            "secret": ""
+          }
+        }
+      ]
+    }
+  {{- if .Values.global.replicationEndpoints }}
+  bootstrapList: |-
+      {{ $last := .Values.global.replicationEndpoints | sortAlpha | last -}}
+      {{ range $index, $location := .Values.global.replicationEndpoints }}
+      {
+          "site": "{{ $location }}",
+          "type": "{{ index $.Values "global" "locationConstraints" $location "type" }}"
+      }
+      {{- if ne $location $last -}},{{- end -}}
+      {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/backbeat/templates/gc/deployment.yaml
+++ b/charts/backbeat/templates/gc/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.orbit.enabled -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -23,7 +24,7 @@ spec:
           args: ["npm", "run", "garbage_collector"]
           env:
             - name: REMOTE_MANAGEMENT_DISABLE
-              value: "{{- if .Values.orbit.enabled }}0{{- else }}1{{- end }}"
+              value: "{{- if .Values.global.orbit.enabled }}0{{- else }}1{{- end }}"
             - name: KAFKA_HOSTS
               value: "{{- printf "%s-zenko-queue:9092" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: EXTENSIONS_GC_AUTH_TYPE
@@ -58,3 +59,4 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+{{- end -}}

--- a/charts/backbeat/templates/ingestion/consumer_deployment.yaml
+++ b/charts/backbeat/templates/ingestion/consumer_deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.orbit.enabled -}}
 {{- if .Values.ingestion.enabled -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -24,7 +25,7 @@ spec:
           args: ["npm", "run", "mongo_queue_processor"]
           env:
             - name: REMOTE_MANAGEMENT_DISABLE
-              value: "{{- if .Values.orbit.enabled }}0{{- else }}1{{- end }}"
+              value: "{{- if .Values.global.orbit.enabled }}0{{- else }}1{{- end }}"
             - name: ZOOKEEPER_AUTO_CREATE_NAMESPACE
               value: "1"
             - name: ZOOKEEPER_CONNECTION_STRING
@@ -61,4 +62,5 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+{{- end -}}
 {{- end -}}

--- a/charts/backbeat/templates/ingestion/producer_deployment.yaml
+++ b/charts/backbeat/templates/ingestion/producer_deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.orbit.enabled -}}
 {{- if .Values.ingestion.enabled -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -23,7 +24,7 @@ spec:
           args: ["npm", "run", "ingestion_populator"]
           env:
             - name: REMOTE_MANAGEMENT_DISABLE
-              value: "{{- if .Values.orbit.enabled }}0{{- else }}1{{- end }}"
+              value: "{{- if .Values.global.orbit.enabled }}0{{- else }}1{{- end }}"
             - name: ZOOKEEPER_AUTO_CREATE_NAMESPACE
               value: "1"
             - name: ZOOKEEPER_CONNECTION_STRING
@@ -60,4 +61,5 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+{{- end -}}
 {{- end -}}

--- a/charts/backbeat/templates/lifecycle/bucket_processor_deployment.yaml
+++ b/charts/backbeat/templates/lifecycle/bucket_processor_deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.orbit.enabled -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -80,3 +81,4 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+{{- end -}}

--- a/charts/backbeat/templates/lifecycle/conductor_deployment.yaml
+++ b/charts/backbeat/templates/lifecycle/conductor_deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.orbit.enabled -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -70,3 +71,4 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+{{- end -}}

--- a/charts/backbeat/templates/lifecycle/object_processor_deployment.yaml
+++ b/charts/backbeat/templates/lifecycle/object_processor_deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.orbit.enabled -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -80,3 +81,4 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+{{- end -}}

--- a/charts/backbeat/templates/replication/data_processor_deployment.yaml
+++ b/charts/backbeat/templates/replication/data_processor_deployment.yaml
@@ -11,10 +11,34 @@ spec:
   replicas: {{ .Values.replication.dataProcessor.replicaCount }}
   template:
     metadata:
+      {{- if not .Values.global.orbit.enabled }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- end }}
       labels:
         app: {{ template "backbeat.name" . }}-replication
         release: {{ .Release.Name }}
     spec:
+      {{- if not .Values.global.orbit.enabled }}
+      initContainers:
+        - name: backbeat-accounts
+          image: "zenko/tools:latest"
+          command:
+            - "sh"
+          args:
+            - "-c"
+            - |
+              set -e
+              set -x
+              jq -s '. as [$ACCS, $KEYS] | $ACCS.accounts | map(.keys={ access: $KEYS[.name].access, secret: $KEYS[.name].secret} ) | { accounts: . }' /accounts/authdata.json /credentials/credentials.json > /data/authdata.json
+          volumeMounts:
+            - name: accounts
+              mountPath: /accounts
+            - name: credentials
+              mountPath: /credentials
+            - name: auth-config
+              mountPath: /data
+      {{- end }}
       containers:
         - name: replication-data-processor
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -22,8 +46,6 @@ spec:
           command: ["/usr/src/app/docker-entrypoint.sh"]
           args: ["npm", "run", "queue_processor"]
           env:
-            - name: REMOTE_MANAGEMENT_DISABLE
-              value: "{{- if .Values.orbit.enabled }}0{{- else }}1{{- end }}"
             - name: ZOOKEEPER_AUTO_CREATE_NAMESPACE
               value: "1"
             - name: ZOOKEEPER_CONNECTION_STRING
@@ -32,20 +54,44 @@ spec:
               value: "{{- printf "%s-zenko-queue:9092" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: LOG_LEVEL
               value: {{ .Values.logging.level }}
-            - name: EXTENSIONS_REPLICATION_SOURCE_AUTH_TYPE
-              value: service
-            - name: EXTENSIONS_REPLICATION_SOURCE_AUTH_ACCOUNT
-              value: service-replication
             - name: EXTENSIONS_REPLICATION_SOURCE_S3_HOST
               value: "{{- printf "%s-cloudserver" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: EXTENSIONS_REPLICATION_SOURCE_S3_PORT
               value: "80"
+            - name: EXTENSIONS_REPLICATION_DEST_BOOTSTRAPLIST
+              value: "{{- printf "%s-cloudserver:80" .Release.Name | trunc 63 | trimSuffix "-" -}}"
+            {{- if .Values.global.orbit.enabled }}
+            - name: REMOTE_MANAGEMENT_DISABLE
+              value: "0"
+            - name: EXTENSIONS_REPLICATION_SOURCE_AUTH_TYPE
+              value: service
+            - name: EXTENSIONS_REPLICATION_SOURCE_AUTH_ACCOUNT
+              value: service-replication
             - name: EXTENSIONS_REPLICATION_DEST_AUTH_TYPE
               value: service
             - name: EXTENSIONS_REPLICATION_DEST_AUTH_ACCOUNT
               value: service-replication
-            - name: EXTENSIONS_REPLICATION_DEST_BOOTSTRAPLIST
-              value: "{{- printf "%s-cloudserver:80" .Release.Name | trunc 63 | trimSuffix "-" -}}"
+            {{ else }}
+            - name: REMOTE_MANAGEMENT_DISABLE
+              value: "1"
+            - name: S3AUTH_CONFIG
+              value: "/data/authdata.json"
+            - name: EXTENSIONS_REPLICATION_SOURCE_AUTH_TYPE
+              value: account
+            - name: EXTENSIONS_REPLICATION_SOURCE_AUTH_ACCOUNT
+              value: Replication
+            - name: EXTENSIONS_REPLICATION_DEST_AUTH_TYPE
+              value: account
+            - name: EXTENSIONS_REPLICATION_DEST_AUTH_ACCOUNT
+              value: Replication
+            {{- if .Values.global.replicationEndpoints }}
+            - name: EXTENSIONS_REPLICATION_DEST_BOOTSTRAPLIST_MORE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Release.Name }}-backbeat-configmap
+                  key: bootstrapList
+            {{- end }}
+            {{- end }}
             - name: MONGODB_HOSTS
               value: "{{ template "backbeat.mongodb-hosts" . }}"
             - name: REDIS_HOST
@@ -64,6 +110,11 @@ spec:
             httpGet:
               path: {{ .Values.health.path.readiness }}
               port: {{ .Values.health.port }}
+          {{- if not .Values.global.orbit.enabled }}
+          volumeMounts:
+            - name: auth-config
+              mountPath: /data
+          {{- end}}
           resources:
 {{ toYaml .Values.replication.dataProcessor.resources | indent 12 }}
     {{- with .Values.replication.dataProcessor.nodeSelector }}
@@ -78,3 +129,14 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+      volumes:
+        {{- if not .Values.global.orbit.enabled }}
+        - name: auth-config
+          emptyDir: {}
+        - name: accounts
+          configMap:
+            name: {{ template "backbeat.fullname" . }}-configmap
+        - name: credentials
+          secret:
+            secretName: {{ .Release.Name }}-service-secrets
+        {{- end }}

--- a/charts/backbeat/templates/replication/populator_deployment.yaml
+++ b/charts/backbeat/templates/replication/populator_deployment.yaml
@@ -11,6 +11,10 @@ spec:
   replicas: {{ .Values.replication.populator.replicaCount }}
   template:
     metadata:
+      {{- if not .Values.global.orbit.enabled }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- end }}
       labels:
         app: {{ template "backbeat.name" . }}-replication
         release: {{ .Release.Name }}
@@ -21,14 +25,30 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args: ["npm", "run", "queue_populator"]
           env:
-            - name: REMOTE_MANAGEMENT_DISABLE
-              value: "{{- if .Values.orbit.enabled }}0{{- else }}1{{- end }}"
             - name: ZOOKEEPER_AUTO_CREATE_NAMESPACE
               value: "1"
             - name: ZOOKEEPER_CONNECTION_STRING
               value: "{{- printf "%s-zenko-quorum:2181" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: KAFKA_HOSTS
               value: "{{- printf "%s-zenko-queue:9092" .Release.Name | trunc 63 | trimSuffix "-" -}}"
+            {{- if .Values.global.orbit.enabled }}
+            - name: REMOTE_MANAGEMENT_DISABLE
+              value: "0"
+            {{ else }}
+            - name: REMOTE_MANAGEMENT_DISABLE
+              value: "1"
+            # Do we need this below?
+            - name: EXTENSIONS_REPLICATION_DEST_BOOTSTRAPLIST
+              value: "{{- printf "%s-cloudserver:80" .Release.Name | trunc 63 | trimSuffix "-" -}}"
+            {{- if .Values.global.locationConstraints }}
+            - name: EXTENSIONS_REPLICATION_DEST_BOOTSTRAPLIST_MORE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Release.Name }}-backbeat-configmap
+                  key: bootstrapList
+            {{- end }}
+            ####################
+            {{- end }}
             - name: MONGODB_HOSTS
               value: "{{ template "backbeat.mongodb-hosts" . }}"
             - name: REDIS_HOST

--- a/charts/backbeat/templates/replication/status_processor_deployment.yaml
+++ b/charts/backbeat/templates/replication/status_processor_deployment.yaml
@@ -11,6 +11,10 @@ spec:
   replicas: {{ .Values.replication.statusProcessor.replicaCount }}
   template:
     metadata:
+      {{- if not .Values.global.orbit.enabled }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- end }}
       labels:
         app: {{ template "backbeat.name" . }}-replication
         release: {{ .Release.Name }}
@@ -22,8 +26,6 @@ spec:
           command: ["/usr/src/app/docker-entrypoint.sh"]
           args: ["npm", "run", "replication_status_processor"]
           env:
-            - name: REMOTE_MANAGEMENT_DISABLE
-              value: "{{- if .Values.orbit.enabled }}0{{- else }}1{{- end }}"
             - name: ZOOKEEPER_AUTO_CREATE_NAMESPACE
               value: "1"
             - name: ZOOKEEPER_CONNECTION_STRING
@@ -32,14 +34,25 @@ spec:
               value: "{{- printf "%s-zenko-queue:9092" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: MONGODB_HOSTS
               value: "{{ template "backbeat.mongodb-hosts" . }}"
-            - name: EXTENSIONS_REPLICATION_SOURCE_AUTH_TYPE
-              value: service
-            - name: EXTENSIONS_REPLICATION_SOURCE_AUTH_ACCOUNT
-              value: service-replication
             - name: EXTENSIONS_REPLICATION_SOURCE_S3_HOST
               value: "{{- printf "%s-cloudserver" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: EXTENSIONS_REPLICATION_SOURCE_S3_PORT
               value: "80"
+            {{- if .Values.global.orbit.enabled }}
+            - name: REMOTE_MANAGEMENT_DISABLE
+              value: "0"
+            - name: EXTENSIONS_REPLICATION_SOURCE_AUTH_TYPE
+              value: service
+            - name: EXTENSIONS_REPLICATION_SOURCE_AUTH_ACCOUNT
+              value: service-replication
+            {{ else }}
+            - name: REMOTE_MANAGEMENT_DISABLE
+              value: "1"
+            - name: EXTENSIONS_REPLICATION_SOURCE_AUTH_TYPE
+              value: account
+            - name: EXTENSIONS_REPLICATION_SOURCE_AUTH_ACCOUNT
+              value: Replication
+            {{- end }}
             - name: REDIS_HOST
               value: "{{- printf "%s-%s" .Release.Name "redis-ha-master-svc" | trunc 63 | trimSuffix "-" -}}"
             - name: REDIS_PORT

--- a/charts/backbeat/values.yaml
+++ b/charts/backbeat/values.yaml
@@ -1,8 +1,12 @@
 # Default values for backbeat.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-orbit:
-  enabled: true
+
+global:
+  orbit:
+    enabled: true
+  locationConstraints: {}
+  replicationEndpoints: []
 
 image:
   repository: zenko/backbeat

--- a/charts/cloudserver/templates/_env.tpl
+++ b/charts/cloudserver/templates/_env.tpl
@@ -20,7 +20,7 @@ env:
     value: "{{ .Release.Name }}-cloudserver,{{ .Values.endpoint }}"
   - name: HEALTHCHECKS_ALLOWFROM
     value: "{{ .Values.allowHealthchecksFrom }}"
-  {{- if .Values.orbit.storageLimit.enabled }}
+  {{- if .Values.global.orbit.storageLimit.enabled }}
   - name: STORAGE_LIMIT_ENABLED
     value: "true"
   {{- end }}
@@ -49,25 +49,25 @@ env:
     value: "{{ template "cloudserver.mongodb-hosts" . }}"
   - name: MONGODB_RS
     value: "{{ default "rs0" .Values.mongodb.replicaSet }}"
-  {{- if .Values.orbit.enabled }}
+  {{- if .Values.global.orbit.enabled }}
   - name: REMOTE_MANAGEMENT_DISABLE
     value: "0"
   - name: MANAGEMENT_ENDPOINT
-    value: "{{- .Values.orbit.endpoint -}}"
+    value: "{{- .Values.global.orbit.endpoint -}}"
   - name: PUSH_ENDPOINT
-    value: "{{- .Values.orbit.pushEndpoint -}}"
+    value: "{{- .Values.global.orbit.pushEndpoint -}}"
   {{- else }}
   - name: REMOTE_MANAGEMENT_DISABLE
     value: "1"
-  - name: SCALITY_ACCESS_KEY_ID
-    valueFrom:
-      secretKeyRef:
-        name: {{ template "cloudserver.fullname" . }}
-        key: keyId
-  - name: SCALITY_SECRET_ACCESS_KEY
-    valueFrom:
-      secretKeyRef:
-        name: {{ template "cloudserver.fullname" . }}
-        key: secretKey
+  - name: S3AUTH_CONFIG
+    value: "/data/authdata.json"
+  {{- if .Values.global.locationConstraints }}
+  - name: S3_LOCATION_FILE
+    value: "/etc/config/locationConfig"
+  {{- if .Values.global.replicationEndpoints }}
+  - name: S3_REPLICATION_FILE
+    value: "/etc/config/replicationInfo"
+  {{- end }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/cloudserver/templates/accounts.yaml
+++ b/charts/cloudserver/templates/accounts.yaml
@@ -1,0 +1,58 @@
+{{- if not .Values.global.orbit.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "cloudserver.fullname" . }}-accounts
+  labels:
+    app: {{ template "cloudserver.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  authdata.json: |-
+    {
+      "accounts": [
+        {
+          {{ $id := randNumeric 12 }}
+          "name": "Lifecycle",
+          "email": "inspector@replication.info",
+          "arn": "{{ printf "arn:aws:iam::%s:root" $id }}",
+          "canonicalID": "http://acs.zenko.io/accounts/service/lifecycle",
+          "shortid": "{{ $id }}",
+          "keys": [{
+            "access": "",
+            "secret": ""
+          }]
+        },
+        {
+          {{ $id := randNumeric 12 }}
+          "name": "Replication",
+          "email": "inspector@lifecycle.info",
+          "arn": "{{ printf "arn:aws:iam::%s:root" $id }}",
+          "canonicalID": "http://acs.zenko.io/accounts/service/replication",
+          "shortid": "{{ $id }}",
+          "keys": [{
+            "access": "",
+            "secret": ""
+          }]
+        }
+        {{ $last := keys .Values.users | sortAlpha | last }}
+        {{- if $last -}},{{- end -}}
+        {{ range $user, $creds := .Values.users }}
+        {
+          {{ $id := randNumeric 12 }}
+          "name": "{{ $user }}",
+          "email": "{{ $user }}@zenko.info",
+          "arn": "{{ printf "arn:aws:iam::%s:root" $id }}",
+          "canonicalID": "{{ $user }}-canonicalID",
+          "shortid": "{{ $id }}",
+          "keys": [{
+            "access": "",
+            "secret": ""
+          }]
+        }
+        {{- if ne $user $last -}},{{- end }}
+        {{- end }}
+      ]
+    }
+{{- end }}

--- a/charts/cloudserver/templates/configmap.yaml
+++ b/charts/cloudserver/templates/configmap.yaml
@@ -1,0 +1,77 @@
+{{- if not .Values.global.orbit.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-cloudserver-configmap
+  labels:
+    app: {{ template "cloudserver.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+{{- if .Values.global.locationConstraints }}
+  locationConfig: |-
+    {{ $last := keys .Values.global.locationConstraints | sortAlpha | last }}
+    {
+      "us-east-1": {
+        "type": "file",
+        "objectId": "us-east-1",
+        "legacyAwsBehavior": {{ default true }},
+        "details": {}
+      }
+      {{- if $last -}},{{- end -}}
+      {{ range $index, $location := .Values.global.locationConstraints }}
+      "{{ $index }}": {
+        "type": "{{ $location.type }}",
+        "objectId": "{{ $index }}",
+        "legacyAwsBehavior": {{ $location.legacyAwsBehavior }},
+        "details": {
+          {{- if eq $location.type "aws_s3" }}
+            "bucketMatch": {{ $location.details.bucketMatch }},
+            "https": {{ $location.details.https | default true }},
+            "awsEndpoint": "{{ $location.details.awsEndpoint }}",
+            "bucketName": "{{ $location.details.bucketName }}",
+            {{- if $location.details.serverSideEncryption }}
+            "serverSideEncryption": {{$location.details.serverSideEncryption | default false}},
+            {{- end }}
+            "credentials": {
+              "accessKey": "{{ $location.details.credentials.accessKey }}",
+              "secretKey": "{{ $location.details.credentials.secretKey }}"
+            }
+          {{- else if eq $location.type "azure" }}
+            "bucketMatch": {{ $location.details.bucketMatch }},
+            "azureStorageEndpoint": "{{ $location.details.azureStorageEndpoint }}",
+            "azureStorageAccountName": "{{ $location.details.azureStorageAccountName }}",
+            "azureStorageAccessKey": "{{ $location.details.azureStorageAccessKey }}",
+            "azureContainerName": "{{ $location.details.azureContainerName }}"
+          {{- else if eq $location.type "gcp" }}
+            "bucketMatch": {{ $location.details.bucketMatch }},
+            "https": {{ $location.details.https | default true }},
+            "gcpEndpoint": "{{ $location.details.gcpEndpoint }}",
+            "bucketName": "{{ $location.details.bucketName }}",
+            "mpuBucketName": "{{ $location.details.mpuBucketName }}",
+            "credentials": {
+              "accessKey": "{{ $location.details.credentials.accessKey }}",
+              "secretKey": "{{ $location.details.credentials.secretKey }}"
+            }
+          {{- end }}
+        }
+      }
+      {{- if ne $index $last -}},{{- end }}
+      {{- end }}
+    }
+{{ if .Values.global.replicationEndpoints }}
+  replicationInfo: |-
+    [
+      {{ $last := keys .Values.global.locationConstraints | sortAlpha | last -}}
+      {{- range $index, $locName := .Values.global.locationConstraints }}
+      {
+        "site": "{{ $index }}",
+        "type": "{{ $locName.type }}"
+      }
+      {{- if ne $index $last -}},{{- end -}}
+      {{- end }}
+    ]
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/cloudserver/templates/deployment.yaml
+++ b/charts/cloudserver/templates/deployment.yaml
@@ -19,10 +19,37 @@ spec:
         {{- if .Values.proxy.https }}
         checksum/config: {{ include (print $.Template.BasePath "/certificate.yaml") . | sha256sum }}
         {{- end }}
+        {{- if not .Values.global.orbit.enabled }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/accounts.yaml") . | sha256sum }}
+        {{- end }}
       labels:
         app: {{ template "cloudserver.name" . }}
         release: {{ .Release.Name }}
     spec:
+      {{- if not .Values.global.orbit.enabled }}
+      initContainers:
+        - name: cloudserver-accounts
+          image: "zenko/tools:latest"
+          command:
+            - "sh"
+          args:
+            - "-c"
+            - |
+              set -e
+              set -x
+              jq -s '.[0] * .[1]' /user-credentials/credentials.json /service-credentials/credentials.json > /data/credentials.json
+              jq -s '. as [$ACCS, $KEYS] | $ACCS.accounts | map(.keys[0]={ access: $KEYS[.name].access, secret: $KEYS[.name].secret} ) | { accounts: . }' /accounts/authdata.json /data/credentials.json > /data/authdata.json
+          volumeMounts:
+            - name: accounts
+              mountPath: /accounts
+            - name: service-credentials
+              mountPath: /service-credentials
+            - name: user-credentials
+              mountPath: /user-credentials
+            - name: auth-config
+              mountPath: /data
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -31,9 +58,9 @@ spec:
             - name: http
               containerPort: 8000
 {{ include "cloudserver.env" . | indent 10 }}
-            {{- if .Values.orbit.enabled }}
+            {{- if .Values.global.orbit.enabled }}
             - name: MANAGEMENT_MODE
-              value: "{{- .Values.orbit.workerMode -}}"
+              value: "{{- .Values.global.orbit.workerMode -}}"
             - name: PUSH_STATS
               value: "false"
             {{- end }}
@@ -52,6 +79,14 @@ spec:
               mountPath: "/ssl"
               readOnly: true
             {{- end }}
+            {{- if not .Values.global.orbit.enabled }}
+            {{- if .Values.global.locationConstraints }}
+            - name: location-config
+              mountPath: /etc/config
+            - name: auth-config
+              mountPath: /data
+            {{- end}}
+            {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}
@@ -69,4 +104,22 @@ spec:
         - name: proxy-cert
           secret:
             secretName: {{ template "cloudserver.fullname" . }}-proxy
+        {{- end }}
+        {{- if not .Values.global.orbit.enabled }}
+        {{- if .Values.global.locationConstraints }}
+        - name: location-config
+          configMap:
+            name: {{ template "cloudserver.fullname" . }}-configmap
+        {{- end }}
+        - name: auth-config
+          emptyDir: {}
+        - name: accounts
+          configMap:
+            name: {{ template "cloudserver.fullname" . }}-accounts
+        - name: service-credentials
+          secret:
+            secretName: {{ .Release.Name }}-service-secrets
+        - name: user-credentials
+          secret:
+            secretName: {{ template "cloudserver.fullname" . }}-user-secrets
         {{- end }}

--- a/charts/cloudserver/templates/manager-deployment.yaml
+++ b/charts/cloudserver/templates/manager-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.orbit.enabled -}}
+{{- if .Values.global.orbit.enabled -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -33,7 +33,7 @@ spec:
               containerPort: 8000
 {{ include "cloudserver.env" . | indent 10 }}
             - name: MANAGEMENT_MODE
-              value: "{{- .Values.orbit.managerMode -}}"
+              value: "{{- .Values.global.orbit.managerMode -}}"
             {{- range $key, $value := .Values.env }}
             - name: {{ $key | upper | replace "." "_" }}
               value: {{ $value | quote }}

--- a/charts/cloudserver/templates/secrets.yaml
+++ b/charts/cloudserver/templates/secrets.yaml
@@ -1,7 +1,8 @@
+{{- if not .Values.global.orbit.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "cloudserver.fullname" . }}
+  name: {{ template "cloudserver.fullname" . }}-user-secrets
   labels:
     app: {{ template "cloudserver.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
@@ -9,5 +10,5 @@ metadata:
     heritage: {{ .Release.Service }}
 type: Opaque
 data:
-  keyId: {{ .Values.credentials.keyId | b64enc }}
-  secretKey: {{ .Values.credentials.secretKey | b64enc }}
+  credentials.json: {{ toJson .Values.users | b64enc }}
+{{- end }}

--- a/charts/cloudserver/templates/tests/cloudserver-test.yaml
+++ b/charts/cloudserver/templates/tests/cloudserver-test.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.orbit.enabled }}
-{{- else }}
+{{- if not .Values.global.orbit.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:

--- a/charts/cloudserver/values.yaml
+++ b/charts/cloudserver/values.yaml
@@ -2,22 +2,61 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-orbit:
-  enabled: true
-  endpoint: https://api.zenko.io
-  pushEndpoint: https://push.api.zenko.io
-  managerMode: push
-  workerMode: push
-  storageLimit:
-  # This allows you to manage storage limits from Orbit
+global:
+  orbit:
     enabled: true
+    endpoint: https://api.zenko.io
+    pushEndpoint: https://push.api.zenko.io
+    managerMode: push
+    workerMode: push
+    storageLimit:
+      # This allows you to manage storage limits from Orbit
+      enabled: true
 
-# When 'orbit.enabled' is 'true', these aren't used, please use
-# https://zenko.io to manage your deployment
+  # When 'orbit.enabled' is 'true', these aren't used, please use
+  # https://zenko.io to manage your deployment
+  locationConstraints: {}
+    # awsbackend:
+    #   type: aws_s3
+    #   legacyAwsBehavior: true
+    #   details:
+    #     bucketMatch: true
+    #     awsEndpoint: s3.amazonaws.com
+    #     bucketName:
+    #     credentials:
+    #       accessKey:
+    #       secretKey:
+    # azurebackend:
+    #   type: azure
+    #   legacyAwsBehavior: true
+    #   details:
+    #     bucketMatch: false
+    #     azureStorageEndpoint: https://example.blob.core.windows.net
+    #     azureStorageAccountName:
+    #     azureStorageAccessKey:
+    #     azureContainerName:
+    # gcpbackend:
+    #   type: gcp
+    #   legacyAwsBehavior: true
+    #   details:
+    #     bucketMatch: false
+    #     gcpEndpoint: storage.googleapis.com
+    #     bucketName:
+    #     mpuBucketName:
+    #     credentials:
+    #       accessKey:
+    #       secretKey:
+  replicationEndpoints: []
+    # - awsbackend
+    # - azurebackend
+    # - gcpbackend
+
 endpoint: zenko.local
-credentials:
-  keyId: deployment-specific-access-key
-  secretKey: deployment-specific-secret-key
+
+users: {}
+  # accountName:
+    # access:
+    # secret:
 
 logging:
    # Options: info, debug, trace

--- a/charts/setup-no-orbit.md
+++ b/charts/setup-no-orbit.md
@@ -1,0 +1,165 @@
+# Setup without Zenko Orbit
+
+This guide will cover how to setup Zenko with user-defined cloud backends and
+replication backends without using Zenko Orbit.
+
+## Location Constraints Setup
+
+To setup and use user-defined cloud backends as location constraints and/or
+replication sites, Orbit must be disabled in the Zenko
+[values.yaml](./zenko/values.yaml) file.
+
+### Adding Cloud Backends
+
+To add a cloud backend, you will have to edit the `locationConstraints`
+value for `global` in your Zenko `values.yaml` file.
+
+```yaml
+global:
+  locationConstraints:
+    (...)
+```
+
+### Adding Replication Sites
+
+To add replication sites, you will need to first define all
+the site information as location constraints, and, once those are defined,
+you can use the locations as sites by modifying the `replicationEndpoints`
+value for `global` in your Zenko `values.yaml` file.
+
+In this examples, the locations `awsbackend`, `azurebackend`, and `gcpbackend`
+are set up as a locations for Zenko.
+
+```yaml
+global:
+  orbit:
+    enabled: false
+  (...)
+  locationConstraints:
+    awsbackend: (...)
+    azurebackend: (...)
+    gcpbackend: (...)
+  replicationEndpoints:
+    - awsbackend
+    - azurebackend
+    - gcpbackend
+```
+
+## Example
+
+The following will show an example of configure the location constraints and
+replication sites for Zenko.
+
+In the file [Zenko/values.yaml](./zenko/values.yaml):
+
++ Configure `global` values:
+
+    - Set `orbit.enabled` to `false`:
+
+      ```yaml
+         global:
+           orbit:
+             enabled: false
+      ```
+
+    - Add Cloudserver compatible backends in `locationConstraints`:
+
+      In this example, our backend is named `cloud-backend` with the endpoint
+      `aws.endpoint.com` and uses the bucket `zenko-bucket`
+
+      ```yaml
+        global:
+          orbit: (...)
+          locationConstraints:
+            cloud-backend:
+              type: aws_s3
+              legacyAwsBehavior: true
+              details:
+                bucketMatch: true
+                https: true
+                awsEndpoint: aws.endpoint.com
+                bucketName: zenko-bucket
+                credentials:
+                  accessKey: WHDBFKILOSDDVF78NPMQ
+                  secretKey: 87hdfGCvDS+YYzefKLnjjZEYstOIuIjs/2X72eET
+      ```
+
+    - Add locations as sites under `replcitionEndpoints`:
+
+      With `cloud-backend` defined in `locationConstraints`
+
+      ```yaml
+        global:
+          orbit: (...)
+          locationConstraints:
+            cloud-backend: (...)
+          replicationEndpoints:
+            - cloud-backend
+      ```
+
+    - Set one or more users for cloudserver:
+
+      ```yaml
+        cloudserver:
+          users:
+            accountname:
+              access: deployment-specific-access-key
+              secret: deployment-specific-secret-key
+      ```
+
+      These are necessary to access cloudserver when orbit is disabled.
+
+With these configurations set, `cloud-backend` can now be used as a location
+constraint and replication site.
+
+## Example with 3 different backends
+
+```yaml
+  global:
+    orbit:
+      enabled: false
+    locationConstraints:
+      awsbackend:
+        type: aws_s3
+        legacyAwsBehavior: true
+        details:
+          bucketMatch: true
+          https: true
+          awsEndpoint: s3.amazonaws.com
+          bucketName: awsBucketName
+          credentials:
+            accessKey: WHDBFKILOSDDVF78NPMQ
+            secretKey: 87hdfGCvDS+YYzefKLnjjZEYstOIuIjs/2X72eET
+      azurebackend:
+        type: azure
+        legacyAwsBehavior: true
+        details:
+          bucketMatch: true
+          azureStorageEndpoint: https://azure-account-name.blob.core.windows.net/
+          azureStorageAccountName: azure-account-name
+          azureStorageAccessKey: auhyDo8izbuU4aZGdhxnWh0ODKFP3IWjsN1UfFaoqFbnYzPj9bxeCVAzTIcgzdgqomDKx6QS+8ov8PYCON0Nxw==
+          azureContainerName: azure-container
+      gcpbackend:
+        type: gcp
+        legacyAwsBehavior: true
+        details:
+          bucketMatch: true
+          https: true
+          gcpEndpoint: storage.googleapis.com
+          bucketName: gcpBucketName
+          mpuBucketName: gcpMpuBucketName
+          credentials:
+            accessKey: GOOGFKILOSDDVF78NPMQ
+            secretKey: 87hdfGCvDS+YYzefKLnjjZEYstOIuIjs/2X72eET
+    replicationEndpoints:
+      - awsbackend
+      - azurebackend
+      - gcpbackend
+
+  cloudserver:
+    endpoint: zenko.local
+    users:
+      accountname:
+        access: deployment-specific-access-key
+        secret: deployment-specific-secret-key
+```

--- a/charts/single-node-values.yml
+++ b/charts/single-node-values.yml
@@ -3,7 +3,7 @@ nodeCount: &nodeCount 1
 ingress:
   enabled: true
   hosts:
-    - ""
+    - "zenko.local"
 
 cloudserver:
   mongodb:

--- a/charts/zenko/templates/secrets.yaml
+++ b/charts/zenko/templates/secrets.yaml
@@ -1,0 +1,14 @@
+{{- if not .Values.global.orbit.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-service-secrets
+  labels:
+    app: {{ template "zenko.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  credentials.json: "{{ printf "{\"Lifecycle\": {\"access\": \"%s\", \"secret\": \"%s\" }, \"Replication\": {\"access\": \"%s\", \"secret\": \"%s\" } }" (randAlphaNum 20 | upper) (randAlphaNum 40) (randAlphaNum 20 | upper) (randAlphaNum 40) | b64enc }}"
+{{- end -}}

--- a/charts/zenko/values.yaml
+++ b/charts/zenko/values.yaml
@@ -24,19 +24,25 @@ ingress:
     #   hosts:
     #     - zenko.example.com
 
+global:
+  orbit:
+    enabled: true
+    endpoint: https://api.zenko.io
+    # When 'orbit.enabled' is 'true', these aren't used, please use
+    # https://zenko.io to manage your deployment
+  locationConstraints: {}
+  replicationEndpoints: []
+
 cloudserver:
   replicaCount: *nodeCount
   replicaFactor: 10
   mongodb:
     replicas: *nodeCount
-  orbit:
-    enabled: true
-  # When 'orbit.enabled' is 'true', these aren't used, please use
-  # https://zenko.io to manage your deployment
   endpoint: zenko.local
-  credentials:
-    keyId: deployment-specific-access-key
-    secretKey: deployment-specific-secret-key
+  users: {}
+    # accountName:
+      # access:
+      # secret:
 
 backbeat:
   replication:

--- a/eve/ci-values.yml
+++ b/eve/ci-values.yml
@@ -37,12 +37,14 @@ redis-ha:
     create: false
     name: default
 
-cloudserver:
-  image:
-    pullPolicy: Always
+global:
   orbit:
     endpoint: "http://ciutil-orbit-simulator:4222"
     managerMode: "poll"
+
+cloudserver:
+  image:
+    pullPolicy: Always
   replicaCount: 0
   env:
     MPU_TESTING: 'yes'

--- a/images/tools/Dockerfile
+++ b/images/tools/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine
+
+RUN apk add --update --no-cache curl jq
+
+CMD ["sh"]


### PR DESCRIPTION
#### This adds several features to Zenko when Orbit is disabled:
- Support for using different cloud backends.
- Replication.
- Multiple Cloudserver users.

#### Documentation

Instrucctions on the setup can be found in ```charts/setup-no-orbit.md```.

#### Upgrades

If related configuration values are changed in ```values.yml```, a ```helm dependency build zenko && helm upgrade zenko zenko``` command (assuming zenko is the release name) will restart the pods with the updated configuration.