### PR TITLE
bugfix: ZENKO-143 mongodb-hosts for backbeat gc

### DIFF
--- a/charts/backbeat/templates/gc/deployment.yaml
+++ b/charts/backbeat/templates/gc/deployment.yaml
@@ -35,7 +35,7 @@ spec:
             - name: S3_PORT
               value: "80"
             - name: MONGODB_HOSTS
-              value: "{{ .Release.Name }}-mongodb-replicaset-0.{{ .Release.Name }}-mongodb-replicaset:27017,{{ .Release.Name }}-mongodb-replicaset-1.{{ .Release.Name }}-mongodb-replicaset:27017,{{ .Release.Name }}-mongodb-replicaset-2.{{ .Release.Name }}-mongodb-replicaset:27017"
+              value: "{{ template "backbeat.mongodb-hosts" . }}"
           livenessProbe:
             httpGet:
               path: {{ .Values.health.path.liveness}}


### PR DESCRIPTION
Make sure backbeat GC service uses mongodb-hosts template string for
MONGODB_HOSTS env var (adapts to number of mongodb hosts
automatically).