### PR TITLE
chore: ZENKO-651 Fix formatting and enable linting for e2e tests

### DIFF
--- a/tests/.dockerignore
+++ b/tests/.dockerignore
@@ -9,3 +9,4 @@
 **/artifacts/
 **/__pycache__/
 **/orbit-simulator/
+**/.tox

--- a/tests/docker-entrypoint.sh
+++ b/tests/docker-entrypoint.sh
@@ -4,6 +4,10 @@ set -u
 set -e
 set -o pipefail
 
+# Lint tests
+pip install tox
+make lint
+
 # Use `nproc` to figure out how many CPUs are available, also in a container
 # environment. The `auto` discovery of `pytest-xdist` uses the number of host
 # cores.

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -32,11 +32,16 @@ passenv =
     CUSTOM_COMPILE_COMMAND
 
 [flake8]
-exclude = .tox,dist,*egg,build,venv
+exclude = .tox,dist,*egg,build,venv,.venv
+# F401	module imported but unused
+# F403	‘from module import *’ used; unable to detect undefined names
+# F405	name may be undefined, or defined from star imports: module
+ignore = F403, F401, F405
 
 # Pylint configuration
 [MESSAGES CONTROL]
 # C0111: Missing %s docstring -- not required for tests
 # W0621: Redefining name %r from outer scope -- required for pytest fixtures
 # W0511: TODO and related comments
-disable=C0111,W0621,W0511
+# W0614 Unused import XYZ from wildcard import
+disable=C0111,W0621,W0511, W0614, wildcard-import, import-error

--- a/tests/zenko_e2e/cloudserver/test_backbeat_metrics.py
+++ b/tests/zenko_e2e/cloudserver/test_backbeat_metrics.py
@@ -1,17 +1,20 @@
-import zenko_e2e.util as util
 import requests
-import zenko_e2e.conf as conf
 import pytest
 
-def build_metrics_endpoint(path):
-	return conf.BACKBEAT_METRICS_ENDPOINT + path
+import zenko_e2e.conf as conf
 
-@pytest.mark.skip(reason ='Not implemented in CI')
+
+def build_metrics_endpoint(path):
+    return conf.BACKBEAT_METRICS_ENDPOINT + path
+
+
+@pytest.mark.skip(reason='Not implemented in CI')
 def test_backbeat_backlog_metrics():
-	for cloud in conf.MULTI_CRR_TARGETS:
-		backend = getattr(conf, '%s_CRR_BACKEND')
-		resp = requests.get(build_metrics_endpoint('/_/metrics/crr/%s/backlog'%backend))
-		assert resp
-		assert resp.status_code == 200
-		payload = resp.json()
-		assert payload
+    for cloud in conf.MULTI_CRR_TARGETS:
+        backend = getattr(conf, '%s_CRR_BACKEND' % cloud)
+        resp = requests.get(build_metrics_endpoint(
+            '/_/metrics/crr/%s/backlog' % backend))
+        assert resp
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload

--- a/tests/zenko_e2e/cloudserver/test_backend.py
+++ b/tests/zenko_e2e/cloudserver/test_backend.py
@@ -1,72 +1,83 @@
+import pytest
 import zenko_e2e.util as util
-import logging
+
 from ..fixtures import *
-
-logging.basicConfig(level = logging.INFO,
-				format =  '%(asctime)s %(name)s %(levelname)s: %(message)s',
-				datefmt = '%S')
-
-_log = logging.getLogger('test')
 
 
 @pytest.mark.conformance
 def test_ring_storage(zenko_bucket, testfile, objkey):
-	util.mark_test('RING STORAGE DEFAULT EP LOCATION')
-	zenko_bucket.create()
-	zenko_bucket.put_object(
-		Body = testfile,
-		Key = objkey
-	)
-	assert util.check_object(objkey, testfile, zenko_bucket)
+    util.mark_test('RING STORAGE DEFAULT EP LOCATION')
+    zenko_bucket.create()
+    zenko_bucket.put_object(
+        Body=testfile,
+        Key=objkey
+    )
+    assert util.check_object(objkey, testfile, zenko_bucket)
+
 
 @pytest.mark.conformance
 def test_aws_storage(aws_ep_bucket, aws_target_bucket, testfile, objkey):
-	util.mark_test('AWS STORAGE DEFAULT EP LOCATION')
-	aws_ep_bucket.create()
-	aws_ep_bucket.put_object(
-		Body = testfile,
-		Key = objkey
-	)
-	assert util.check_object(objkey, testfile, aws_ep_bucket, aws_target_bucket)
+    util.mark_test('AWS STORAGE DEFAULT EP LOCATION')
+    aws_ep_bucket.create()
+    aws_ep_bucket.put_object(
+        Body=testfile,
+        Key=objkey
+    )
+    assert util.check_object(
+        objkey, testfile, aws_ep_bucket, aws_target_bucket)
+
 
 @pytest.mark.conformance
 def test_gcp_storage(gcp_ep_bucket, gcp_target_bucket, testfile, objkey):
-	util.mark_test('GCP STORAGE DEFAULT EP LOCATION')
-	gcp_ep_bucket.create()
-	gcp_ep_bucket.put_object(
-		Body = testfile,
-		Key = objkey
-	)
-	assert util.check_object(objkey, testfile, gcp_ep_bucket, gcp_target_bucket)
+    util.mark_test('GCP STORAGE DEFAULT EP LOCATION')
+    gcp_ep_bucket.create()
+    gcp_ep_bucket.put_object(
+        Body=testfile,
+        Key=objkey
+    )
+    assert util.check_object(
+        objkey, testfile, gcp_ep_bucket, gcp_target_bucket)
+
 
 @pytest.mark.conformance
 def test_azure_storage(azure_ep_bucket, azure_target_bucket, testfile, objkey):
-	util.mark_test('AZURE STORAGE DEFAULT EP LOCATION')
-	azure_ep_bucket.create()
-	azure_ep_bucket.put_object(
-		Body = testfile,
-		Key = objkey
-	)
-	assert util.check_object(objkey, testfile, azure_ep_bucket, azure_target_bucket)
+    util.mark_test('AZURE STORAGE DEFAULT EP LOCATION')
+    azure_ep_bucket.create()
+    azure_ep_bucket.put_object(
+        Body=testfile,
+        Key=objkey
+    )
+    assert util.check_object(
+        objkey, testfile, azure_ep_bucket, azure_target_bucket)
 
-@pytest.mark.skip(reason ='Wasabi Not implemented in CI')
-@pytest.mark.conformance
-def test_wasabi_storage(wasabi_ep_bucket, wasabi_target_bucket, testfile, objkey):
-	util.mark_test('WASABI STORAGE DEFAULT EP LOCATION')
-	wasabi_ep_bucket.create()
-	wasabi_ep_bucket.put_object(
-		Body = testfile,
-		Key = objkey
-	)
-	assert util.check_object(objkey, testfile, wasabi_ep_bucket, wasabi_target_bucket)
 
-@pytest.mark.skip(reason = 'Digital Ocean Spaces is super flakey causing this test to fail')
+@pytest.mark.skip(reason='Wasabi Not implemented in CI')
 @pytest.mark.conformance
-def test_digital_ocean_storage(digital_ocean_ep_bucket, digital_ocean_target_bucket, testfile, objkey):
-	util.mark_test('DIGITAL OCEAN STORAGE DEFAULT EP LOCATION')
-	digital_ocean_ep_bucket.create()
-	digital_ocean_ep_bucket.put_object(
-		Body = testfile,
-		Key = objkey
-	)
-	assert util.check_object(objkey, testfile, digital_ocean_ep_bucket, digital_ocean_target_bucket)
+def test_wasabi_storage(
+        wasabi_ep_bucket, wasabi_target_bucket, testfile, objkey):
+    util.mark_test('WASABI STORAGE DEFAULT EP LOCATION')
+    wasabi_ep_bucket.create()
+    wasabi_ep_bucket.put_object(
+        Body=testfile,
+        Key=objkey
+    )
+    assert util.check_object(
+        objkey, testfile, wasabi_ep_bucket, wasabi_target_bucket)
+
+
+@pytest.mark.skip(
+    reason='Digital Ocean Spaces is super flakey causing this test to fail')
+@pytest.mark.conformance
+def test_digital_ocean_storage(
+        digital_ocean_ep_bucket,
+        digital_ocean_target_bucket,
+        testfile,
+        objkey):
+    util.mark_test('DIGITAL OCEAN STORAGE DEFAULT EP LOCATION')
+    digital_ocean_ep_bucket.create()
+    digital_ocean_ep_bucket.put_object(
+        Body=testfile,
+        Key=objkey
+    )
+    assert util.check_object(
+        objkey, testfile, digital_ocean_ep_bucket, digital_ocean_target_bucket)

--- a/tests/zenko_e2e/cloudserver/test_crr_retry.py
+++ b/tests/zenko_e2e/cloudserver/test_crr_retry.py
@@ -1,17 +1,14 @@
+import pytest
 from ..fixtures import *
-import logging
 
-logging.basicConfig(level = logging.DEBUG,
-				format =  '%(asctime)s %(name)s %(levelname)s: %(message)s',
-				datefmt = '%S')
 
-@pytest.mark.skip(reason = 'This test requires manual work to complete')
+@pytest.mark.skip(reason='This test requires manual work to complete')
 def test_crr_retry(aws_crr_bucket, aws_crr_target_bucket, testfile, objkey):
-	util.mark_test('CRR RETRY')
-	aws_crr_bucket.put_object(
-		Body = testfile,
-		Key = objkey
-	)
-	util.remark('Finished uploading')
-	input()
-	assert util.check_object(objkey, testfile, aws_crr_bucket, aws_crr_target_bucket, timeout = 30)
+    util.mark_test('CRR RETRY')
+    aws_crr_bucket.put_object(
+        Body=testfile,
+        Key=objkey
+    )
+    util.remark('Finished uploading')
+    assert util.check_object(
+        objkey, testfile, aws_crr_bucket, aws_crr_target_bucket, timeout=30)

--- a/tests/zenko_e2e/cloudserver/test_encryption.py
+++ b/tests/zenko_e2e/cloudserver/test_encryption.py
@@ -1,22 +1,18 @@
 from zenko_e2e.fixtures import *
 import zenko_e2e.util as util
-import logging
 
-logging.basicConfig(level = logging.INFO,
-				format =  '%(asctime)s %(name)s %(levelname)s: %(message)s',
-				datefmt = '%S')
 
-_log = logging.getLogger('test')
-
-def test_serverside_encryption(encrypted_bucket, aws_target_bucket, testfile, objkey):
-    _log.info('Using endpoint %s'%conf.ZENKO_AWS_ENDPOINT)
+def test_serverside_encryption(
+        encrypted_bucket, aws_target_bucket, testfile, objkey):
     encrypted_bucket.put_object(
-        Key = objkey,
-        Body = testfile
+        Key=objkey,
+        Body=testfile
     )
