### PR TITLE
chore: bump cloudserver to rc3

### DIFF
--- a/charts/cloudserver-front/values.yaml
+++ b/charts/cloudserver-front/values.yaml
@@ -32,7 +32,7 @@ replicaCount: 1
 
 image:
   repository: zenko/cloudserver
-  tag: 8.0.6-RC2
+  tag: 8.0.7-RC3
   pullPolicy: IfNotPresent
 
 proxy:

--- a/charts/s3-data/values.yaml
+++ b/charts/s3-data/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: zenko/cloudserver
-  tag: 8.0.6-RC2
+  tag: 8.0.7-RC3
   pullPolicy: IfNotPresent
 service:
   name: s3-data


### PR DESCRIPTION
* bf: ZENKO 790 redis limit return
* Merge branch 'improvement/ZENKO-749-removeS3toS3ObjectTestFrom-aws-node-sdk' into q/8.0
* improvement: ZENKO-749 removed crr s3 to s3 object test from aws-node-sdk
* bf: ZENKO-660 api proxy fixes
* bf: ZENKO 773 failing lifecycle unit tests
* bf: bump arsenal version changes
* bf(zenko-473): Handle a unspecified storage quota correctly
* bf: ZENKO 726 storage limit
* bf: ZENKO 726 storage limit config level