### PR TITLE
ft: cloudserver soft anti-affinity

### DIFF
--- a/charts/cloudserver/templates/deployment.yaml
+++ b/charts/cloudserver/templates/deployment.yaml
@@ -58,10 +58,8 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.affinity }}
       affinity:
-{{ toYaml . | indent 8 }}
-    {{- end }}
+{{ tpl .Values.affinity . | indent 8 }}
     {{- with .Values.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}

--- a/charts/cloudserver/templates/manager-deployment.yaml
+++ b/charts/cloudserver/templates/manager-deployment.yaml
@@ -55,10 +55,8 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.affinity }}
       affinity:
-{{ toYaml . | indent 8 }}
-    {{- end }}
+{{ tpl .Values.affinity . | indent 8 }}
     {{- with .Values.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}

--- a/charts/cloudserver/values.yaml
+++ b/charts/cloudserver/values.yaml
@@ -92,7 +92,20 @@ nodeSelector: {}
 
 tolerations: []
 
-affinity: {}
+# These default settings are for a "soft" anti affinity scheduling
+# where the deployment of replicas will try to be scheduled on different
+# nodes in the cluster. This can be customized to user specific values.
+# https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+affinity: |
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 5
+      podAffinityTerm:
+        topologyKey: "kubernetes.io/hostname"
+        labelSelector:
+          matchLabels:
+            app: {{ template "cloudserver.name" . }}
+            release: {{ .Release.Name | quote }}
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
Sets up a default soft anti affinity for the cloudserver chart