### PR TITLE
chore: zenko-filer NodePort service

### DIFF
--- a/charts/zenko-filer/templates/service.yaml
+++ b/charts/zenko-filer/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  type: {{ .Values.nfsd.service.type }}
+  type: {{ .Values.service.type }}
   ports:
     - name: nfs
       port: 2049

--- a/charts/zenko-filer/values.yaml
+++ b/charts/zenko-filer/values.yaml
@@ -3,28 +3,29 @@
 # Declare variables to be passed into your templates.
 replicaCount: 1
 
+service:
+  type: NodePort
+
 nfsd:
   name: "zenko-nfsd"
   image:
     repository: zenko/zenko-nfsd
-    tag: edge
+    tag: 8.0.0
     pullPolicy: IfNotPresent
   loglevel: INFO
-  service:
-    type: ClusterIP
 
 md:
   name: "zenko-md"
   image:
     repository: zenko/zenko-md
-    tag: edge
+    tag: 8.0.0
     pullPolicy: IfNotPresent
 
 portmap:
   name: "portmap"
   image:
     repository: zenko/portmap
-    tag: edge
+    tag: 8.0.0
     pullPolicy: IfNotPresent
 
 mongodb:


### PR DESCRIPTION
This changes Zenko Filer service type to NodePort. Even though this is not the final or ideal way of exposing the service, it's better than ClusterIP because it allows exposing the service outside the Kubernetes Cluster without having to do port-forwarding to the pods.

Additionally, image tags have been updated to 8.0.0 to follow the version pattern that other components have.