### PR TITLE
feat: add support to change the number of mongodb replicas

### DIFF
--- a/charts/backbeat/templates/_helpers.tpl
+++ b/charts/backbeat/templates/_helpers.tpl
@@ -30,3 +30,12 @@ Create chart name and version as used by the chart label.
 {{- define "backbeat.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create the default mongodb replicaset hosts string
+*/}}
+{{- define "backbeat.mongodb-hosts" -}}
+{{- $count := (atoi (printf "%d" (int64 .Values.mongodb.replicas))) -}}
+{{- $release := .Release.Name -}}
+{{- range $v := until $count }}{{ $release }}-mongodb-replicaset-{{ $v }}.{{ $release }}-mongodb-replicaset:27017{{ if ne $v (sub $count 1) }},{{- end -}}{{- end -}}
+{{- end -}}

--- a/charts/backbeat/templates/api/deployment.yaml
+++ b/charts/backbeat/templates/api/deployment.yaml
@@ -43,7 +43,7 @@ spec:
             - name: EXTENSIONS_REPLICATION_DEST_BOOTSTRAPLIST
               value: "{{- printf "%s-cloudserver-front:80" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: MONGODB_HOSTS
-              value: "{{ .Release.Name }}-mongodb-replicaset-0.{{ .Release.Name }}-mongodb-replicaset:27017,{{ .Release.Name }}-mongodb-replicaset-1.{{ .Release.Name }}-mongodb-replicaset:27017,{{ .Release.Name }}-mongodb-replicaset-2.{{ .Release.Name }}-mongodb-replicaset:27017"
+              value: "{{ template "backbeat.mongodb-hosts" . }}"
           livenessProbe:
             httpGet:
               path: /_/healthcheck

--- a/charts/backbeat/templates/lifecycle/consumer_deployment.yaml
+++ b/charts/backbeat/templates/lifecycle/consumer_deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - name: KAFKA_HOSTS
               value: "{{- printf "%s-zenko-queue:9092" .Release.Name .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: MONGODB_HOSTS
-              value: "{{ .Release.Name }}-mongodb-replicaset-0.{{ .Release.Name }}-mongodb-replicaset:27017,{{ .Release.Name }}-mongodb-replicaset-1.{{ .Release.Name }}-mongodb-replicaset:27017,{{ .Release.Name }}-mongodb-replicaset-2.{{ .Release.Name }}-mongodb-replicaset:27017"
+              value: "{{ template "backbeat.mongodb-hosts" . }}"
             - name: S3_HOST
               value: "{{- printf "%s-cloudserver-front" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: S3_PORT

--- a/charts/backbeat/templates/lifecycle/producer_deployment.yaml
+++ b/charts/backbeat/templates/lifecycle/producer_deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - name: KAFKA_HOSTS
               value: "{{- printf "%s-zenko-queue:9092" .Release.Name .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: MONGODB_HOSTS
-              value: "{{ .Release.Name }}-mongodb-replicaset-0.{{ .Release.Name }}-mongodb-replicaset:27017,{{ .Release.Name }}-mongodb-replicaset-1.{{ .Release.Name }}-mongodb-replicaset:27017,{{ .Release.Name }}-mongodb-replicaset-2.{{ .Release.Name }}-mongodb-replicaset:27017"
+              value: "{{ template "backbeat.mongodb-hosts" . }}"
             - name: S3_HOST
               value: "{{- printf "%s-cloudserver-front" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: S3_PORT

--- a/charts/backbeat/templates/replication/consumer_deployment.yaml
+++ b/charts/backbeat/templates/replication/consumer_deployment.yaml
@@ -47,7 +47,7 @@ spec:
             - name: EXTENSIONS_REPLICATION_DEST_BOOTSTRAPLIST
               value: "{{- printf "%s-cloudserver-front:80" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: MONGODB_HOSTS
-              value: "{{ .Release.Name }}-mongodb-replicaset-0.{{ .Release.Name }}-mongodb-replicaset:27017,{{ .Release.Name }}-mongodb-replicaset-1.{{ .Release.Name }}-mongodb-replicaset:27017,{{ .Release.Name }}-mongodb-replicaset-2.{{ .Release.Name }}-mongodb-replicaset:27017"
+              value: "{{ template "backbeat.mongodb-hosts" . }}"
             - name: REDIS_HOST
               value: "{{- printf "%s-%s" .Release.Name "redis-ha-master-svc" | trunc 63 | trimSuffix "-" -}}"
             - name: REDIS_PORT

