### PR TITLE
rf: remove wait flags and programatically wait

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -47,6 +47,7 @@ models:
       GCP_CRR_SRC_BUCKET_NAME: ci-zenko-gcp-crr-src-bucket
       GCP_MPU_BUCKET_NAME: ci-zenko-gcp-mpu-bucket
       GCP_MPU_BUCKET_NAME_2: ci-zenko-gcp-mpu-bucket-2
+      INSTALL_TIMEOUT: "400"
       MULTI_CRR_SRC_BUCKET: ci-zenko-multi-crr-src-bucket
       TILLER_NAMESPACE: '%(prop:testNamespace)s'
       TRANSIENT_SRC_BUCKET: ci-zenko-transient-src-bucket
@@ -95,9 +96,9 @@ models:
   - ShellCommand: &test_zenko
       name: Test zenko
       command: >-
-        sleep 90 &&
         make DOCKER_IMAGE_NAME=$E2E_DOCKER_IMAGE_NAME
         DOCKER_IMAGE_TAG='%(prop:commit_short_revision)s' end2end
+        || (echo "Tests have failed" ; kubectl get pods -L redis-role ; exit 1) >&2 
       workdir: build/tests
       env:
         <<: *global_env
@@ -174,8 +175,7 @@ stages:
           helm upgrade $ZENKO_HELM_RELEASE --namespace %(prop:testNamespace)s
           --install charts/zenko
           -f eve/ci-values.yml
-          --timeout 800
-          --wait $(./eve/workers/ci_env.sh set)
+          $(./eve/workers/ci_env.sh set)
         haltOnFailure: true
         env:
           <<: *global_env
@@ -235,8 +235,7 @@ stages:
             --set backbeat.image.repository=%(secret:private_registry_url)s/zenko/backbeat
             --set s3-data.image.tag='%(prop:cloudserver_sha1)s'
             --set s3-data.image.repository=%(secret:private_registry_url)s/zenko/cloudserver
-            --timeout 800
-            --wait $(./eve/workers/ci_env.sh set)
+            $(./eve/workers/ci_env.sh set)
           haltOnFailure: true
           env:
             <<: *global_env


### PR DESCRIPTION
Reduces flakiness with the installation step of the CI where sometime pods would be in indefinitate Crashloop state that would cause the CI potentially wait 800 seconds for an install to finish. The Crashloop state is normal especially in the CI environment where the services are expecting the buckets that are predefined environment but don't yet exist until test initialization. The CI still explicitly expects the stack to stabilize but this is now part of the test initialization thus saving time on sleep commands and unneccessary waits. Additionally, this allows devs to collect logs on a stack that was unable to stabilize for debugging purposes.