-    refHash = util.hashobj(testfile)
-    localHash = util.get_object_hash(encrypted_bucket, objkey)
-    assert refHash == localHash
-    remotekey = '%s/%s'%(encrypted_bucket.name, objkey) if not conf.BUCKET_MATCH else objkey
-    remoteHash = util.get_object_hash(aws_target_bucket, objkey, timeout=30)
-    assert remoteHash is not None and refHash != remoteHash
+    ref_hash = util.hashobj(testfile)
+    local_hash = util.get_object_hash(encrypted_bucket, objkey)
+    assert ref_hash == local_hash
+    remote_key = '%s/%s' % (encrypted_bucket.name,
+                            objkey) if not conf.BUCKET_MATCH else objkey
+    remote_hash = util.get_object_hash(
+        aws_target_bucket, remote_key, timeout=30)
+    assert remote_hash is not None and ref_hash != remote_hash

--- a/tests/zenko_e2e/cloudserver/test_lifecycle.py
+++ b/tests/zenko_e2e/cloudserver/test_lifecycle.py
@@ -1,18 +1,19 @@
-from ..fixtures import *
-import zenko_e2e.conf as conf
 import time
-import logging
+
+import pytest
+import zenko_e2e.conf as conf
+
+from ..fixtures import *
 
 
-@pytest.mark.skip(reason = 'This test requires manual work to complete')
+@pytest.mark.skip(reason='This test requires manual work to complete')
 def test_expiration(expiring_bucket, testfile, objkey):
-	util.mark_test('LIFECYCLE EXPIRATION')
-	expiry, bucket = expiring_bucket
-	bucket.put_object(
-		Body = testfile,
-		Key = objkey
-	)
-	print(bucket.name)
-	assert util.check_object(objkey, testfile, bucket)
-	time.sleep(conf.EXPIRY_DELTA.total_seconds() + 10)
-	assert not util.check_object(objkey, testfile, bucket)
+    util.mark_test('LIFECYCLE EXPIRATION')
+    expiry, bucket = expiring_bucket  # pylint: disable=unused-variable
+    bucket.put_object(
+        Body=testfile,
+        Key=objkey
+    )
+    assert util.check_object(objkey, testfile, bucket)
+    time.sleep(conf.EXPIRY_DELTA.total_seconds() + 10)
+    assert not util.check_object(objkey, testfile, bucket)

--- a/tests/zenko_e2e/cloudserver/test_location_constraints.py
+++ b/tests/zenko_e2e/cloudserver/test_location_constraints.py
@@ -1,55 +1,77 @@
+import logging
+
 import pytest
 import zenko_e2e.util as util
-import logging
+
 from ..fixtures import *
 
-logging.basicConfig(level = logging.INFO,
-				format =  '%(asctime)s %(name)s %(levelname)s: %(message)s',
-				datefmt = '%S')
+logging.basicConfig(level=logging.INFO,
+                    format='%(asctime)s %(name)s %(levelname)s: %(message)s',
+                    datefmt='%S')
+
 
 @pytest.mark.conformance
 def test_aws_storage(aws_loc_bucket, aws_target_bucket, testfile, objkey):
-	util.mark_test('AWS STORAGE LOCATION CONSTRAINT')
-	aws_loc_bucket.put_object(
-		Body = testfile,
-		Key = objkey
-	)
-	assert util.check_object(objkey, testfile, aws_loc_bucket, aws_target_bucket)
+    util.mark_test('AWS STORAGE LOCATION CONSTRAINT')
+    aws_loc_bucket.put_object(
+        Body=testfile,
+        Key=objkey
+    )
+    assert util.check_object(
+        objkey, testfile, aws_loc_bucket, aws_target_bucket)
+
 
 @pytest.mark.conformance
 def test_gcp_storage(gcp_loc_bucket, gcp_target_bucket, testfile, objkey):
-	util.mark_test('GCP STORAGE LOCATION CONSTRAINT')
-	gcp_loc_bucket.put_object(
-		Body = testfile,
-		Key = objkey
-	)
-	assert util.check_object(objkey, testfile, gcp_loc_bucket, gcp_target_bucket)
+    util.mark_test('GCP STORAGE LOCATION CONSTRAINT')
+    gcp_loc_bucket.put_object(
+        Body=testfile,
+        Key=objkey
+    )
+    assert util.check_object(
+        objkey, testfile, gcp_loc_bucket, gcp_target_bucket)
+
 
 @pytest.mark.conformance
-def test_azure_storage(azure_loc_bucket, azure_target_bucket, testfile, objkey):
-	util.mark_test('AZURE STORAGE LOCATION CONSTRAINT')
-	azure_loc_bucket.put_object(
-		Body = testfile,
-		Key = objkey
-	)
-	assert util.check_object(objkey, testfile, azure_loc_bucket, azure_target_bucket)
+def test_azure_storage(
+        azure_loc_bucket, azure_target_bucket, testfile, objkey):
+    util.mark_test('AZURE STORAGE LOCATION CONSTRAINT')
+    azure_loc_bucket.put_object(
+        Body=testfile,
+        Key=objkey
+    )
+    assert util.check_object(
+        objkey, testfile, azure_loc_bucket, azure_target_bucket)
 
-@pytest.mark.skip(reason ='Wasabi Not implemented in CI')
-@pytest.mark.conformance
-def test_wasabi_storage(wasabi_loc_bucket, wasabi_target_bucket, testfile, objkey):
-	util.mark_test('WASABI STORAGE LOCATION CONSTRAINT')
-	wasabi_loc_bucket.put_object(
-		Body = testfile,
-		Key = objkey
-	)
-	assert util.check_object(objkey, testfile, wasabi_loc_bucket, wasabi_target_bucket)
 
-@pytest.mark.skip(reason = 'Digital Ocean Spaces is super flakey causing this test to fail')
+@pytest.mark.skip(reason='Wasabi Not implemented in CI')
 @pytest.mark.conformance
-def test_digital_ocean_storage(digital_ocean_loc_bucket, digital_ocean_target_bucket, testfile, objkey):
-	util.mark_test('DIGITAL OCEAN STORAGE LOCATION CONSTRAINT')
-	digital_ocean_loc_bucket.put_object(
-		Body = testfile,
-		Key = objkey
-	)
-	assert uitl.check_object(objkey, testfile, digital_ocean_loc_bucket, digital_ocean_target_bucket)
+def test_wasabi_storage(
+        wasabi_loc_bucket, wasabi_target_bucket, testfile, objkey):
+    util.mark_test('WASABI STORAGE LOCATION CONSTRAINT')
+    wasabi_loc_bucket.put_object(
+        Body=testfile,
+        Key=objkey
+    )
+    assert util.check_object(
+        objkey, testfile, wasabi_loc_bucket, wasabi_target_bucket)
+
+
+@pytest.mark.skip(
+    reason='Digital Ocean Spaces is super flakey causing this test to fail')
+@pytest.mark.conformance
+def test_digital_ocean_storage(
+        digital_ocean_loc_bucket,
+        digital_ocean_target_bucket,
+        testfile,
+        objkey):
+    util.mark_test('DIGITAL OCEAN STORAGE LOCATION CONSTRAINT')
+    digital_ocean_loc_bucket.put_object(
+        Body=testfile,
+        Key=objkey
+    )
+    assert util.check_object(
+        objkey,
+        testfile,
+        digital_ocean_loc_bucket,
+        digital_ocean_target_bucket)

--- a/tests/zenko_e2e/cloudserver/test_metadata.py
+++ b/tests/zenko_e2e/cloudserver/test_metadata.py
@@ -1,64 +1,72 @@
-from ..fixtures import *
-import requests
-import xml.etree.ElementTree as ET
 import re
+import xml.etree.ElementTree as ET
+
+import requests
+import pytest
+
+from ..fixtures import *
+
 
 @pytest.mark.conformance
-def test_set_metadata(empty_object, testfile, objkey):
-	util.mark_test('SET METADATA')
-	assert empty_object.put(
-			Body = testfile,
-			Metadata = conf.METADATA_EXAMPLE
-		)
+def test_set_metadata(empty_object, testfile):
+    util.mark_test('SET METADATA')
+    assert empty_object.put(
+        Body=testfile,
+        Metadata=conf.METADATA_EXAMPLE
+    )
+
 
 @pytest.mark.conformance
 def test_get_metadata(metadata_object):
-	util.mark_test('GET METADATA')
-	print(metadata_object.bucket_name, metadata_object.key)
-	resp = metadata_object.get()
-	assert resp
-	assert 'Metadata' in resp
-	for k, v in conf.METADATA_EXAMPLE.items():
-		assert k in resp['Metadata']
-		assert resp['Metadata'].get(k, None) == v
+    util.mark_test('GET METADATA')
+    print(metadata_object.bucket_name, metadata_object.key)
+    resp = metadata_object.get()
+    assert resp
+    assert 'Metadata' in resp
+    for key, value in conf.METADATA_EXAMPLE.items():
+        assert key in resp['Metadata']
+        assert resp['Metadata'].get(key, None) == value
+
 
 @pytest.mark.conformance
-def test_set_get_metadata(empty_object, testfile, objkey):
-	util.mark_test('SET & GET METADATA')
-	empty_object.put(
-		Body = testfile,
-		Metadata = conf.METADATA_EXAMPLE
-	)
-	resp = empty_object.get()
-	assert resp
-	assert 'Metadata' in resp
-	for k, v in conf.METADATA_EXAMPLE.items():
-		assert k in resp['Metadata']
-		assert resp['Metadata'].get(k, None) == v
+def test_set_get_metadata(empty_object, testfile):
+    util.mark_test('SET & GET METADATA')
+    empty_object.put(
+        Body=testfile,
+        Metadata=conf.METADATA_EXAMPLE
+    )
+    resp = empty_object.get()
+    assert resp
+    assert 'Metadata' in resp
+    for key, value in conf.METADATA_EXAMPLE.items():
+        assert key in resp['Metadata']
+        assert resp['Metadata'].get(key, None) == value
 
-def get_xml_namespace(el):
-	m = re.match('\{.*\}', el.tag)
-	return m.group(0) if m else ''
+
+def get_xml_namespace(elem):
+    match = re.match(r'\{.*\}', elem.tag)
+    return match.group(0) if match else ''
+
 
 @pytest.mark.conformance
 def test_metadata_search(metadata_multi, s3auth):
