### PR TITLE
feat: add zenko-filer chart

### DIFF
--- a/charts/single-node-values.yml
+++ b/charts/single-node-values.yml
@@ -13,6 +13,10 @@ backbeat:
   mongodb:
     replicas: *nodeCount
 
+zenko-filer:
+  mongodb:
+    replicas: *nodeCount
+
 zenko-queue:
   replicas: *nodeCount
   kafkaHeapOptions: "-Xms256M"

--- a/charts/zenko-filer/.helmignore
+++ b/charts/zenko-filer/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/zenko-filer/Chart.yaml
+++ b/charts/zenko-filer/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Zenko Filer
+name: zenko-filer
+version: 0.1.0

--- a/charts/zenko-filer/nfsd.conf
+++ b/charts/zenko-filer/nfsd.conf
@@ -1,0 +1,75 @@
+SCALITY
+{
+    redis_sentinels = "%REDIS_SENTINEL_BOOTSTRAP%";
+    redis_name = "%REDIS_CLUSTER_NAME%";
+    #redis_host = "%REDIS_HOST%";
+    #redis_port = %REDIS_PORT%;
+    dbd_url = "%BUCKETD_URL%";
+
+    ## If neither of location_config or sproxyd_url is defined
+    ## the locations descriptions are gathered from the PENSIEVE
+    ## bucket, which is expected in a Zenko on Kubernetes context.
+    #location_config = "%LOCATIONS_CONFIGURATION_FILE%";
+    #sproxyd_url = "%SPROXYD_URL%"
+}
+
+NFS_CORE_PARAM {
+	Enable_NLM = false;
+}
+
+NFSV4
+{
+    ## It is not advised to enable the Graceless option
+    #Graceless = true;
+    ## 'Only_Numeric_Owners = true' disables the use of the ID Mapper
+    Only_Numeric_Owners = true;
+}
+
+# EXPORT
+# {
+#     # Export Id (mandatory, each EXPORT must have a unique Export_Id)
+#     Export_Id = 76;
+#
+#     # Exported path (mandatory)
+#     Path = /mybucket;
+#
+#     # Pseudo Path (required for NFS v4)
+#     Pseudo = /mybucket;
+#
+#     # Required for access (default is None)
+#     # Could use CLIENT blocks instead
+#     # To grant write access to the NFS server:
+#     # * The bucket must have its versioning configuration undefined
+#     # * The bucket attribute isNFS must be set to 'true'
+#     #   (This happens when the bucket has been created with the appropriate tool XXX)
+#     Access_Type = RW;
+#
+#     # Used to complete the posix attributes on objects
+#     # not created via the NFS mount point
+#     Anonymous_uid = 1000;
+#     Anonymous_gid = 1000;
+#
+#     # Protocols to activate on this export
+#     Protocols = 3, 4, 9p;
+#
+#     # Do not squash root user, Since the underlying filesystem
+#     # has no real substanciation, it is a required option enabling
+#     # NFS clients to create objects in the bucket
+#     Squash = No_root_squash;
+#
+#     # PrefWrite = 1048576;
+#
+#     # Exporting FSAL
+#     FSAL {
+#         # Use the "SCALITY" FSAL when exporting buckets from Zenko
+#         Name = "SCALITY";
+#         # Name of the bucket to export
+#         bucket = "mybucket";
+#         # prefix connects the export root to a common prefix in the bucket
+#         prefix = "thisprefix";
+#         # umask is used to complete missing posix permissions on objects not created via the NFS mount point
+#         umask = 02;
+#         # Fallback location constraint
+#         location_constraint = "scality-us-east-1";
+#     }
+#}

