### PR TITLE
ZENKO-782 ft: add replication factor to cloud server

### DIFF
--- a/charts/cloudserver/templates/_helpers.tpl
+++ b/charts/cloudserver/templates/_helpers.tpl
@@ -39,3 +39,12 @@ Create the default mongodb replicaset hosts string
 {{- $release := .Release.Name -}}
 {{- range $v := until $count }}{{ $release }}-mongodb-replicaset-{{ $v }}.{{ $release }}-mongodb-replicaset:27017{{ if ne $v (sub $count 1) }},{{- end -}}{{- end -}}
 {{- end -}}
+
+{{/*
+Increases the number of cloudserver replicas by the replicaFactor value
+*/}}
+{{- define "cloudserver.replicaFactor" -}}
+{{- $factor := mul .Values.replicaFactor .Values.replicaCount -}}
+{{- printf "%d" $factor }}
+{{- end -}}
+

--- a/charts/cloudserver/templates/deployment.yaml
+++ b/charts/cloudserver/templates/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ template "cloudserver.replicaFactor" . }}
   selector:
     matchLabels:
       app: {{ template "cloudserver.name" . }}

--- a/charts/cloudserver/values.yaml
+++ b/charts/cloudserver/values.yaml
@@ -31,11 +31,12 @@ mongodb:
   replicaSet: rs0
   replicas: 3
 
-# When Orbit is enabled, there will be an additional fully stateless replica
-# added which serves as the "manager" for reporting metrics. For example,
-# with a "replicaCount: 2" and Orbit management enabled, there would be a
-# total of 3 pods deployed (2 worker replicas + 1 manager).
-replicaCount: 2
+# Replication factor will deploy n * replicaCount for deployments that need
+# not only HA but high performance and throughput. When Orbit is enabled, there 
+# will be an additional stateless single manager pod deployed which serves as the 
+# "manager" for reporting metrics. This manager pod currently cannot scale replicas.
+replicaCount: 3
+replicaFactor: 1
 
 image:
   repository: zenko/cloudserver

--- a/charts/zenko/values.yaml
+++ b/charts/zenko/values.yaml
@@ -25,6 +25,8 @@ ingress:
     #     - zenko.example.com
 
 cloudserver:
+  replicaCount: *nodeCount
+  replicaFactor: 10
   mongodb:
     replicas: *nodeCount
   orbit:


### PR DESCRIPTION
Adds replica factor options to cloudserver chart. Default replicaFactor for Zenko values is set to 10 but within the cloudserver chart is 1.