-	util.mark_test('SEARCH METADATA')
-	o1, o2 = metadata_multi
-	base = conf.ZENKO_ENDPOINT + '/%s/?search=x-amz-meta-%s=%s'
-	req1 = base%(o1.bucket_name, 'color', conf.METADATA_EXAMPLE['color'])
-	req2 = base%(o1.bucket_name, 'flavor', conf.METADATA_EXAMPLE['flavor'])
-	print(req1, req2)
-	# This should return only the first object
-	resp = requests.get(req1, auth=s3auth, verify = conf.VERIFY_CERTIFICATES)
-	parsed = ET.fromstring(resp.text)
-	ns = get_xml_namespace(parsed)
-	for result in parsed.findall(ns + 'Contents'):
-		key = result.find(ns + 'Key').text
-		assert key == o1.key and not key == o2.key
-	# This should return both
-	resp = requests.get(req2, auth=s3auth)
-	parsed = ET.fromstring(resp.text)
-	ns = get_xml_namespace(parsed)
-	for result in parsed.findall(ns + 'Contents'):
-		key = result.find(ns + 'Key').text
-		assert key == o1.key or key == o2.key
+    util.mark_test('SEARCH METADATA')
+    obj1, obj2 = metadata_multi
+    base = conf.ZENKO_ENDPOINT + '/%s/?search=x-amz-meta-%s=%s'
+    req1 = base % (obj1.bucket_name, 'color', conf.METADATA_EXAMPLE['color'])
+    req2 = base % (obj1.bucket_name, 'flavor', conf.METADATA_EXAMPLE['flavor'])
+    print(req1, req2)
+    # This should return only the first object
+    resp = requests.get(req1, auth=s3auth, verify=conf.VERIFY_CERTIFICATES)
+    parsed = ET.fromstring(resp.text)
+    namespace = get_xml_namespace(parsed)
+    for result in parsed.findall(namespace + 'Contents'):
+        key = result.find(namespace + 'Key').text
+        assert key == obj1.key and not key == obj2.key
+    # This should return both
+    resp = requests.get(req2, auth=s3auth)
+    parsed = ET.fromstring(resp.text)
+    namespace = get_xml_namespace(parsed)
+    for result in parsed.findall(namespace + 'Contents'):
+        key = result.find(namespace + 'Key').text
+        assert key == obj1.key or key == obj2.key

--- a/tests/zenko_e2e/cloudserver/test_mpu.py
+++ b/tests/zenko_e2e/cloudserver/test_mpu.py
@@ -1,61 +1,71 @@
-import zenko_e2e.conf as conf
+import pytest
 from ..fixtures import *
-import logging
+
 
 @pytest.mark.conformance
 def test_mpu_aws(aws_ep_bucket, aws_target_bucket, mpufile, objkey):
-	util.mark_test('AWS MPU UPLOAD')
-	aws_ep_bucket.create('zenko-aws-mpu-bucket')
-	aws_ep_bucket.put_object(
-		Body = mpufile,
-		Key = objkey
-	)
-	util.remark('Done uploading file, downloading and checking hash')
-	assert util.check_object(objkey, mpufile, aws_ep_bucket, aws_target_bucket)
+    util.mark_test('AWS MPU UPLOAD')
+    aws_ep_bucket.create('zenko-aws-mpu-bucket')
+    aws_ep_bucket.put_object(
+        Body=mpufile,
+        Key=objkey
+    )
+    util.remark('Done uploading file, downloading and checking hash')
+    assert util.check_object(objkey, mpufile, aws_ep_bucket, aws_target_bucket)
+
 
 @pytest.mark.conformance
 def test_mpu_gcp(gcp_ep_bucket, gcp_target_bucket, mpufile, objkey):
-	util.mark_test('GCP MPU UPLOAD')
-	gcp_ep_bucket.create('zenko-gcp-mpu-bucket')
-	gcp_ep_bucket.put_object(
-		Body = mpufile,
-		Key = objkey
-	)
-	util.remark('Done uploading file, downloading and checking hash')
-	assert util.check_object(objkey, mpufile, gcp_ep_bucket, gcp_target_bucket)
+    util.mark_test('GCP MPU UPLOAD')
+    gcp_ep_bucket.create('zenko-gcp-mpu-bucket')
+    gcp_ep_bucket.put_object(
+        Body=mpufile,
+        Key=objkey
+    )
+    util.remark('Done uploading file, downloading and checking hash')
+    assert util.check_object(objkey, mpufile, gcp_ep_bucket, gcp_target_bucket)
 
 # @pytest.mark.skip()
+
+
 @pytest.mark.conformance
 def test_mpu_azure(azure_ep_bucket, azure_target_bucket, mpufile, objkey):
-	util.mark_test('AZURE MPU UPLOAD')
-	azure_ep_bucket.create('zenko-azure-mpu-bucket')
-	azure_ep_bucket.put_object(
-		Body = mpufile,
-		Key = objkey
-	)
-	util.remark('Done uploading file, downloading and checking hash')
-	assert util.check_object(objkey, mpufile, azure_ep_bucket, azure_target_bucket)
+    util.mark_test('AZURE MPU UPLOAD')
+    azure_ep_bucket.create('zenko-azure-mpu-bucket')
+    azure_ep_bucket.put_object(
+        Body=mpufile,
+        Key=objkey
+    )
+    util.remark('Done uploading file, downloading and checking hash')
+    assert util.check_object(
+        objkey, mpufile, azure_ep_bucket, azure_target_bucket)
 
-@pytest.mark.skip(reason ='Wasabi not implemented in CI')
+
+@pytest.mark.skip(reason='Wasabi not implemented in CI')
 @pytest.mark.conformance
 def test_mpu_wasabi(wasabi_ep_bucket, wasabi_target_bucket, mpufile, objkey):
-	util.mark_test('WASABI MPU UPLOAD')
-	wasabi_ep_bucket.create()
-	wasabi_ep_bucket.put_object(
-		Body = mpufile,
-		Key = objkey
-	)
-	util.remark('Done uploading file, downloading and checking hash')
-	assert util.check_object(objkey, mpufile, wasabi_ep_bucket, wasabi_target_bucket)
+    util.mark_test('WASABI MPU UPLOAD')
+    wasabi_ep_bucket.create()
+    wasabi_ep_bucket.put_object(
+        Body=mpufile,
+        Key=objkey
+    )
+    util.remark('Done uploading file, downloading and checking hash')
+    assert util.check_object(
+        objkey, mpufile, wasabi_ep_bucket, wasabi_target_bucket)
 
-@pytest.mark.skip(reason = 'Digital Ocean Spaces is super flakey causing this test to fail')
+
+@pytest.mark.skip(
+    reason='Digital Ocean Spaces is super flakey causing this test to fail')
 @pytest.mark.conformance
-def test_mpu_digital_ocean(digital_ocean_ep_bucket, digital_ocean_target_bucket, mpufile, objkey):
-	util.mark_test('DIGITAL OCEAN MPU UPLOAD')
-	digital_ocean_ep_bucket.create()
-	digital_ocean_ep_bucket.put_object(
-		Body = mpufile,
-		Key = objkey
-	)
-	util.remark('Done uploading file, downloading and checking hash')
-	assert uitl.check_object(objkey, mpufile, digital_ocean_ep_bucket, digital_ocean_target_bucket)
+def test_mpu_digital_ocean(digital_ocean_ep_bucket,
+                           digital_ocean_target_bucket, mpufile, objkey):
+    util.mark_test('DIGITAL OCEAN MPU UPLOAD')
+    digital_ocean_ep_bucket.create()
+    digital_ocean_ep_bucket.put_object(
+        Body=mpufile,
+        Key=objkey
+    )
+    util.remark('Done uploading file, downloading and checking hash')
+    assert util.check_object(
+        objkey, mpufile, digital_ocean_ep_bucket, digital_ocean_target_bucket)

--- a/tests/zenko_e2e/cloudserver/test_replication.py
+++ b/tests/zenko_e2e/cloudserver/test_replication.py
@@ -1,66 +1,91 @@
-import pytest
-import zenko_e2e.conf as conf
-import zenko_e2e.util as util
 import logging
-import time
+
+import pytest
+import zenko_e2e.util as util
+
 from ..fixtures import *
 
-logging.basicConfig(level = logging.INFO,
-				format =  '%(asctime)s %(name)s %(levelname)s: %(message)s',
-				datefmt = '%S')
+logging.basicConfig(level=logging.INFO,
+                    format='%(asctime)s %(name)s %(levelname)s: %(message)s',
+                    datefmt='%S')
 
-@pytest.mark.skip(reason ='Test not behaving properly')
+
+@pytest.mark.skip(reason='Test not behaving properly')
 @pytest.mark.conformance
 def test_aws_1_1(aws_crr_bucket, aws_crr_target_bucket, testfile, objkey):
-	util.mark_test('AWS 1-1 REPLICATION')
-	aws_crr_bucket.put_object(
-		Body = testfile,
-		Key = objkey
-	)
-	print(aws_crr_bucket.name)
-	assert util.check_object(objkey, testfile, aws_crr_bucket, aws_crr_target_bucket, timeout = 30)
+    util.mark_test('AWS 1-1 REPLICATION')
+    aws_crr_bucket.put_object(
+        Body=testfile,
+        Key=objkey
+    )
+    print(aws_crr_bucket.name)
+    assert util.check_object(
+        objkey, testfile, aws_crr_bucket, aws_crr_target_bucket, timeout=30)
 
-@pytest.mark.skip(reason ='Test not behaving properly')
+
+@pytest.mark.skip(reason='Test not behaving properly')
 @pytest.mark.conformance
 def test_gcp_1_1(gcp_crr_bucket, gcp_crr_target_bucket, testfile, objkey):
-	util.mark_test('GCP 1-1 REPLICATION')
-	gcp_crr_bucket.put_object(
-		Body = testfile,
-		Key = objkey
-	)
-	assert util.check_object(objkey, testfile, gcp_crr_bucket, gcp_crr_target_bucket, timeout = 30)
+    util.mark_test('GCP 1-1 REPLICATION')
+    gcp_crr_bucket.put_object(
+        Body=testfile,
+        Key=objkey
+    )
+    assert util.check_object(
+        objkey, testfile, gcp_crr_bucket, gcp_crr_target_bucket, timeout=30)
 
-@pytest.mark.skip(reason ='Test not behaving properly')
-@pytest.mark.conformance
-def test_azure_1_1(azure_crr_bucket, azure_crr_target_bucket, testfile, objkey):
-	util.mark_test('AZURE 1-1 REPLICATION')
-	azure_crr_bucket.put_object(
-		Body = testfile,
-		Key = objkey
-	)
-	assert util.check_object(objkey, testfile, azure_crr_bucket, azure_crr_target_bucket, timeout = 30)
 
-@pytest.mark.skip(reason ='Wasabi not implemented in CI')
+@pytest.mark.skip(reason='Test not behaving properly')
 @pytest.mark.conformance
-def test_wasabi_1_1(wasabi_crr_bucket, wasabi_crr_target_bucket, testfile, objkey):
-	util.mark_test('AZURE 1-1 REPLICATION')
-	wasabi_crr_bucket.put_object(
-		Body = testfile,
-		Key = objkey
-	)
-	assert util.check_object(objkey, testfile, wasabi_crr_bucket, wasabi_crr_target_bucket, timeout = 30)
+def test_azure_1_1(
+        azure_crr_bucket, azure_crr_target_bucket, testfile, objkey):
+    util.mark_test('AZURE 1-1 REPLICATION')
+    azure_crr_bucket.put_object(
+        Body=testfile,
+        Key=objkey
+    )
+    assert util.check_object(
+        objkey,
+        testfile,
+        azure_crr_bucket,
+        azure_crr_target_bucket,
+        timeout=30)
 
