### PR TITLE
bf: ZENKO-619 fix typo in lifecycle helm charts

### DIFF
--- a/charts/backbeat/templates/lifecycle/conductor_deployment.yaml
+++ b/charts/backbeat/templates/lifecycle/conductor_deployment.yaml
@@ -27,7 +27,7 @@ spec:
             - name: ZOOKEEPER_CONNECTION_STRING
               value: "{{- printf "%s-zenko-quorum:2181" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: KAFKA_HOSTS
-              value: "{{- printf "%s-zenko-queue:9092" .Release.Name .Release.Name | trunc 63 | trimSuffix "-" -}}"
+              value: "{{- printf "%s-zenko-queue:9092" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: LOG_LEVEL
               value: {{ .Values.logging.level }}
             - name: EXTENSIONS_LIFECYCLE_ZOOKEEPER_PATH

--- a/charts/backbeat/templates/lifecycle/consumer_deployment.yaml
+++ b/charts/backbeat/templates/lifecycle/consumer_deployment.yaml
@@ -27,7 +27,7 @@ spec:
             - name: ZOOKEEPER_CONNECTION_STRING
               value: "{{- printf "%s-zenko-quorum:2181" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: KAFKA_HOSTS
-              value: "{{- printf "%s-zenko-queue:9092" .Release.Name .Release.Name | trunc 63 | trimSuffix "-" -}}"
+              value: "{{- printf "%s-zenko-queue:9092" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: MONGODB_HOSTS
               value: "{{ template "backbeat.mongodb-hosts" . }}"
             - name: S3_HOST

--- a/charts/backbeat/templates/lifecycle/producer_deployment.yaml
+++ b/charts/backbeat/templates/lifecycle/producer_deployment.yaml
@@ -27,7 +27,7 @@ spec:
             - name: ZOOKEEPER_CONNECTION_STRING
               value: "{{- printf "%s-zenko-quorum:2181" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: KAFKA_HOSTS
-              value: "{{- printf "%s-zenko-queue:9092" .Release.Name .Release.Name | trunc 63 | trimSuffix "-" -}}"
+              value: "{{- printf "%s-zenko-queue:9092" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: MONGODB_HOSTS
               value: "{{ template "backbeat.mongodb-hosts" . }}"
             - name: S3_HOST


### PR DESCRIPTION
Remove extra .Release.Name in format string arguments for KAFKA_HOSTS
value.