### PR TITLE
rf: ZENKO-758 rename replication pods

### DIFF
--- a/charts/backbeat/templates/replication/data_processor_deployment.yaml
+++ b/charts/backbeat/templates/replication/data_processor_deployment.yaml
@@ -1,14 +1,14 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "backbeat.fullname" . }}-status
+  name: {{ template "backbeat.fullname" . }}-replication-data-processor
   labels:
     app: {{ template "backbeat.name" . }}-replication
     chart: {{ template "backbeat.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  replicas: {{ .Values.replication.status.replicaCount }}
+  replicas: {{ .Values.replication.dataProcessor.replicaCount }}
   template:
     metadata:
       labels:
@@ -16,11 +16,11 @@ spec:
         release: {{ .Release.Name }}
     spec:
       containers:
-        - name: replication-status
+        - name: replication-data-processor
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/usr/src/app/docker-entrypoint.sh"]
-          args: ["npm", "run", "replication_status_processor"]
+          args: ["npm", "run", "queue_processor"]
           env:
             - name: REMOTE_MANAGEMENT_DISABLE
               value: "{{- if .Values.orbit.enabled }}0{{- else }}1{{- end }}"
@@ -30,8 +30,8 @@ spec:
               value: "{{- printf "%s-zenko-quorum:2181" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: KAFKA_HOSTS
               value: "{{- printf "%s-zenko-queue:9092" .Release.Name | trunc 63 | trimSuffix "-" -}}"
-            - name: MONGODB_HOSTS
-              value: "{{ template "backbeat.mongodb-hosts" . }}"
+            - name: LOG_LEVEL
+              value: {{ .Values.logging.level }}
             - name: EXTENSIONS_REPLICATION_SOURCE_AUTH_TYPE
               value: service
             - name: EXTENSIONS_REPLICATION_SOURCE_AUTH_ACCOUNT
@@ -40,6 +40,14 @@ spec:
               value: "{{- printf "%s-cloudserver-front" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: EXTENSIONS_REPLICATION_SOURCE_S3_PORT
               value: "80"
+            - name: EXTENSIONS_REPLICATION_DEST_AUTH_TYPE
+              value: service
+            - name: EXTENSIONS_REPLICATION_DEST_AUTH_ACCOUNT
+              value: service-replication
+            - name: EXTENSIONS_REPLICATION_DEST_BOOTSTRAPLIST
+              value: "{{- printf "%s-cloudserver-front:80" .Release.Name | trunc 63 | trimSuffix "-" -}}"
+            - name: MONGODB_HOSTS
+              value: "{{ template "backbeat.mongodb-hosts" . }}"
             - name: REDIS_HOST
               value: "{{- printf "%s-%s" .Release.Name "redis-ha-master-svc" | trunc 63 | trimSuffix "-" -}}"
             - name: REDIS_PORT
@@ -48,8 +56,6 @@ spec:
               value: "{{- printf "%s-%s" .Release.Name "redis" | trunc 63 | trimSuffix "-" -}}"
             - name: REDIS_LOCALCACHE_PORT
               value: "6379"
-            - name: LOG_LEVEL
-              value: {{ .Values.logging.level }}
           livenessProbe:
             httpGet:
               path: {{ .Values.health.path.liveness}}
@@ -59,16 +65,16 @@ spec:
               path: {{ .Values.health.path.readiness }}
               port: {{ .Values.health.port }}
           resources:
-{{ toYaml .Values.replication.status.resources | indent 12 }}
-    {{- with .Values.replication.status.nodeSelector }}
+{{ toYaml .Values.replication.dataProcessor.resources | indent 12 }}
+    {{- with .Values.replication.dataProcessor.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.replication.status.affinity }}
+    {{- with .Values.replication.dataProcessor.affinity }}
       affinity:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.replication.status.tolerations }}
+    {{- with .Values.replication.dataProcessor.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}

--- a/charts/backbeat/templates/replication/populator_deployment.yaml
+++ b/charts/backbeat/templates/replication/populator_deployment.yaml
@@ -1,14 +1,14 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "backbeat.fullname" . }}-producer
+  name: {{ template "backbeat.fullname" . }}-replication-populator
   labels:
     app: {{ template "backbeat.name" . }}-replication
     chart: {{ template "backbeat.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  replicas: {{ .Values.replication.producer.replicaCount }}
+  replicas: {{ .Values.replication.populator.replicaCount }}
   template:
     metadata:
       labels:
@@ -16,7 +16,7 @@ spec:
         release: {{ .Release.Name }}
     spec:
       containers:
-        - name: {{ template "backbeat.fullname" . }}-producer
+        - name: replication-populator
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args: ["npm", "run", "queue_populator"]
@@ -50,16 +50,16 @@ spec:
               path: {{ .Values.health.path.readiness }}
               port: {{ .Values.health.port }}
           resources:
-{{ toYaml .Values.replication.producer.resources | indent 12 }}
-    {{- with .Values.replication.producer.nodeSelector }}
+{{ toYaml .Values.replication.populator.resources | indent 12 }}
+    {{- with .Values.replication.populator.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.replication.producer.affinity }}
+    {{- with .Values.replication.populator.affinity }}
       affinity:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.replication.producer.tolerations }}