--- a/charts/zenko-filer/templates/_helpers.tpl
+++ b/charts/zenko-filer/templates/_helpers.tpl
@@ -1,0 +1,41 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "zenko-filer.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "zenko-filer.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "zenko-filer.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the default mongodb replicaset hosts string
+*/}}
+{{- define "zenko-filer.mongodb-hosts" -}}
+{{- $count := (atoi (printf "%d" (int64 .Values.mongodb.replicas))) -}}
+{{- $release := .Release.Name -}}
+{{- range $v := until $count }}{{ $release }}-mongodb-replicaset-{{ $v }}.{{ $release }}-mongodb-replicaset:27017{{ if ne $v (sub $count 1) }},{{- end -}}{{- end -}}
+{{- end -}}

--- a/charts/zenko-filer/templates/configmap.yaml
+++ b/charts/zenko-filer/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "zenko-filer.fullname" . }}-configmap
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app: {{ template "zenko-filer.name" . }}
+data:
+  nfsd.conf: |
+{{ .Files.Get "nfsd.conf" | indent 4 }}

--- a/charts/zenko-filer/templates/deployment.yaml
+++ b/charts/zenko-filer/templates/deployment.yaml
@@ -1,0 +1,122 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "zenko-filer.fullname" . }}
+  labels:
+    app: {{ template "zenko-filer.name" . }}
+    chart: {{ template "zenko-filer.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "zenko-filer.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      labels:
+        app: {{ template "zenko-filer.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Values.nfsd.name }}
+          image: "{{ .Values.nfsd.image.repository }}:{{ .Values.nfsd.image.tag }}"
+          imagePullPolicy: {{ .Values.nfsd.image.pullPolicy }}
+          ports:
+            - name: nfs
+              containerPort: 2049
+          volumeMounts:
+            - name: portmap-data
+              mountPath: /run
+            - name: metadata-data
+              mountPath: /conf
+            - name: nfsd-config
+              mountPath: /template
+          env:
+            - name: CONFIGURATION_DIRECTORY
+              value: "/conf"
+            - name: CONFIGURATION_TEMPLATE
+              value: "/template/nfsd.conf"
+            - name: ZENKO_MD_HOST
+              value: "127.0.0.1"
+            - name: ZENKO_MD_PORT
+              value: "9000"
+            - name: REDIS_SENTINEL_BOOTSTRAP
+              value: "{{- printf "%s-%s:26379" .Release.Name "redis-ha-sentinel" | trunc 63 | trimSuffix "-" -}}"
+            - name: REDIS_CLUSTER_NAME
+              value: "mymaster"
+            - name: NFSD_LOG_FILE
+              value: "/logs/scality-nfsd.log"
+          args: ['scality.nfsd', '-N', 'INFO', '-F', '-f', '/conf/scality-nfsd.conf', '-L', '/dev/stdout']
+          # TODO: livenessProbe:
+          # TODO: readinessProbe:
+        - name: "{{ .Values.md.name }}"
+          image: "{{ .Values.md.image.repository }}:{{ .Values.md.image.tag }}"
+          imagePullPolicy: {{ .Values.md.image.pullPolicy }}
+          ports:
+            - name: zenko-md
+              containerPort: 9000
+          env:
+            - name: MDP_BIND_ADDRESS
+              value: "0.0.0.0"
+            - name: MDP_LISTEN_PORT
+              value: "9000"
+            - name: MDP_WORKERS
+              value: "4"
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: S3METADATA
+              value: "mongodb"
+            - name: MONGODB_HOSTS
+              value: "{{ template "zenko-filer.mongodb-hosts" . }}"
+            - name: MONGODB_RS
+              value: "rs0"
+            - name: MONGODB_DATABASE
+              value: "metadata"
+          args: ['npm', 'start']
+          livenessProbe:
+            httpGet:
+              port: zenko-md
+              path: /default/metadataInformation
+          readinessProbe:
+            httpGet:
+              port: zenko-md
+              path: /default/bucket/PENSIEVE
+        - name: "{{ .Values.portmap.name }}"
+          image: "{{ .Values.portmap.image.repository }}:{{ .Values.portmap.image.tag }}"
+          imagePullPolicy: {{ .Values.portmap.image.pullPolicy }}
+          ports:
+            - name: rpcbind
+              containerPort: 111
+            - name: rpcbind-udp
+              containerPort: 111
+              protocol: UDP
+          volumeMounts:
+            - name: portmap-data
+              mountPath: /run
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+      volumes:
+        - name: nfsd-config
+          configMap:
+            defaultMode: 0755
+            name: {{ template "zenko-filer.fullname" . }}-configmap
+        - name: metadata-data
+          emptyDir: {}
+        - name: portmap-data
+          emptyDir: {}

--- a/charts/zenko-filer/templates/service.yaml
+++ b/charts/zenko-filer/templates/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "zenko-filer.fullname" . }}
+  labels:
+    app: {{ template "zenko-filer.name" . }}
+    chart: {{ template "zenko-filer.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.nfsd.service.type }}
+  ports:
+    - name: nfs
+      port: 2049
+    - name: rpcbind
+      port: 111
+    - name: rpcbind-udp
+      port: 111
+      protocol: UDP
+  selector:
+    app: {{ template "zenko-filer.name" . }}
+    release: {{ .Release.Name }}

--- a/charts/zenko-filer/values.yaml
+++ b/charts/zenko-filer/values.yaml
@@ -1,0 +1,46 @@
+# Default values for zenko-filer.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 1
+
+nfsd:
+  name: "zenko-nfsd"
+  image:
+    repository: zenko/zenko-nfsd
+    tag: edge
+    pullPolicy: IfNotPresent
+  loglevel: INFO
+  service:
+    type: ClusterIP
+
+md:
+  name: "zenko-md"
+  image:
+    repository: zenko/zenko-md
+    tag: edge
+    pullPolicy: IfNotPresent
+
+portmap:
+  name: "portmap"
+  image:
+    repository: zenko/portmap
+    tag: edge
+    pullPolicy: IfNotPresent
+
+mongodb:
+  replicas: 3
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/charts/zenko/requirements.lock
+++ b/charts/zenko/requirements.lock
@@ -26,5 +26,8 @@ dependencies:
 - name: cloudserver-front
   repository: file://../cloudserver-front
   version: 0.1.4
-digest: sha256:4fbe68bcb4a27d60e6a2a66dfe8584738a8cd89a42ce120adffce7186f2212cf
-generated: 2018-05-24T17:41:45.543504677-07:00
+- name: zenko-filer
+  repository: file://../zenko-filer
+  version: 0.1.0
+digest: sha256:208435872c10660819bb35f155fac56abada13890d44c12f01aaa2eadb74232e
+generated: 2018-06-26T18:28:59.261108105-07:00

--- a/charts/zenko/requirements.yaml
+++ b/charts/zenko/requirements.yaml
@@ -31,3 +31,7 @@ dependencies:
 - name: cloudserver-front
   version: "0.1.4"
   repository: "file://../cloudserver-front"
+- name: zenko-filer
+  version: "0.1.0"
+  repository: "file://../zenko-filer"
+  condition: zenko-filer.enabled

--- a/charts/zenko/values.yaml
+++ b/charts/zenko/values.yaml
@@ -40,6 +40,11 @@ backbeat:
   mongodb:
     replicas: *nodeCount
 
+zenko-filer:
+  enabled: false
+  mongodb:
+    replicas: *nodeCount
+
 prometheus:
   rbac:
     create: true


### PR DESCRIPTION
This adds the Zenko-Filer chart to Zenko, which you allows exporting buckets through NFS 🚀.

Zenko-Filer is made up of 3 components:
- Zenko-NFSD: Zenko's NFS server
- Zenko-MD: Zenko Metadata Gateway
- Portmap: RPC Server (rpcbind)

All of these are deployed in a 3 container pod (see ```zenko-filer/templates/deployment.yaml```).

NFS server and exports configuration is managed through a configmap, which reads from a file ```zenko-filer/nfsd.conf``` that can be modified (i.e to add new NFS exports). An upgrade (like ```helm upgrade``` for example), will then restart the NFS server with the updated configuration.