### PR TITLE
ci: re-enable grafana tests

### DIFF
--- a/charts/zenko/values.yaml
+++ b/charts/zenko/values.yaml
@@ -108,6 +108,7 @@ redis-ha:
 grafana:
   enabled: true
   sidecar:
+    image: zenko/grafana-sidecar:latest
     datasources:
       enabled: true
       # Every config map with the following label will be used as datasource. By default,

--- a/eve/ci-values.yml
+++ b/eve/ci-values.yml
@@ -45,4 +45,10 @@ backbeat:
       cronRule: "0 */1 * * * *"
 
 grafana:
-  enabled: false
+  rbac:
+    create: false
+    pspEnabled: false
+  serviceAccount:
+    create: false
+  adminUser: admin
+  adminPassword: strongpassword

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -154,7 +154,7 @@ stages:
           helm upgrade $ZENKO_HELM_RELEASE --namespace %(prop:testNamespace)s
           --install charts/zenko
           -f eve/ci-values.yml
-          --timeout 700
+          --timeout 800
           --wait $(./eve/workers/ci_env.sh set)
         haltOnFailure: true
         env:
@@ -214,7 +214,7 @@ stages:
             --set backbeat.image.repository=%(secret:private_registry_url)s/zenko/backbeat
             --set s3-data.image.tag='%(prop:cloudserver_sha1)s'
             --set s3-data.image.repository=%(secret:private_registry_url)s/zenko/cloudserver
-            --timeout 1700
+            --timeout 800
             --wait $(./eve/workers/ci_env.sh set)
           haltOnFailure: true
           env:

--- a/tests/zenko_e2e/conftest.py
+++ b/tests/zenko_e2e/conftest.py
@@ -71,7 +71,7 @@ def grafana_client():
         user = 'admin'
     password = os.getenv('GRAFANA_PASSWORD')
     if not password:
-        password = 'admin'
+        password = 'strongpassword'
     url = os.getenv('GRAFANA_ENDPOINT')
     if not url:
         url = 'http://{}-grafana:80'.format(zenko_helm_release())

--- a/tests/zenko_e2e/grafana/test_dashboard.py
+++ b/tests/zenko_e2e/grafana/test_dashboard.py
@@ -6,7 +6,6 @@ GRAFANA_DASHBOARDS = [
 ]
 
 
-@pytest.mark.skip(reason="Grafana doesn't install on CI")
 @pytest.mark.nondestructive
 @pytest.mark.parametrize('dashboard', GRAFANA_DASHBOARDS)
 def test_dashboard(grafana_client, dashboard):

--- a/tests/zenko_e2e/grafana/test_datasource.py
+++ b/tests/zenko_e2e/grafana/test_datasource.py
@@ -6,7 +6,6 @@ GRAFANA_DATASOURCES = [
 ]
 
 
-@pytest.mark.skip(reason="Grafana doesn't install on CI")
 @pytest.mark.nondestructive
 @pytest.mark.parametrize('datasource', GRAFANA_DATASOURCES)
 def test_datasource(grafana_client, datasource):


### PR DESCRIPTION
The Grafana tests were disabled because its chart was not installing in CI due to privilege issues. The Grafana sidecar image has been updated to a custom one that does not have privilege implications and now it is possible to install Grafana on CI and run the tests for it.