### PR TITLE
chore: delete unnecessary cert configuration var

### DIFF
--- a/charts/cloudserver-front/templates/deployment.yaml
+++ b/charts/cloudserver-front/templates/deployment.yaml
@@ -65,8 +65,6 @@ spec:
               value: "{{ .Values.proxy.https }}"
             - name: HTTPS_PROXY
               value: "{{ .Values.proxy.https }}"
-            - name: HTTPS_PROXY_CERTIFICATE
-              value: "/ssl/ca.crt"
             - name: NODE_EXTRA_CA_CERTS
               value: "/ssl/ca.crt"
 {{- end }}


### PR DESCRIPTION
Thanks to `NODE_EXTRA_CA_CERTS`, we no longer need `HTTPS_PROXY_CERTIFICATE`.