-@pytest.mark.skip(reason ='Not implemented in CI')
+
+@pytest.mark.skip(reason='Wasabi not implemented in CI')
 @pytest.mark.conformance
-def test_multi_1_M(multi_crr_bucket, aws_crr_target_bucket, gcp_crr_target_bucket, azure_crr_target_bucket, testfile, objkey):
-	util.mark_test("MULTI 1-M REPLICATION")
-	multi_crr_bucket.put_object(
-		Body = testfile,
-		Key = objkey
-	)
-	assert util.check_object(objkey, testfile,
-		multi_crr_bucket,
-		aws_crr_target_bucket,
-		gcp_crr_target_bucket,
-		azure_crr_target_bucket,
-		timeout = 30)
+def test_wasabi_1_1(wasabi_crr_bucket,
+                    wasabi_crr_target_bucket, testfile, objkey):
+    util.mark_test('AZURE 1-1 REPLICATION')
+    wasabi_crr_bucket.put_object(
+        Body=testfile,
+        Key=objkey
+    )
+    assert util.check_object(
+        objkey,
+        testfile,
+        wasabi_crr_bucket,
+        wasabi_crr_target_bucket,
+        timeout=30)
+
+
+@pytest.mark.skip(reason='Not implemented in CI')
+@pytest.mark.conformance
+def test_multi_1_M(  # pylint: disable=invalid-name, too-many-arguments
+        multi_crr_bucket,
+        aws_crr_target_bucket,
+        gcp_crr_target_bucket,
+        azure_crr_target_bucket,
+        testfile,
+        objkey):
+    util.mark_test("MULTI 1-M REPLICATION")
+    multi_crr_bucket.put_object(
+        Body=testfile,
+        Key=objkey
+    )
+    assert util.check_object(objkey, testfile,
+                             multi_crr_bucket,
+                             aws_crr_target_bucket,
+                             gcp_crr_target_bucket,
+                             azure_crr_target_bucket,
+                             timeout=30)

--- a/tests/zenko_e2e/fixtures/backend.py
+++ b/tests/zenko_e2e/fixtures/backend.py
@@ -1,100 +1,117 @@
-from boto3 import Session
 from botocore.handlers import set_list_objects_encoding_type_url
-from botocore.client import Config
-import zenko_e2e.conf as conf
+from boto3 import Session
 import pytest
+from azure.storage.blob import BlockBlobService  # noqa pylint: disable=no-name-in-module
+
 from awsauth import S3Auth
-import configparser
-import os.path
-from azure.storage.blob import BlockBlobService
+import zenko_e2e.conf as conf
 from zenko_e2e.util import AzureResource
 
-'''
-This Module contains pytest fixtures relating to the various backends zenko supports.
-All boto3 Sessions and Resources are created in the module.
-'''
-
-
-boto_config = Config(connect_timeout=5, retries={'max_attempts': 0})
+# This Module contains pytest fixtures relating
+# to the various backends zenko supports.
+# All boto3 Sessions and Resources are created in the module.
 
 
 @pytest.fixture
 def vault():
-	vault_session = Session(profile_name='zenko')
-	return vault_session.resource('iam', endpoint_url = conf.ZENKO_VAULT_ENDPOINT)
+    vault_session = Session(profile_name='zenko')
+    return vault_session.resource(
+        'iam', endpoint_url=conf.ZENKO_VAULT_ENDPOINT)
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def s3auth():
-	return S3Auth(conf.ZENKO_ACCESS_KEY, conf.ZENKO_SECRET_KEY)
+    return S3Auth(conf.ZENKO_ACCESS_KEY, conf.ZENKO_SECRET_KEY)
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def aws_resource():
-	return Session(aws_access_key_id = conf.AWS_ACCESS_KEY,
-                aws_secret_access_key = conf.AWS_SECRET_KEY).resource('s3')
+    return Session(aws_access_key_id=conf.AWS_ACCESS_KEY,
+                   aws_secret_access_key=conf.AWS_SECRET_KEY).resource('s3')
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def aws_crr_resource():
-	return Session(aws_access_key_id = conf.AWS_BACKBEAT_ACCESS_KEY,
-                aws_secret_access_key = conf.AWS_BACKBEAT_SECRET_KEY).resource('s3')
+    return Session(
+        aws_access_key_id=conf.AWS_BACKBEAT_ACCESS_KEY,
+        aws_secret_access_key=conf.AWS_BACKBEAT_SECRET_KEY).resource('s3')
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def gcp_resource():
-	sesh = Session(aws_access_key_id = conf.GCP_ACCESS_KEY,
-                aws_secret_access_key = conf.GCP_SECRET_KEY)
-	sesh.events.unregister('before-parameter-build.s3.ListObjects', set_list_objects_encoding_type_url)
-	return sesh.resource('s3', endpoint_url=conf.GCP_ENDPOINT)
+    sesh = Session(aws_access_key_id=conf.GCP_ACCESS_KEY,
+                   aws_secret_access_key=conf.GCP_SECRET_KEY)
+    sesh.events.unregister(
+        'before-parameter-build.s3.ListObjects',
+        set_list_objects_encoding_type_url)
+    return sesh.resource('s3', endpoint_url=conf.GCP_ENDPOINT)
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def azure_resource():
-	return AzureResource(
-		BlockBlobService(
-			account_name = conf.AZURE_ACCESS_KEY,
-			account_key = conf.AZURE_SECRET_KEY
-		)
-	)
+    return AzureResource(
+        BlockBlobService(
+            account_name=conf.AZURE_ACCESS_KEY,
+            account_key=conf.AZURE_SECRET_KEY
+        )
+    )
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def wasabi_resource():
-	s =  Session(profile_name='wasabi')
-	return s.resource('s3', endpoint_url = conf.WASABI_ENDPOINT)
+    sesh = Session(profile_name='wasabi')
+    return sesh.resource('s3', endpoint_url=conf.WASABI_ENDPOINT)
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def digital_ocean_resource():
-	s =  Session(profile_name='do')
-	return s.resource('s3', endpoint_url = conf.DO_ENDPOINT)
+    sesh = Session(profile_name='do')
+    return sesh.resource('s3', endpoint_url=conf.DO_ENDPOINT)
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def zenko_resource():
-	s =  Session(aws_access_key_id = conf.ZENKO_ACCESS_KEY,
-                aws_secret_access_key = conf.ZENKO_SECRET_KEY)
-	return s.resource('s3', endpoint_url = conf.ZENKO_ENDPOINT, verify = conf.VERIFY_CERTIFICATES)
+    sesh = Session(aws_access_key_id=conf.ZENKO_ACCESS_KEY,
+                   aws_secret_access_key=conf.ZENKO_SECRET_KEY)
+    return sesh.resource('s3', endpoint_url=conf.ZENKO_ENDPOINT,
+                         verify=conf.VERIFY_CERTIFICATES)
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def aws_endpoint_resource():
-	s =  Session(aws_access_key_id = conf.ZENKO_ACCESS_KEY,
-                aws_secret_access_key = conf.ZENKO_SECRET_KEY)
-	return s.resource('s3', endpoint_url = conf.ZENKO_AWS_ENDPOINT, verify = conf.VERIFY_CERTIFICATES)
+    sesh = Session(aws_access_key_id=conf.ZENKO_ACCESS_KEY,
+                   aws_secret_access_key=conf.ZENKO_SECRET_KEY)
+    return sesh.resource('s3', endpoint_url=conf.ZENKO_AWS_ENDPOINT,
+                         verify=conf.VERIFY_CERTIFICATES)
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def gcp_endpoint_resource():
-	s =  Session(aws_access_key_id = conf.ZENKO_ACCESS_KEY,
-                aws_secret_access_key = conf.ZENKO_SECRET_KEY)
-	return s.resource('s3', endpoint_url = conf.ZENKO_GCP_ENDPOINT, verify = conf.VERIFY_CERTIFICATES)
+    sesh = Session(aws_access_key_id=conf.ZENKO_ACCESS_KEY,
+                   aws_secret_access_key=conf.ZENKO_SECRET_KEY)
+    return sesh.resource('s3', endpoint_url=conf.ZENKO_GCP_ENDPOINT,
+                         verify=conf.VERIFY_CERTIFICATES)
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def azure_endpoint_resource():
-	s =  Session(aws_access_key_id = conf.ZENKO_ACCESS_KEY,
-                aws_secret_access_key = conf.ZENKO_SECRET_KEY)
-	return s.resource('s3', endpoint_url = conf.ZENKO_AZURE_ENDPOINT, verify = conf.VERIFY_CERTIFICATES)
+    sesh = Session(aws_access_key_id=conf.ZENKO_ACCESS_KEY,
+                   aws_secret_access_key=conf.ZENKO_SECRET_KEY)
+    return sesh.resource('s3', endpoint_url=conf.ZENKO_AZURE_ENDPOINT,
+                         verify=conf.VERIFY_CERTIFICATES)
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def wasabi_endpoint_resource():
-	s =  Session(aws_access_key_id = conf.ZENKO_ACCESS_KEY,
-                aws_secret_access_key = conf.ZENKO_SECRET_KEY)
-	return s.resource('s3', endpoint_url = conf.ZENKO_WASABI_ENDPOINT, verify = conf.VERIFY_CERTIFICATES)
+    sesh = Session(aws_access_key_id=conf.ZENKO_ACCESS_KEY,
+                   aws_secret_access_key=conf.ZENKO_SECRET_KEY)
+    return sesh.resource('s3', endpoint_url=conf.ZENKO_WASABI_ENDPOINT,
+                         verify=conf.VERIFY_CERTIFICATES)
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def digital_ocean_endpoint_resource():
-	s =  Session(aws_access_key_id = conf.ZENKO_ACCESS_KEY,
-                aws_secret_access_key = conf.ZENKO_SECRET_KEY)
-	return s.resource('s3', endpoint_url = conf.ZENKO_DO_ENDPOINT, verify = conf.VERIFY_CERTIFICATES)
+    sesh = Session(aws_access_key_id=conf.ZENKO_ACCESS_KEY,
+                   aws_secret_access_key=conf.ZENKO_SECRET_KEY)
+    return sesh.resource('s3', endpoint_url=conf.ZENKO_DO_ENDPOINT,
+                         verify=conf.VERIFY_CERTIFICATES)

--- a/tests/zenko_e2e/fixtures/bucket.py
+++ b/tests/zenko_e2e/fixtures/bucket.py
@@ -1,235 +1,257 @@
+import re
+import warnings
+
+import requests
+
 import pytest
 import zenko_e2e.conf as conf
 import zenko_e2e.util as util