--- a/charts/backbeat/templates/replication/producer_deployment.yaml
+++ b/charts/backbeat/templates/replication/producer_deployment.yaml
@@ -30,7 +30,7 @@ spec:
             - name: KAFKA_HOSTS
               value: "{{- printf "%s-zenko-queue:9092" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: MONGODB_HOSTS
-              value: "{{ .Release.Name }}-mongodb-replicaset-0.{{ .Release.Name }}-mongodb-replicaset:27017,{{ .Release.Name }}-mongodb-replicaset-1.{{ .Release.Name }}-mongodb-replicaset:27017,{{ .Release.Name }}-mongodb-replicaset-2.{{ .Release.Name }}-mongodb-replicaset:27017"
+              value: "{{ template "backbeat.mongodb-hosts" . }}"
             - name: REDIS_HOST
               value: "{{- printf "%s-%s" .Release.Name "redis-ha-master-svc" | trunc 63 | trimSuffix "-" -}}"
             - name: REDIS_PORT

--- a/charts/backbeat/templates/replication/status_deployment.yaml
+++ b/charts/backbeat/templates/replication/status_deployment.yaml
@@ -31,7 +31,7 @@ spec:
             - name: KAFKA_HOSTS
               value: "{{- printf "%s-zenko-queue:9092" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: MONGODB_HOSTS
-              value: "{{ .Release.Name }}-mongodb-replicaset-0.{{ .Release.Name }}-mongodb-replicaset:27017,{{ .Release.Name }}-mongodb-replicaset-1.{{ .Release.Name }}-mongodb-replicaset:27017,{{ .Release.Name }}-mongodb-replicaset-2.{{ .Release.Name }}-mongodb-replicaset:27017"
+              value: "{{ template "backbeat.mongodb-hosts" . }}"
             - name: EXTENSIONS_REPLICATION_SOURCE_AUTH_TYPE
               value: service
             - name: EXTENSIONS_REPLICATION_SOURCE_AUTH_ACCOUNT

--- a/charts/backbeat/values.yaml
+++ b/charts/backbeat/values.yaml
@@ -13,6 +13,9 @@ logging:
    # Options: info, debug, trace
    level: info
 
+mongodb:
+  replicas: 3
+
 api:
   replicaCount: 1
   service:

--- a/charts/cloudserver-front/templates/_helpers.tpl
+++ b/charts/cloudserver-front/templates/_helpers.tpl
@@ -38,3 +38,12 @@ Create the orbit management endpoint when running in ci mode
 {{- define "cloudserver-front.ci_endpoint" -}}
 {{- printf "http://%s-orbit-simulator:4222" .Values.ci.orbit_ns -}}
 {{- end -}}
+
+{{/*
+Create the default mongodb replicaset hosts string
+*/}}
+{{- define "cloudserver-front.mongodb-hosts" -}}
+{{- $count := (atoi (printf "%d" (int64 .Values.mongodb.replicas))) -}}
+{{- $release := .Release.Name -}}
+{{- range $v := until $count }}{{ $release }}-mongodb-replicaset-{{ $v }}.{{ $release }}-mongodb-replicaset:27017{{ if ne $v (sub $count 1) }},{{- end -}}{{- end -}}
+{{- end -}}

--- a/charts/cloudserver-front/templates/deployment.yaml
+++ b/charts/cloudserver-front/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
             - name: S3METADATA
               value: "mongodb"
             - name: MONGODB_HOSTS
-              value: "{{ .Release.Name }}-mongodb-replicaset-0.{{ .Release.Name }}-mongodb-replicaset:27017,{{ .Release.Name }}-mongodb-replicaset-1.{{ .Release.Name }}-mongodb-replicaset:27017,{{ .Release.Name }}-mongodb-replicaset-2.{{ .Release.Name }}-mongodb-replicaset:27017"
+              value: "{{ template "cloudserver-front.mongodb-hosts" . }}"
             - name: MONGODB_RS
               value: "{{ default "rs0" .Values.mongodb.replicaSet }}"
 {{- end}}

--- a/charts/cloudserver-front/values.yaml
+++ b/charts/cloudserver-front/values.yaml
@@ -25,6 +25,7 @@ allowHealthchecksFrom: '0.0.0.0/0'
 mongodb:
   enabled: true
   replicaSet: rs0
+  replicas: 3
 
 replicaCount: 1
 