+    {{- with .Values.replication.populator.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}

--- a/charts/backbeat/templates/replication/status_processor_deployment.yaml
+++ b/charts/backbeat/templates/replication/status_processor_deployment.yaml
@@ -1,14 +1,14 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "backbeat.fullname" . }}-consumer
+  name: {{ template "backbeat.fullname" . }}-replication-status-processor
   labels:
     app: {{ template "backbeat.name" . }}-replication
     chart: {{ template "backbeat.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  replicas: {{ .Values.replication.consumer.replicaCount }}
+  replicas: {{ .Values.replication.statusProcessor.replicaCount }}
   template:
     metadata:
       labels:
@@ -16,11 +16,11 @@ spec:
         release: {{ .Release.Name }}
     spec:
       containers:
-        - name: {{ template "backbeat.fullname" . }}-consumer
+        - name: replication-status-processor
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/usr/src/app/docker-entrypoint.sh"]
-          args: ["npm", "run", "queue_processor"]
+          args: ["npm", "run", "replication_status_processor"]
           env:
             - name: REMOTE_MANAGEMENT_DISABLE
               value: "{{- if .Values.orbit.enabled }}0{{- else }}1{{- end }}"
@@ -30,8 +30,8 @@ spec:
               value: "{{- printf "%s-zenko-quorum:2181" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: KAFKA_HOSTS
               value: "{{- printf "%s-zenko-queue:9092" .Release.Name | trunc 63 | trimSuffix "-" -}}"
-            - name: LOG_LEVEL
-              value: {{ .Values.logging.level }}
+            - name: MONGODB_HOSTS
+              value: "{{ template "backbeat.mongodb-hosts" . }}"
             - name: EXTENSIONS_REPLICATION_SOURCE_AUTH_TYPE
               value: service
             - name: EXTENSIONS_REPLICATION_SOURCE_AUTH_ACCOUNT
@@ -40,14 +40,6 @@ spec:
               value: "{{- printf "%s-cloudserver-front" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: EXTENSIONS_REPLICATION_SOURCE_S3_PORT
               value: "80"
-            - name: EXTENSIONS_REPLICATION_DEST_AUTH_TYPE
-              value: service
-            - name: EXTENSIONS_REPLICATION_DEST_AUTH_ACCOUNT
-              value: service-replication
-            - name: EXTENSIONS_REPLICATION_DEST_BOOTSTRAPLIST
-              value: "{{- printf "%s-cloudserver-front:80" .Release.Name | trunc 63 | trimSuffix "-" -}}"
-            - name: MONGODB_HOSTS
-              value: "{{ template "backbeat.mongodb-hosts" . }}"
             - name: REDIS_HOST
               value: "{{- printf "%s-%s" .Release.Name "redis-ha-master-svc" | trunc 63 | trimSuffix "-" -}}"
             - name: REDIS_PORT
@@ -56,6 +48,8 @@ spec:
               value: "{{- printf "%s-%s" .Release.Name "redis" | trunc 63 | trimSuffix "-" -}}"
             - name: REDIS_LOCALCACHE_PORT
               value: "6379"
+            - name: LOG_LEVEL
+              value: {{ .Values.logging.level }}
           livenessProbe:
             httpGet:
               path: {{ .Values.health.path.liveness}}
@@ -65,16 +59,16 @@ spec:
               path: {{ .Values.health.path.readiness }}
               port: {{ .Values.health.port }}
           resources:
-{{ toYaml .Values.replication.consumer.resources | indent 12 }}
-    {{- with .Values.replication.consumer.nodeSelector }}
+{{ toYaml .Values.replication.statusProcessor.resources | indent 12 }}
+    {{- with .Values.replication.statusProcessor.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.replication.consumer.affinity }}
+    {{- with .Values.replication.statusProcessor.affinity }}
       affinity:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.replication.consumer.tolerations }}
+    {{- with .Values.replication.statusProcessor.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}

--- a/charts/backbeat/values.yaml
+++ b/charts/backbeat/values.yaml
@@ -101,7 +101,7 @@ lifecycle:
       enabled: True
 
 replication:
-  consumer:
+  dataProcessor:
     replicaCount: 1
 
     resources: {}
@@ -109,7 +109,7 @@ replication:
     tolerations: []
     affinity: {}
 
-  producer:
+  populator:
     replicaCount: 1
 
     resources: {}
@@ -117,7 +117,7 @@ replication:
     tolerations: []
     affinity: {}
 
-  status:
+  statusProcessor:
     replicaCount: 1
 
     resources: {}


### PR DESCRIPTION
Add "replication" to pod names to avoid confusions, and change
"producer" and "consumer" to more meaningful names.

New pod names:

- backbeat-producer -> backbeat-replication-populator
- backbeat-consumer -> backbeat-replication-data-processor
- backbeat-status -> backbeat-replication-status-processor

If there's a risk it does not fit anymore in DNS name limit (63 char?)
we can consider shortening names, but ideally (to me) they would be as
self-descriptive as they can get.