-import requests
-import re
-import warnings
 from awsauth import S3Auth
 
-'''
-This module contains all boto3 Buckets created from the various backends or zenko itself
-'''
+BUCKET_NAME_FORMAT = re.compile(r'^[a-zA-Z0-9.\-_]{1,255}$')
 
-bucket_name_format = re.compile(r'^[a-zA-Z0-9.\-_]{1,255}$')
 
 def create_bucket(resource, name):
-	if '"' in name:
-		name = name.replace('"', '')
-		warnings.warn('`"` found in bucket name! silently stripping')
-	if bucket_name_format.fullmatch(name) is None:
-		raise RuntimeError('%s is an invalid bucket name!')
-	return resource.Bucket(name)
+    if '"' in name:
+        name = name.replace('"', '')
+        warnings.warn('`"` found in bucket name! silently stripping')
+    if BUCKET_NAME_FORMAT.fullmatch(name) is None:
+        raise RuntimeError('%s is an invalid bucket name!')
+    return resource.Bucket(name)
 
 # These are buckets from the actual cloud backend
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def aws_target_bucket(aws_resource):
-	bucket = create_bucket(aws_resource, conf.AWS_TARGET_BUCKET)
-	yield bucket
-	util.cleanup_bucket(bucket, delete_bucket= False)
+    bucket = create_bucket(aws_resource, conf.AWS_TARGET_BUCKET)
+    yield bucket
+    util.cleanup_bucket(bucket, delete_bucket=False)
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def gcp_target_bucket(gcp_resource):
-	bucket =  create_bucket(gcp_resource, conf.GCP_TARGET_BUCKET)
-	yield bucket
-	util.cleanup_bucket(bucket, delete_bucket= False)
+    bucket = create_bucket(gcp_resource, conf.GCP_TARGET_BUCKET)
+    yield bucket
+    util.cleanup_bucket(bucket, delete_bucket=False)
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def azure_target_bucket(azure_resource):
-	bucket =  create_bucket(azure_resource, conf.AZURE_TARGET_BUCKET)
-	yield bucket
-	util.cleanup_azure_bucket(bucket, delete_bucket= False)
+    bucket = create_bucket(azure_resource, conf.AZURE_TARGET_BUCKET)
+    yield bucket
+    util.cleanup_azure_bucket(bucket, delete_bucket=False)
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def wasabi_target_bucket(wasabi_resource):
-	bucket = create_bucket(wasabi_resource, conf.WASABI_TARGET_BUCKET)
-	yield bucket
-	util.cleanup_bucket(bucket, delete_bucket= False)
+    bucket = create_bucket(wasabi_resource, conf.WASABI_TARGET_BUCKET)
+    yield bucket
+    util.cleanup_bucket(bucket, delete_bucket=False)
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def digital_ocean_target_bucket(digital_ocean_resource):
-	bucket = create_bucket(digital_ocean_resource, conf.DO_TARGET_BUCKET)
-	yield bucket
-	util.cleanup_bucket(bucket, delete_bucket= False)
+    bucket = create_bucket(digital_ocean_resource, conf.DO_TARGET_BUCKET)
+    yield bucket
+    util.cleanup_bucket(bucket, delete_bucket=False)
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def aws_crr_target_bucket(aws_crr_resource):
-	bucket = create_bucket(aws_crr_resource, conf.AWS_CRR_TARGET_BUCKET)
-	yield bucket
-	util.cleanup_bucket(bucket, delete_bucket= False)
+    bucket = create_bucket(aws_crr_resource, conf.AWS_CRR_TARGET_BUCKET)
+    yield bucket
+    util.cleanup_bucket(bucket, delete_bucket=False)
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def gcp_crr_target_bucket(gcp_resource):
-	bucket = create_bucket(gcp_resource, conf.GCP_CRR_TARGET_BUCKET)
-	yield bucket
-	util.cleanup_bucket(bucket, delete_bucket= False)
+    bucket = create_bucket(gcp_resource, conf.GCP_CRR_TARGET_BUCKET)
+    yield bucket
+    util.cleanup_bucket(bucket, delete_bucket=False)
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def azure_crr_target_bucket(azure_resource):
-	bucket = create_bucket(azure_resource, conf.AZURE_CRR_TARGET_BUCKET)
-	yield bucket
-	util.cleanup_azure_bucket(bucket, delete_bucket= False)
+    bucket = create_bucket(azure_resource, conf.AZURE_CRR_TARGET_BUCKET)
+    yield bucket
+    util.cleanup_azure_bucket(bucket, delete_bucket=False)
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def wasabi_crr_target_bucket(wasabi_resource):
-	bucket = create_bucket(wasabi_resource, conf.WASABI_CRR_TARGET_BUCKET)
-	yield bucket
-	util.cleanup_bucket(bucket, delete_bucket= False)
+    bucket = create_bucket(wasabi_resource, conf.WASABI_CRR_TARGET_BUCKET)
+    yield bucket
+    util.cleanup_bucket(bucket, delete_bucket=False)
 
-@pytest.fixture(scope = 'session')
+
+@pytest.fixture(scope='session')
 def digital_crr_ocean_bucket(digital_ocean_resource):
-	bucket = create_bucket(digital_ocean_resource, conf.DO_CRR_TARGET_BUCKET)
-	yield bucket
-	util.cleanup_bucket(bucket, delete_bucket= False)
+    bucket = create_bucket(digital_ocean_resource, conf.DO_CRR_TARGET_BUCKET)
+    yield bucket
+    util.cleanup_bucket(bucket, delete_bucket=False)
 
 # A generic bucket in zenko
-@pytest.fixture(scope = 'function')
+
+
+@pytest.fixture(scope='function')
 def zenko_bucket(zenko_resource):
-	name = util.gen_bucket_name()
-	bucket = create_bucket(zenko_resource, name)
-	yield bucket
-	util.cleanup_bucket(bucket)
+    name = util.gen_bucket_name()
+    bucket = create_bucket(zenko_resource, name)
+    yield bucket
+    util.cleanup_bucket(bucket)
 
 # These are buckets that exists in zenko, not on the actual cloud services
 # They are configured to use backend specific endpoints,
 # with default locations configured to the respective backend
+
+
 @pytest.fixture
 def aws_ep_bucket(aws_endpoint_resource):
-	name = util.gen_bucket_name()
-	bucket = create_bucket(aws_endpoint_resource, name)
-	yield bucket
-	util.cleanup_bucket(bucket)
+    name = util.gen_bucket_name()
+    bucket = create_bucket(aws_endpoint_resource, name)
+    yield bucket
+    util.cleanup_bucket(bucket)
+
 
 @pytest.fixture
 def gcp_ep_bucket(gcp_endpoint_resource):
-	name = util.gen_bucket_name()
-	bucket = create_bucket(gcp_endpoint_resource, name)
-	yield bucket
-	util.cleanup_bucket(bucket)
+    name = util.gen_bucket_name()
+    bucket = create_bucket(gcp_endpoint_resource, name)
+    yield bucket
+    util.cleanup_bucket(bucket)
+
 
 @pytest.fixture
 def azure_ep_bucket(azure_endpoint_resource):
-	name = util.gen_bucket_name()
-	bucket = create_bucket(azure_endpoint_resource, name)
-	yield bucket
-	util.cleanup_bucket(bucket)
+    name = util.gen_bucket_name()
+    bucket = create_bucket(azure_endpoint_resource, name)
+    yield bucket
+    util.cleanup_bucket(bucket)
+
 
 @pytest.fixture
 def wasabi_ep_bucket(wasabi_endpoint_resource):
-	name = util.gen_bucket_name()
-	bucket = create_bucket(wasabi_endpoint_resource, name)
-	yield bucket
-	util.cleanup_bucket(bucket)
+    name = util.gen_bucket_name()
+    bucket = create_bucket(wasabi_endpoint_resource, name)
+    yield bucket
+    util.cleanup_bucket(bucket)
+
 
 @pytest.fixture
 def digital_ocean_ep_bucket(digital_ocean_endpoint_resource):
-	name = util.gen_bucket_name()
-	bucket = create_bucket(digital_ocean_endpoint_resource, name)
-	yield bucket
-	util.cleanup_bucket(bucket)
+    name = util.gen_bucket_name()
+    bucket = create_bucket(digital_ocean_endpoint_resource, name)
+    yield bucket
+    util.cleanup_bucket(bucket)
 
 # These buckets are configured using a LocationConstraint to each backend
 
+
 @pytest.fixture
 def aws_loc_bucket(zenko_bucket):
-	name = util.gen_bucket_name()
-	loc_config = { 'LocationConstraint': conf.AWS_BACKEND }
-	zenko_bucket.create(
-		CreateBucketConfiguration = loc_config
-	)
-	return zenko_bucket
+    loc_config = {'LocationConstraint': conf.AWS_BACKEND}
+    zenko_bucket.create(
+        CreateBucketConfiguration=loc_config
+    )
+    return zenko_bucket
+
 
 @pytest.fixture
 def gcp_loc_bucket(zenko_bucket):
-	name = util.gen_bucket_name()
-	loc_config = { 'LocationConstraint': conf.GCP_BACKEND }
-	zenko_bucket.create(
-		CreateBucketConfiguration = loc_config
-	)
-	return zenko_bucket
+    loc_config = {'LocationConstraint': conf.GCP_BACKEND}
+    zenko_bucket.create(
+        CreateBucketConfiguration=loc_config
+    )
+    return zenko_bucket
+
 
 @pytest.fixture
 def azure_loc_bucket(zenko_bucket):
-	name = util.gen_bucket_name()
-	loc_config = { 'LocationConstraint': conf.AZURE_BACKEND }
-	zenko_bucket.create(
-		CreateBucketConfiguration = loc_config
-	)
-	return zenko_bucket
+    loc_config = {'LocationConstraint': conf.AZURE_BACKEND}
+    zenko_bucket.create(
+        CreateBucketConfiguration=loc_config
+    )
+    return zenko_bucket
+
 
 @pytest.fixture
 def wasabi_loc_bucket(zenko_bucket):
-	name = util.gen_bucket_name()
-	loc_config = { 'LocationConstraint': conf.WASABI_BACKEND }
-	zenko_bucket.create(
-		CreateBucketConfiguration = loc_config
-	)
-	return zenko_bucket
+    loc_config = {'LocationConstraint': conf.WASABI_BACKEND}
+    zenko_bucket.create(
+        CreateBucketConfiguration=loc_config
+    )
+    return zenko_bucket
+
 
 @pytest.fixture
 def digital_ocean_loc_bucket(zenko_bucket):
-	name = util.gen_bucket_name()
-	loc_config = { 'LocationConstraint': conf.DO_BACKEND }
-	zenko_bucket.create(
-		CreateBucketConfiguration = loc_config
-	)
-	return zenko_bucket
+    loc_config = {'LocationConstraint': conf.DO_BACKEND}
+    zenko_bucket.create(
+        CreateBucketConfiguration=loc_config
+    )
+    return zenko_bucket
 
 # These are bucket in zenko with replication enabled
 
