### PR TITLE
bf(ZENKO-852): Prevent CI object name conflicts

### DIFF
--- a/tests/zenko_e2e/conf.py
+++ b/tests/zenko_e2e/conf.py
@@ -1,5 +1,6 @@
 import os
 from datetime import timedelta
+import uuid
 import requests
 
 
@@ -26,6 +27,8 @@ def strip_port(url):
 def baseurl(url):
     return strip_port(strip_proto(url))
 
+
+OBJ_PREFIX = '-'.join(['test', uuid.uuid4().hex])
 
 SERVICEACCOUNT_PATH = '/var/run/secrets/kubernetes.io/serviceaccount'
 

--- a/tests/zenko_e2e/fixtures/object.py
+++ b/tests/zenko_e2e/fixtures/object.py
@@ -3,16 +3,15 @@ import zenko_e2e.conf as conf
 import zenko_e2e.util as util
 
 
-@pytest.fixture
+@pytest.fixture(scope='function')
 def objkey():
-    return util.make_name('test-object')
+    return '/'.join([conf.OBJ_PREFIX, util.make_name('test-object')])
 
 
 @pytest.fixture
-def empty_object(zenko_bucket):
+def empty_object(zenko_bucket, objkey):
     zenko_bucket.create()
-    name = util.gen_bucket_name('test-object')
-    return zenko_bucket.Object(name)
+    return zenko_bucket.Object(objkey)
 
 
 @pytest.fixture
@@ -27,8 +26,8 @@ def metadata_object(empty_object, emptyfile):
 @pytest.fixture
 def metadata_multi(zenko_bucket, emptyfile):
     zenko_bucket.create()
-    name1 = util.gen_bucket_name('test-object')
-    name2 = util.gen_bucket_name('test-object')
+    name1 = objkey()
+    name2 = objkey()
     obj1 = zenko_bucket.Object(name1)
     obj2 = zenko_bucket.Object(name2)
     obj1.put(

--- a/tests/zenko_e2e/util/bucket.py
+++ b/tests/zenko_e2e/util/bucket.py
@@ -107,7 +107,9 @@ def cleanup_bucket(bucket, replicated=False, delete_bucket=True): # noqa pylint:
             objects = []
             versions = version_list['Versions']
             for v in versions:  # pylint: disable=invalid-name
-                objects.append({'VersionId': v['VersionId'], 'Key': v['Key']})
+                if v['Key'].startswith(conf.OBJ_PREFIX):
+                    objects.append(
+                        {'VersionId': v['VersionId'], 'Key': v['Key']})
             response = client.delete_objects(
                 Bucket=bucket_name, Delete={'Objects': objects})
             print(response)
@@ -118,7 +120,9 @@ def cleanup_bucket(bucket, replicated=False, delete_bucket=True): # noqa pylint:
             objects = []
             delete_markers = version_list['DeleteMarkers']
             for d in delete_markers:  # pylint: disable=invalid-name
-                objects.append({'VersionId': d['VersionId'], 'Key': d['Key']})
+                if d['Key'].startswith(conf.OBJ_PREFIX):
+                    objects.append(
+                        {'VersionId': d['VersionId'], 'Key': d['Key']})
             response = client.delete_objects(
                 Bucket=bucket_name, Delete={'Objects': objects})
             print(response)


### PR DESCRIPTION
This adds a per run prefix to objects and then checks for the prefix before deleting objects. This is to prevent concurrent test runs from deleting each others objects and causing a incorrect test failure.