### PR TITLE
bugfix: remove bad cloudserver dashboard stat

### DIFF
--- a/charts/cloudserver/dashboards/cloudserver.json
+++ b/charts/cloudserver/dashboards/cloudserver.json
@@ -38,94 +38,13 @@
       }
     ]
   },
-  "description": "Metrics obtained from Cloudserver pods",
+  "description": "Metrics obtained from Cloudserver",
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
   "links": [],
   "panels": [
-    {
-      "cacheTimeout": null,
-      "colorBackground": true,
-      "colorValue": false,
-      "colors": [
-        "#299c46",
-        "#614d93",
-        "#d44a3a"
-      ],
-      "datasource": "Prometheus",
-      "description": "Start time of the process.",
-      "format": "dtdurations",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 12,
-        "x": 0,
-        "y": 0
-      },
-      "id": 6,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "100%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "#82b5d8",
-        "full": true,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "time() - (process_start_time_seconds{app=\"cloudserver\"})",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "refId": "A"
-        }
-      ],
-      "thresholds": "",
-      "title": "Time Alive",
-      "type": "singlestat",
-      "valueFontSize": "70%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
-    },
     {
       "cacheTimeout": null,
       "colorBackground": true,
@@ -147,8 +66,8 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 12,
-        "x": 12,
+        "w": 24,
+        "x": 0,
         "y": 0
       },
       "id": 22,
@@ -1161,5 +1080,5 @@
   "timezone": "",
   "title": "Cloudserver",
   "uid": "Ze9RVGDmz",
-  "version": 1
+  "version": 2
 }


### PR DESCRIPTION
This removes a stat/graph from the Cloudserver Grafana dashboard since it doesn't work with more than 1 pod.