-@pytest.fixture(scope = 'function')
+
+@pytest.fixture(scope='function')
 def aws_crr_bucket(zenko_resource):
-	bucket = create_bucket(zenko_resource, conf.AWS_CRR_SRC_BUCKET)
-	util.bucket_safe_create(bucket)
-	yield bucket
-	util.cleanup_bucket(bucket, delete_bucket = False)
+    bucket = create_bucket(zenko_resource, conf.AWS_CRR_SRC_BUCKET)
+    util.bucket_safe_create(bucket)
+    yield bucket
+    util.cleanup_bucket(bucket, delete_bucket=False)
 
-@pytest.fixture(scope = 'function')
+
+@pytest.fixture(scope='function')
 def gcp_crr_bucket(zenko_resource):
-	bucket = create_bucket(zenko_resource, conf.GCP_CRR_SRC_BUCKET)
-	util.bucket_safe_create(bucket)
-	yield bucket
-	util.cleanup_bucket(bucket, delete_bucket = False)
+    bucket = create_bucket(zenko_resource, conf.GCP_CRR_SRC_BUCKET)
+    util.bucket_safe_create(bucket)
+    yield bucket
+    util.cleanup_bucket(bucket, delete_bucket=False)
 
-@pytest.fixture(scope = 'function')
+
+@pytest.fixture(scope='function')
 def azure_crr_bucket(zenko_resource):
-	bucket = create_bucket(zenko_resource, conf.AZURE_CRR_SRC_BUCKET)
-	util.bucket_safe_create(bucket)
-	yield bucket
-	util.cleanup_bucket(bucket, delete_bucket = False)
+    bucket = create_bucket(zenko_resource, conf.AZURE_CRR_SRC_BUCKET)
+    util.bucket_safe_create(bucket)
+    yield bucket
+    util.cleanup_bucket(bucket, delete_bucket=False)
 
-@pytest.fixture(scope = 'function')
+
+@pytest.fixture(scope='function')
 def wasabi_crr_bucket(zenko_resource):
-	bucket = create_bucket(zenko_resource, conf.WASABI_CRR_SRC_BUCKET)
-	util.bucket_safe_create(bucket)
-	yield bucket
-	util.cleanup_bucket(bucket, delete_bucket = False)
+    bucket = create_bucket(zenko_resource, conf.WASABI_CRR_SRC_BUCKET)
+    util.bucket_safe_create(bucket)
+    yield bucket
+    util.cleanup_bucket(bucket, delete_bucket=False)
 
-@pytest.fixture(scope = 'function')
+
+@pytest.fixture(scope='function')
 def digital_ocean_crr_bucket(zenko_resource):
-	bucket = create_bucket(zenko_resource, conf.DO_CRR_SRC_BUCKET)
-	util.bucket_safe_create(bucket)
-	yield bucket
-	util.cleanup_bucket(bucket, delete_bucket = False)
+    bucket = create_bucket(zenko_resource, conf.DO_CRR_SRC_BUCKET)
+    util.bucket_safe_create(bucket)
+    yield bucket
+    util.cleanup_bucket(bucket, delete_bucket=False)
 
-@pytest.fixture(scope = 'function')
+
+@pytest.fixture(scope='function')
 def muti_crr_bucket(zenko_resource):
-	bucket = create_bucket(zenko_resource, conf.MULTI_CRR_SRC_BUCKET)
-	util.bucket_safe_create(bucket)
-	yield bucket
-	util.cleanup_bucket(bucket, delete_bucket = False)
+    bucket = create_bucket(zenko_resource, conf.MULTI_CRR_SRC_BUCKET)
+    util.bucket_safe_create(bucket)
+    yield bucket
+    util.cleanup_bucket(bucket, delete_bucket=False)
 
 
-	resp = requests.get(req1, auth=s3auth, verify = conf.VERIFY_CERTIFICATES)
-
-
-@pytest.fixture(scope = 'function')
+@pytest.fixture(scope='function')
 def encrypted_bucket(aws_endpoint_resource):
-	auth = S3Auth(conf.ZENKO_ACCESS_KEY, conf.ZENKO_SECRET_KEY, service_url = conf.ZENKO_AWS_ENDPOINT)
-	name = util.gen_bucket_name()
-	ep = '%s/%s/'%(conf.ZENKO_AWS_ENDPOINT, name)
-	headers = { 'x-amz-scal-server-side-encryption': 'AES256' }
-	resp = requests.put(ep, auth=auth, headers = headers, verify = conf.VERIFY_CERTIFICATES)
-	bucket = create_bucket(aws_endpoint_resource, name)
-	yield bucket
-	util.cleanup_bucket(bucket)
+    auth = S3Auth(conf.ZENKO_ACCESS_KEY, conf.ZENKO_SECRET_KEY,
+                  service_url=conf.ZENKO_AWS_ENDPOINT)
+    name = util.gen_bucket_name()
+    endp = '%s/%s/' % (conf.ZENKO_AWS_ENDPOINT, name)
+    headers = {'x-amz-scal-server-side-encryption': 'AES256'}
+    requests.put(endp, auth=auth, headers=headers,
+                 verify=conf.VERIFY_CERTIFICATES)
+    bucket = create_bucket(aws_endpoint_resource, name)
+    yield bucket
+    util.cleanup_bucket(bucket)

--- a/tests/zenko_e2e/fixtures/data.py
+++ b/tests/zenko_e2e/fixtures/data.py
@@ -1,17 +1,21 @@
 import pytest
 
-@pytest.fixture(scope = 'session')
-def testfile(): # 1KB
-	return b'0' * 1024
 
-@pytest.fixture(scope = 'session')
-def bigfile(): # 10 MB
-	return b'0' * 1024 * 1024 * 10
+@pytest.fixture(scope='session')
+def testfile():  # 1KB
+    return b'0' * 1024
 
-@pytest.fixture(scope = 'session')
-def emptyfile(): # O bytes
-	return b''
 
-@pytest.fixture(scope = 'session')
-def mpufile(): # 100 MB
-	return b'0' * ( 1024 ** 2 * 100 )
+@pytest.fixture(scope='session')
+def bigfile():  # 10 MB
+    return b'0' * 1024 * 1024 * 10
+
+
+@pytest.fixture(scope='session')
+def emptyfile():  # O bytes
+    return b''
+
+
+@pytest.fixture(scope='session')
+def mpufile():  # 100 MB
+    return b'0' * (1024 ** 2 * 100)

--- a/tests/zenko_e2e/fixtures/lifecycle.py
+++ b/tests/zenko_e2e/fixtures/lifecycle.py
@@ -1,16 +1,17 @@
-import pytest
 from datetime import datetime
-import zenko_e2e.util as util
+
+import pytest
 import zenko_e2e.conf as conf
+
 
 @pytest.fixture
 def expiring_bucket(zenko_bucket):
-	zenko_bucket.create()
-	lc = zenko_bucket.LifecycleConfiguration()
-	expiry = datetime.utcnow() + conf.EXPIRY_DELTA
-	print('Expiring objects at %s'%expiry)
-	doc = conf.EXPIRY_RULE.copy()
-	doc['Rules'][0]['Expiration']['Date'] = expiry
-	print(doc)
-	lc.put(LifecycleConfiguration = doc)
-	return expiry, zenko_bucket
+    zenko_bucket.create()
+    loc = zenko_bucket.LifecycleConfiguration()
+    expiry = datetime.utcnow() + conf.EXPIRY_DELTA
+    print('Expiring objects at %s' % expiry)
+    doc = conf.EXPIRY_RULE.copy()
+    doc['Rules'][0]['Expiration']['Date'] = expiry
+    print(doc)
+    loc.put(LifecycleConfiguration=doc)
+    return expiry, zenko_bucket

--- a/tests/zenko_e2e/fixtures/misc.py
+++ b/tests/zenko_e2e/fixtures/misc.py
@@ -1,7 +1,8 @@
 import pytest
 from zenko_e2e import conf
 
+
 @pytest.fixture(scope='session', autouse=True)
-def create_zenko_replication_buckets(zenko_resource):
-	for bucket in conf.ZENKO_REPL_BUCKETS:
-		zenko_resource.Bucket(bucket).create()
+def create_replication_buckets(zenko_resource):
+    for bucket in conf.ZENKO_REPL_BUCKETS:
+        zenko_resource.Bucket(bucket).create()

--- a/tests/zenko_e2e/fixtures/object.py
+++ b/tests/zenko_e2e/fixtures/object.py
@@ -2,44 +2,49 @@ import pytest
 import zenko_e2e.conf as conf
 import zenko_e2e.util as util
 
+
 @pytest.fixture
 def objkey():
-	return util.make_name('test-object')
+    return util.make_name('test-object')
+
 
 @pytest.fixture
 def empty_object(zenko_bucket):
-	zenko_bucket.create()
-	name = util.gen_bucket_name('test-object')
-	return zenko_bucket.Object(name)
+    zenko_bucket.create()
+    name = util.gen_bucket_name('test-object')
+    return zenko_bucket.Object(name)
+
 
 @pytest.fixture
 def metadata_object(empty_object, emptyfile):
-	empty_object.put(
-		Body = emptyfile,
-		Metadata = conf.METADATA_EXAMPLE
-	)
-	return empty_object
+    empty_object.put(
+        Body=emptyfile,
+        Metadata=conf.METADATA_EXAMPLE
+    )
+    return empty_object
+
 
 @pytest.fixture
 def metadata_multi(zenko_bucket, emptyfile):
-	zenko_bucket.create()
-	name1 = util.gen_bucket_name('test-object')
-	name2 = util.gen_bucket_name('test-object')
-	o1 = zenko_bucket.Object(name1)
-	o2 = zenko_bucket.Object(name2)
-	o1.put(
-		Body = emptyfile,
-		Metadata = conf.METADATA_EXAMPLE
-	)
-	o2.put(
-		Body = emptyfile,
-		Metadata = conf.METADATA_EXAMPLE2
-	)
-	return (o1, o2)
+    zenko_bucket.create()
+    name1 = util.gen_bucket_name('test-object')
+    name2 = util.gen_bucket_name('test-object')
+    obj1 = zenko_bucket.Object(name1)
+    obj2 = zenko_bucket.Object(name2)
+    obj1.put(
+        Body=emptyfile,
+        Metadata=conf.METADATA_EXAMPLE
+    )
+    obj2.put(
+        Body=emptyfile,
+        Metadata=conf.METADATA_EXAMPLE2
+    )
+    return (obj1, obj2)
+
 
 @pytest.fixture
 def zenko_object(empty_object, testfile):
-	empty_object.put(
-		Body = testfile
-	)
-	return empty_object
+    empty_object.put(
+        Body=testfile
+    )
+    return empty_object