--- a/charts/single-node-values.yml
+++ b/charts/single-node-values.yml
@@ -1,25 +1,35 @@
+nodeCount: &nodeCount 1
+
 ingress:
   enabled: true
   hosts:
     - ""
 
+cloudserver-front:
+  mongodb:
+    replicas: *nodeCount
+
+backbeat:
+  mongodb:
+    replicas: *nodeCount
+
 zenko-queue:
-  replicas: 1
+  replicas: *nodeCount
   kafkaHeapOptions: "-Xms256M"
   configurationOverrides:
-    "offsets.topic.replication.factor": 1
-    "min.insync.replicas": 1
+    "offsets.topic.replication.factor": *nodeCount
+    "min.insync.replicas": *nodeCount
 
 zenko-quorum:
-  replicaCount: 1
+  replicaCount: *nodeCount
   env:
     ZK_HEAP_SIZE: "256M"
 
 mongodb-replicaset:
   replicaSet: rs0
-  replicas: 3
+  replicas: *nodeCount
 
 redis-ha:
   replicas:
-    servers: 1
-    sentinels: 1
+    servers: *nodeCount
+    sentinels: *nodeCount

--- a/charts/zenko/values.yaml
+++ b/charts/zenko/values.yaml
@@ -1,6 +1,12 @@
 # Default values for zenko.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+
+# By default, MongoDB, Redis-HA, Zenko-Queue, and Zenko-Quorum
+# will use this value for their replica count. Typically, this
+# is equivalent to the number of nodes in a Kubernetes Cluster.
+nodeCount: &nodeCount 3
+
 ingress:
   enabled: false
   # Used to create an Ingress record.
@@ -19,6 +25,8 @@ ingress:
     #     - zenko.example.com
 
 cloudserver-front:
+  mongodb:
+    replicas: *nodeCount
   orbit:
     enabled: true
   # When 'orbit.enabled' is 'true', these aren't used, please use
@@ -28,30 +36,30 @@ cloudserver-front:
     keyId: deployment-specific-access-key
     secretKey: deployment-specific-secret-key
 
+backbeat:
+  mongodb:
+    replicas: *nodeCount
+
 prometheus:
   rbac:
     create: true
-
   alertmanager:
     enabled: false
-
   kubeStateMetrics:
     enabled: false
-
   nodeExporter:
     enabled: false
-
   pushgateway:
     enabled: false
 
 mongodb-replicaset:
   replicaSet: rs0
-  replicas: 3
+  replicas: *nodeCount
 
 zenko-queue:
 ## Extensive list of configurables can be found here:
 ## https://github.com/kubernetes/charts/blob/master/incubator/kafka/values.yaml
-  replicas: 3
+  replicas: *nodeCount
   rbac:
     enabled: true
   configurationOverrides:
@@ -70,7 +78,7 @@ zookeeper:
 zenko-quorum:
 ## Extensive list of configurables can be found here:
 ## https://github.com/kubernetes/charts/blob/master/incubator/zookeeper/values.yaml
-  replicaCount: 3
+  replicaCount: *nodeCount
   exporters:
     jmx:
       enabled: true
@@ -86,5 +94,5 @@ redis-ha:
   rbac:
     create: true
   replicas:
-    servers: 3
-    sentinels: 3
+    servers: *nodeCount
+    sentinels: *nodeCount


### PR DESCRIPTION
Before, the environmental variable MONGODB_HOSTS (which both Backbeat and Cloudserver-front use) was a hardcoded string of 3 MongoDB replica sets, like this:

```
{{ .Release.Name }}-mongodb-replicaset-0.{{ .Release.Name }}-mongodb-replicaset:27017,{{ .Release.Name }}-mongodb-replicaset-1.{{ .Release.Name }}-mongodb-replicaset:27017,{{ .Release.Name }}-mongodb-replicaset-2.{{ .Release.Name }}-mongodb-replicaset:27017
```

These changes will generate the proper MONGODB_HOSTS string based on the number of replicas sets specified in the charts/values.yaml file.

These changes also introduce the "nodeCount" anchor value, which serves as a base value for the number of replicas for the various deployments (MongoDB, Redis-HA, Zenko-Queue and Zenko-Quorum). Typically, this will be the number of nodes in a Kubernetes cluster, but of course, the user can modify individual values as they wish.

The single-node-values.yml was also updated and now it will only deploy 1 MongoDB replica set instead of 3.