### PR TITLE
ci: remove configuration from user-observable part

### DIFF
--- a/charts/cloudserver-front/templates/_helpers.tpl
+++ b/charts/cloudserver-front/templates/_helpers.tpl
@@ -31,14 +31,6 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-
-{{/*
-Create the orbit management endpoint when running in ci mode
-*/}}
-{{- define "cloudserver-front.ci_endpoint" -}}
-{{- printf "http://%s-orbit-simulator:4222" .Values.ci.orbit_ns -}}
-{{- end -}}
-
 {{/*
 Create the default mongodb replicaset hosts string
 */}}

--- a/charts/cloudserver-front/templates/deployment.yaml
+++ b/charts/cloudserver-front/templates/deployment.yaml
@@ -75,19 +75,12 @@ spec:
 {{- if .Values.orbit.enabled }}
             - name: REMOTE_MANAGEMENT_DISABLE
               value: "0"
-{{- if .Values.ci.enabled }}
-            - name: MANAGEMENT_ENDPOINT
-              value: {{ template "cloudserver-front.ci_endpoint" . }}
-            - name: MANAGEMENT_MODE
-              value: poll
-{{- else }}
             - name: MANAGEMENT_ENDPOINT
               value: "{{- .Values.orbit.endpoint -}}"
             - name: MANAGEMENT_MODE
               value: "{{- .Values.orbit.mode -}}"
             - name: PUSH_ENDPOINT
               value: "{{- .Values.orbit.pushEndpoint -}}"
-{{ end }}
 {{- else }}
             - name: REMOTE_MANAGEMENT_DISABLE
               value: "1"

--- a/charts/cloudserver-front/values.yaml
+++ b/charts/cloudserver-front/values.yaml
@@ -2,10 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-ci:
-  enabled: false
-  orbit_ns: ciutil
-
 orbit:
   enabled: true
   endpoint: https://api.zenko.io

--- a/eve/ci-values.yml
+++ b/eve/ci-values.yml
@@ -1,4 +1,3 @@
-
 ingress:
   enabled: true
 
@@ -36,5 +35,6 @@ redis-ha:
 cloudserver-front:
   image:
     pullPolicy: Always
-  ci:
-    enabled: true
+  orbit:
+    endpoint: "http://ciutil-orbit-simulator:4222"
+    mode: "poll"


### PR DESCRIPTION
This removes ci configuration from the user observable part of the charts. Instead, CI is been deployed "like a user" will do.