--- a/tests/zenko_e2e/fixtures/replication.py
+++ b/tests/zenko_e2e/fixtures/replication.py
@@ -1,79 +1,103 @@
 import json
 
-import zenko_e2e.conf as conf
 import pytest
+import zenko_e2e.conf as conf
 import zenko_e2e.util as util
+
 
 @pytest.fixture
 def crr_role(vault):
-	name = util.gen_bucket_name('crr-role-test')
-	return vault.create_role(
-		RoleName = name,
-		AssumeRolePolicyDocument = conf.ROLE_CONF
-		)
+    name = util.gen_bucket_name('crr-role-test')
+    return vault.create_role(
+        RoleName=name,
+        AssumeRolePolicyDocument=conf.ROLE_CONF
+    )
+
 
 @pytest.fixture
 def aws_replication_policy(vault, zenko_bucket):
-	name = util.gen_bucket_name('crr-policy-test')
-	doc = util.format_json(conf.REPL_POLICY_TPL, src = zenko_bucket.name, dest = conf.AWS_CRR_TARGET_BUCKET)
-	policy = vault.create_policy(
-		PolicyName = name,
-		PolicyDocument = doc
-	)
-	return (zenko_bucket, policy)
+    name = util.gen_bucket_name('crr-policy-test')
+    doc = util.format_json(
+        conf.REPL_POLICY_TPL,
+        src=zenko_bucket.name,
+        dest=conf.AWS_CRR_TARGET_BUCKET)
+    policy = vault.create_policy(
+        PolicyName=name,
+        PolicyDocument=doc
+    )
+    return (zenko_bucket, policy)
+
 
 @pytest.fixture
 def gcp_replication_policy(vault, zenko_bucket):
-	name = util.gen_bucket_name('crr-policy-test')
-	doc = util.format_json(conf.REPL_POLICY_TPL, src = zenko_bucket.name, dest = conf.GCP_CRR_TARGET_BUCKET)
-	policy = vault.create_policy(
-		PolicyName = name,
-		PolicyDocument = doc
-	)
-	return (zenko_bucket, policy)
+    name = util.gen_bucket_name('crr-policy-test')
+    doc = util.format_json(
+        conf.REPL_POLICY_TPL,
+        src=zenko_bucket.name,
+        dest=conf.GCP_CRR_TARGET_BUCKET)
+    policy = vault.create_policy(
+        PolicyName=name,
+        PolicyDocument=doc
+    )
+    return (zenko_bucket, policy)
+
 
 @pytest.fixture
 def azure_replication_policy(vault, zenko_bucket):
-	name = util.gen_bucket_name('crr-policy-test')
-	doc = util.format_json(conf.REPL_POLICY_TPL, src = zenko_bucket.name, dest = conf.AZURE_CRR_TARGET_BUCKET)
-	policy = vault.create_policy(
-		PolicyName = name,
-		PolicyDocument = doc
-	)
-	return (zenko_bucket, policy)
+    name = util.gen_bucket_name('crr-policy-test')
+    doc = util.format_json(
+        conf.REPL_POLICY_TPL,
+        src=zenko_bucket.name,
+        dest=conf.AZURE_CRR_TARGET_BUCKET)
+    policy = vault.create_policy(
+        PolicyName=name,
+        PolicyDocument=doc
+    )
+    return (zenko_bucket, policy)
+
 
 @pytest.fixture
 def wasabi_replication_policy(vault, zenko_bucket):
-	name = util.gen_bucket_name('crr-policy-test')
-	doc = util.format_json(conf.REPL_POLICY_TPL, src = zenko_bucket.name, dest = conf.WASABI_CRR_TARGET_BUCKET)
-	policy = vault.create_policy(
-		PolicyName = name,
-		PolicyDocument = doc
-	)
-	return (zenko_bucket, policy)
+    name = util.gen_bucket_name('crr-policy-test')
+    doc = util.format_json(
+        conf.REPL_POLICY_TPL,
+        src=zenko_bucket.name,
+        dest=conf.WASABI_CRR_TARGET_BUCKET)
+    policy = vault.create_policy(
+        PolicyName=name,
+        PolicyDocument=doc
+    )
+    return (zenko_bucket, policy)
+
 
 @pytest.fixture
-def digital_ocean_replication_policy(vault, zenko_bucket):
-	name = util.gen_bucket_name('crr-policy-test')
-	doc = util.format_json(conf.REPL_POLICY_TPL, src = zenko_bucket.name, dest = conf.DO_CRR_TARGET_BUCKET)
-	policy = vault.create_policy(
-		PolicyName = name,
-		PolicyDocument = doc
-	)
-	return (zenko_bucket, policy)
+def do_replication_policy(vault, zenko_bucket):
+    name = util.gen_bucket_name('crr-policy-test')
+    doc = util.format_json(
+        conf.REPL_POLICY_TPL,
+        src=zenko_bucket.name,
+        dest=conf.DO_CRR_TARGET_BUCKET)
+    policy = vault.create_policy(
+        PolicyName=name,
+        PolicyDocument=doc
+    )
+    return (zenko_bucket, policy)
+
 
 @pytest.fixture
 def multi_replication_policy(vault, zenko_bucket):
-	name = util.gen_bucket_name('crr-policy-test')
-	doc = util.format_json(conf.MULTI_REPL_POLICY_TPL_PT1, src = zenko_bucket.name, asString = False)
-	for target in conf.MULTI_CRR_TARGETS:
-		bucket = getattr(conf, '%s_CRR_TARGET_BUCKET'%target)
-		dest = util.format_json(conf.MULTI_REPL_POLICY_TPL_PT2, dest = bucket, asString = False)
-		doc['Statement'].append(dest)
-	print(doc)
-	doc = json.dumps(doc)
-	policy = vault.create_policy(
-		PolicyName = name,
-		PolicyDocument = doc
-	)
-	return (zenko_bucket, policy)
+    name = util.gen_bucket_name('crr-policy-test')
+    doc = util.format_json(conf.MULTI_REPL_POLICY_TPL_PT1,
+                           src=zenko_bucket.name, as_string=False)
+    for target in conf.MULTI_CRR_TARGETS:
+        bucket = getattr(conf, '%s_CRR_TARGET_BUCKET' % target)
+        dest = util.format_json(
+            conf.MULTI_REPL_POLICY_TPL_PT2, dest=bucket, as_string=False)
+        doc['Statement'].append(dest)
+    print(doc)
+    doc = json.dumps(doc)
+    policy = vault.create_policy(
+        PolicyName=name,
+        PolicyDocument=doc
+    )
+    return (zenko_bucket, policy)

--- a/tests/zenko_e2e/prometheus/client.py
+++ b/tests/zenko_e2e/prometheus/client.py
@@ -22,5 +22,4 @@ class PrometheusClient(object):
         assert resp.status_code == 200
         body = resp.json()
         assert body['status'] == 'success'
-
         return body['data']

--- a/tests/zenko_e2e/util/azure.py
+++ b/tests/zenko_e2e/util/azure.py
@@ -1,69 +1,72 @@
 
 
+class ObjectStub:  # pylint: disable=too-few-public-methods
+    def __init__(self, k, v=None):
+        def func(*args, **kwargs):  # pylint: disable=unused-argument
+            pass
+        setattr(self, k, v if v is not None else func)
 
-class ObjectStub:
-	def __init__(self, k, v = None):
-		def func(*args, **kwargs):
-			pass
-		setattr(self, k, v if v is not None else func)
 
-class AzureResource:
-	def __init__(self, service):
-		self._service = service
+class AzureResource:  # pylint: disable=too-few-public-methods
+    def __init__(self, service):
+        self._service = service
 
-	def Bucket(self, name):
-		return AzureBucket(self._service, name)
+    def Bucket(self, name):  # pylint: disable=invalid-name
+        return AzureBucket(self._service, name)
+
 
 class AzureBucket:
-	def __init__(self, service, name):
-		self._service = service
-		self._name = name
+    def __init__(self, service, name):
+        self._service = service
+        self._name = name
 
-	@property
-	def name(self):
-		return self._name
+    @property
+    def name(self):
+        return self._name
 
-	def create(self):
-		return self._service.create_container(self._name)
+    def create(self):
+        return self._service.create_container(self._name)
 
-	def delete(self):
-		return self._service.delete_container(self._name)
+    def delete(self):
+        return self._service.delete_container(self._name)
 
-	def put_object(self, Key = None, Body = None):
-		if Key is None or Body is None:
-			raise Exception
-		return self._service.create_blob_from_bytes(
-			self._name,
-			Key,
-			Body
-		)
+    def put_object(self, Key=None, Body=None):  # pylint: disable=invalid-name
+        if Key is None or Body is None:
+            raise Exception
+        return self._service.create_blob_from_bytes(
+            self._name,
+            Key,
+            Body
+        )
 
-	def download_fileobj(self, key, f):
-		blob = self._service.get_blob_to_bytes(
-			self._name,
-			key
-		)
-		if blob:
-			f.write(blob.content)
-			return True
-		else:
-			raise Exception('Failed to get blob %s/%s from azure!'%(self._name, key))
+    def download_fileobj(self, key, ofile):
+        blob = self._service.get_blob_to_bytes(
+            self._name,
+            key
+        )
+        if blob:
+            ofile.write(blob.content)
+            return True
+        else:
+            raise Exception('Failed to get blob %s/%s from azure!' %
+                            (self._name, key))
 
-	@property
-	def objects(self):
-		def f():
-			return self._service.list_blobs(self._name)
-		return ObjectStub('all', f)
+    @property
+    def objects(self):
+        def func():
+            return self._service.list_blobs(self._name)
+        return ObjectStub('all', func)
 
-	def Versioning(self):
-		return ObjectStub('suspend')
+    def Versioning(self):  # pylint: disable=invalid-name, no-self-use
+        return ObjectStub('suspend')
 
-	def  delete_blob(self, name):
-		self._service.delete_blob(self._name, name)
+    def delete_blob(self, name):
+        self._service.delete_blob(self._name, name)
 
-def cleanup_azure_bucket(bucket, replicated = False, delete_bucket = True):
-	blobs = list(bucket.objects.all())
-	for blob in blobs:
-		bucket.delete_blob(blob.name)
-	if delete_bucket:
-		bucket.delete()
+
+def cleanup_azure_bucket(bucket, delete_bucket=True):
+    blobs = list(bucket.objects.all())
+    for blob in blobs:
+        bucket.delete_blob(blob.name)
+    if delete_bucket:
+        bucket.delete()

--- a/tests/zenko_e2e/util/bucket.py
+++ b/tests/zenko_e2e/util/bucket.py
@@ -5,112 +5,125 @@ import tempfile
 import time
 import zenko_e2e.conf as conf
 
-_log = logging.getLogger('util.bucket')
+_log = logging.getLogger('util.bucket')  # pylint: disable=invalid-name
+
 
 def bucket_safe_create(bucket):
