### PR TITLE
improvement: Update Cloudserver Image tag

### DIFF
--- a/charts/cloudserver-front/values.yaml
+++ b/charts/cloudserver-front/values.yaml
@@ -31,7 +31,7 @@ replicaCount: 1
 
 image:
   repository: zenko/cloudserver
-  tag: 8.0.2
+  tag: 8.0.3
   pullPolicy: IfNotPresent
 
 proxy:


### PR DESCRIPTION
Updating image tag for cloudserver with the latest fixes as of 07/01/2018