-	try:
-		bucket.create()
-	except bucket.meta.client.exceptions.BucketAlreadyOwnedByYou:
-		print('Bucket %s already exists!'%bucket.name)
-	except Exception as e:
-		print('Error creating bucket %s'%bucket.name)
-		logging.exception(e)
-		raise e
+    try:
+        bucket.create()
+    except bucket.meta.client.exceptions.BucketAlreadyOwnedByYou:
+        print('Bucket %s already exists!' % bucket.name)
+    except Exception as exp:  # pylint: disable=broad-except
+        print('Error creating bucket %s' % bucket.name)
+        logging.exception(exp)
+        raise exp
 
-def gen_bucket_name(root = 'zenko-test-bucket'):
-	return '%s-%s'%(root, uuid.uuid4().hex)
+
+def gen_bucket_name(root='zenko-test-bucket'):
+    return '%s-%s' % (root, uuid.uuid4().hex)
+
 
 def hashobj(data):
-	return hashlib.md5(data).hexdigest()
+    return hashlib.md5(data).hexdigest()
+
 
 def enable_versioning(bucket):
-	_log.info('Enabling bucket versioning on %s'%bucket.name)
-	v = bucket.Versioning().enable()
+    _log.info('Enabling bucket versioning on %s', bucket.name)
+    bucket.Versioning().enable()
 
-def get_object_hash(bucket, key, timeout = 0, backoff = 5, ts = None):
-	if ts is None:
-		ts = time.time()
-	try:
-		with tempfile.TemporaryFile() as f:
-			bucket.download_fileobj(key, f)
-			f.seek(0)
-			return hashobj(f.read())
-	except Exception as e:
-		if time.time() - ts > timeout:
-			_log.error('Unable to retrieve remote file (%s/%s) for hashing!'%(bucket.name, key))
-			_log.exception(e)
-			return None
-		else:
-			time.sleep(backoff)
-			return get_object_hash(bucket, key, timeout, ts = ts, backoff = backoff)
 
-def check_object(key, data, local, *args, timeout = 0, backoff = 5):
-	refHash = hashobj(data)
-	localHash = get_object_hash(local, key, timeout, backoff)
-	if localHash is None:
-		_log.error('Unable to retrieve %s/%s from zenko'%(local.name, key))
-		contents = list(local.objects.all())
-		_log.debug('%s bucket contents %s'%(local.name, contents))
-	if not refHash == localHash:
-		_log.error('Local object hash != data hash')
-		return False
-	passed = True
-	for bucket in args:
-		remotekey = '%s/%s'%(local.name, key) if not conf.BUCKET_MATCH  and local is not bucket else key
-		rHash = get_object_hash(bucket, remotekey, timeout, backoff)
-		if rHash is None:
-			_log.error('Unable to retrieve %s/%s from cloud backend'%(bucket.name, remotekey))
-			contents = list(bucket.objects.all())
-			_log.debug('%s bucket contents %s'%(bucket.name, contents))
-		if not rHash == refHash:
-			_log.error('Object in %s did not match data!'%bucket)
-			passed = False
-	return passed
+def get_object_hash(bucket, key, timeout=0, backoff=5, _timestamp=None):
+    if _timestamp is None:
+        _timestamp = time.time()
+    try:
+        with tempfile.TemporaryFile() as tfile:
+            bucket.download_fileobj(key, tfile)
+            tfile.seek(0)
+            return hashobj(tfile.read())
+    except Exception as exp:  # pylint: disable=broad-except
+        if time.time() - _timestamp > timeout:
+            _log.error(
+                'Unable to retrieve remote file (%s/%s) for hashing!',
+                bucket.name, key)
+            _log.exception(exp)
+            return None
+        time.sleep(backoff)
+        return get_object_hash(bucket, key, timeout,
+                               _timestamp=_timestamp, backoff=backoff)
 
-def cleanup_bucket(bucket, replicated = False, delete_bucket = True):
-	if replicated:
-		bucket.Versioning().suspend()
-	client = bucket.meta.client
-	IsTruncated = True
-	MaxKeys = 1000
-	KeyMarker = None
-	Bucket = bucket.name
-	Prefix = ''
-	while IsTruncated == True:
-		if not KeyMarker:
-			version_list = client.list_object_versions(
-				Bucket=Bucket,
-				MaxKeys=MaxKeys,
-				Prefix=Prefix)
-		else:
-			version_list = client.list_object_versions(
-				Bucket=Bucket,
-				MaxKeys=MaxKeys,
-				Prefix=Prefix,
-				KeyMarker=KeyMarker)
 
-		try:
-			objects = []
-			versions = version_list['Versions']
-			for v in versions:
-				objects.append({'VersionId':v['VersionId'],'Key': v['Key']})
-			response = client.delete_objects(Bucket=Bucket,Delete={'Objects':objects})
-			print(response)
-		except:
-			pass
+def check_object(key, data, local, *args, timeout=0, backoff=5):
+    ref_hash = hashobj(data)
+    local_hash = get_object_hash(local, key, timeout, backoff)
+    if local_hash is None:
+        _log.error('Unable to retrieve %s/%s from zenko', local.name, key)
+        contents = list(local.objects.all())
+        _log.debug('%s bucket contents %s', local.name, contents)
+    if ref_hash != local_hash:
+        _log.error('Local object hash != data hash')
+        return False
+    passed = True
+    for bucket in args:
+        remotekey = '%s/%s' % (local.name,
+                key) if not conf.BUCKET_MATCH and local is not bucket else key  # noqa pylint: disable=bad-continuation
+        remote_hash = get_object_hash(bucket, remotekey, timeout, backoff)
+        if remote_hash is None:
+            _log.error('Unable to retrieve %s/%s from cloud backend',
+                       bucket.name, remotekey)
+            contents = list(bucket.objects.all())
+            _log.debug('%s bucket contents %s', bucket.name, contents)
+        if remote_hash != ref_hash:
+            _log.error('Object in %s did not match data!', bucket)
+            passed = False
+    return passed
 
-		try:
-			objects = []
-			delete_markers = version_list['DeleteMarkers']
-			for d in delete_markers:
-				objects.append({'VersionId':d['VersionId'],'Key': d['Key']})
-			response = client.delete_objects(Bucket=Bucket,Delete={'Objects':objects})
-			print(response)
-		except:
-			pass
 
-		IsTruncated = version_list['IsTruncated']
-		if IsTruncated:
-			KeyMarker = version_list['NextKeyMarker']
-	if delete_bucket:
-		bucket.delete()
+def cleanup_bucket(bucket, replicated=False, delete_bucket=True): # noqa pylint: disable=too-many-locals
+    if replicated:
+        bucket.Versioning().suspend()
+    client = bucket.meta.client
+    is_truncated = True
+    max_keys = 1000
+    key_marker = None
+    bucket_name = bucket.name
+    prefix = ''
+    while is_truncated:
+        if not key_marker:
+            version_list = client.list_object_versions(
+                Bucket=bucket_name,
+                MaxKeys=max_keys,
+                Prefix=prefix)
+        else:
+            version_list = client.list_object_versions(
+                Bucket=bucket_name,
+                MaxKeys=max_keys,
+                Prefix=prefix,
+                KeyMarker=key_marker)
+
+        try:
+            objects = []
+            versions = version_list['Versions']
+            for v in versions:  # pylint: disable=invalid-name
+                objects.append({'VersionId': v['VersionId'], 'Key': v['Key']})
+            response = client.delete_objects(
+                Bucket=bucket_name, Delete={'Objects': objects})
+            print(response)
+        except BaseException:
+            pass
+
+        try:
+            objects = []
+            delete_markers = version_list['DeleteMarkers']
+            for d in delete_markers:  # pylint: disable=invalid-name
+                objects.append({'VersionId': d['VersionId'], 'Key': d['Key']})
+            response = client.delete_objects(
+                Bucket=bucket_name, Delete={'Objects': objects})
+            print(response)
+        except BaseException:
+            pass
+
+        is_truncated = version_list['IsTruncated']
+        if is_truncated:
+            key_marker = version_list['NextKeyMarker']
+    if delete_bucket:
+        bucket.delete()

--- a/tests/zenko_e2e/util/misc.py
+++ b/tests/zenko_e2e/util/misc.py
@@ -1,43 +1,28 @@
 import uuid
 import json
 
-def make_name(name, nonce = None):
-	if nonce is None:
-		nonce = uuid.uuid4().hex
-	return '%s-%s'%(name, nonce)
+
+def make_name(name, nonce=None):
+    if nonce is None:
+        nonce = uuid.uuid4().hex
+    return '%s-%s' % (name, nonce)
 
 
-def format_json(tpl, asString = True, **kwargs):
-	conf = tpl.format(**kwargs)
-	conf = json.loads(conf)
-	if asString:
-		conf = json.dumps(conf)
-	return conf
+def format_json(tpl, as_string=True, **kwargs):
+    conf = tpl.format(**kwargs)
+    conf = json.loads(conf)
+    if as_string:
+        conf = json.dumps(conf)
+    return conf
 
 
 def mark_test(name):
-	head = ' Starting %s '%name
-	print('\n' + '=' * 35 + head + '=' * 35, flush = True)
+    head = ' Starting %s ' % name
+    print('\n' + '=' * 35 + head + '=' * 35, flush=True)
+
 
 def remark(text):
-	print('\n' + '=' * 35 + text + '=' * 35, flush = True)
-
-
-def pretty_print_POST(req):
-    """
-    At this point it is completely built and ready
-    to be fired; it is "prepared".
-
-    However pay attention at the formatting used in
-    this function because it is programmed to be pretty
-    printed and may differ from the actual request.
-    """
-    print('{}\n{}\n{}\n\n{}'.format(
-        '-----------START-----------',
-        req.method + ' ' + req.url,
-        '\n'.join('{}: {}'.format(k, v) for k, v in req.headers.items()),
-        req.body,
-    ))
+    print('\n' + '=' * 35 + text + '=' * 35, flush=True)
 
 
 def strip_proto(url):
@@ -46,11 +31,13 @@ def strip_proto(url):
         return '//'.join(parts[1:])
     return parts[0]
 
+
 def strip_port(url):
     parts = url.split(':')
     if len(parts) <= 2:
         return parts[0]
     return ':'.join(parts[:2])
+
 
 def baseurl(url):
     return strip_port(strip_proto(url))


### PR DESCRIPTION
some linting rules regarding wildcard imports were disabled to improve readability.

ie to keep
```
from ..fixtures import *
```

from turning into

```
from ..fixtures import (zenko_bucket,
                       testfile,
                       objkey,
                       aws_ep_bucket,
                       aws_target_bucket,
                       gcp_ep_bucket,
                       gcp_target_bucket,
                       azure_ep_bucket,
                       azure_target_bucket,
                       wasabi_ep_bucket,
                       wasabi_target_bucket,
                       digital_ocean_ep_bucket,
                       digital_ocean_target_bucket)
```