### PR TITLE
feature: ZENKO-846 Add retry test

### DIFF
--- a/tests/backbeat/Using.md
+++ b/tests/backbeat/Using.md
@@ -124,3 +124,34 @@
 
 7. Run the test suite: `npm run test_api` for API tests, or
    `npm run test_crr_pause_resume` for CRR pause and resume tests.
+
+### Retry tests
+
+1. Create a bucket on AWS `<destination-fail-aws-bucket-name>` with versioning
+   enabled.
+2. In Orbit, create an AWS location `<destination-fail-aws-location-name>` with
+   an AWS bucket `<destination-fail-aws-bucket-name>`.
+3. Export the keys, AWS bucket name, and AWS location (for example, in `.env`
+   and `.secrets.env`):
+
+```
+export AWS_S3_BACKEND_ACCESS_KEY=<aws-access-key>
+export AWS_S3_BACKEND_SECRET_KEY=<aws-secret-key>
+export AWS_S3_FAIL_BACKBEAT_BUCKET_NAME=<destination-fail-aws-bucket-name>
+export AWS_S3_FAIL_BACKEND_DESTINATION_LOCATION=<destination-fail-aws-bucket-name>
+```
+
+4. If using `*.env` files, source the files:
+
+```
+source .env && source .secrets.env
+```
+
+6. Update the backbeat configuration properties as such:
+
+```
+extensions.replication.queueProcessor.retryTimeoutS: 1
+extensions.replication.replicationStatusProcessor.retryTimeoutS: 1
+```
+
+7. Run the test suite: `npm run test_retry`.

--- a/tests/backbeat/package.json
+++ b/tests/backbeat/package.json
@@ -21,6 +21,7 @@
   "scripts": {
     "test_crr": "mocha --exit -t 10000 --recursive tests/crr",
     "test_api": "mocha --exit -t 10000 --recursive tests/api",
+    "test_retry": "mocha --exit -t 10000 --recursive tests/retry",
     "test_crr_pause_resume": "mocha --exit -t 10000 --recursive tests/crr-pause-resume"
   },
   "author": ""

--- a/tests/backbeat/tests/crr/azureBackend.js
+++ b/tests/backbeat/tests/crr/azureBackend.js
@@ -34,9 +34,9 @@ describe('Replication with Azure backend', function() {
     ], done));
 
     afterEach(done => series([
-        next => utils.deleteVersionedBucket(srcBucket, next),
         next => utils.deleteAllBlobs(destContainer, `${srcBucket}/${keyPrefix}`,
             next),
+        next => utils.deleteVersionedBucket(srcBucket, next),
     ], done));
 
     it('should replicate an object', done => series([

--- a/tests/backbeat/tests/retry/retry.js
+++ b/tests/backbeat/tests/retry/retry.js
@@ -1,0 +1,166 @@
+const assert = require('assert');
+const crypto = require('crypto');
+const { series, parallel, times, timesSeries, doWhilst } = require('async');
+
+const { scalityS3Client, awsS3Client } = require('../../s3SDK');
+const ReplicationUtility = require('../../ReplicationUtility');
+const { makeGETRequest, makePOSTRequest, getResponseBody } =
+    require('../../utils/request');
+
+const scalityUtils = new ReplicationUtility(scalityS3Client);
+const awsUtils = new ReplicationUtility(awsS3Client);
+const srcBucket = `source-bucket-${Date.now()}`;
+const destFailBucket = process.env.AWS_S3_FAIL_BACKBEAT_BUCKET_NAME;
+const destFailLocation = process.env.AWS_S3_FAIL_BACKEND_DESTINATION_LOCATION;
+
+const hex = crypto.createHash('md5')
+    .update(Math.random().toString())
+    .digest('hex');
+const keyPrefix = `${srcBucket}/${hex}`;
+const key = `object-to-replicate-${Date.now()}`;
+const REPLICATION_TIMEOUT = 1200000;
+
+function checkMetrics(prevBacklog, prevCompletions, prevFailures, body) {
+    const { backlog, completions, failures } = body;
+    assert.strictEqual((backlog.results.count - prevBacklog.count), 0);
+    assert.strictEqual((backlog.results.size - prevBacklog.size), 0);
+    assert.strictEqual((completions.results.count - prevCompletions.count), 1);
+    assert.strictEqual((completions.results.size - prevCompletions.size), 1);
+    assert.strictEqual((failures.results.count - prevFailures.count), 0);
+    assert.strictEqual((failures.results.size - prevFailures.size), 0);
+}
+
+function performRetries(keys, done) {
+    return series([
+       next => awsUtils.deleteVersionedBucket(destFailBucket, next),
+       next => times(keys.length, (n, cb) =>
+           scalityUtils.putObject(srcBucket, keys[n], Buffer.alloc(1),
+                cb),
+        next),
+        next => times(keys.length, (n, cb) =>
+            scalityUtils.waitWhilePendingCRR(srcBucket, keys[n], cb),
+        next),
+        next => times(keys.length, (n, cb) =>
+            scalityUtils.getHeadObject(srcBucket, keys[n],
+            (err, data) => {
+                if (err) {
+                   return cb(err);
+                }
+                const { ReplicationStatus, Metadata, VersionId } = data;
+                versionId = VersionId;
+                assert.strictEqual(ReplicationStatus, 'FAILED');
+                assert.strictEqual(
+                   Metadata[`${destFailLocation}-replication-status`],
+                   'FAILED');
+                setTimeout(function () {
+                    return cb();
+                }, 5000)
+            }),
+        next),
+        next => makeGETRequest('/_/backbeat/api/crr/failed',
+            (err, res) => {
+                assert.ifError(err);
+                return getResponseBody(res, (err, body) => {
+                    assert.ifError(err);
+                    postBody = JSON.stringify(body.Versions);
+                    next();
+                });
+            }),
+        next => awsUtils.createVersionedBucket(destFailBucket, next),
+        next => makePOSTRequest('/_/backbeat/api/crr/failed', postBody,
+            (err, res) => {
+                assert.ifError(err);
+                return getResponseBody(res, (err, body) => {
+                    assert.ifError(err);
+                    return next();
+                });
+            }),
+        next => times(keys.length, (n, cb) =>
+            scalityUtils.waitWhileFailedCRR(srcBucket, keys[n], cb),
+        next),
+        next => timesSeries(keys.length, (n, cb) =>
+            scalityUtils.compareObjectsAWS(srcBucket, destFailBucket,
+                keys[n], undefined, cb),
+        next),
+    ], done);
+}
+
+describe('Backbeat replication retry', function() {
+    this.timeout(REPLICATION_TIMEOUT);
+    const roleArn = 'arn:aws:iam::root:role/s3-replication-role';
+
+    beforeEach(done => series([
+        next => scalityUtils.createVersionedBucket(srcBucket, next),
+        next => scalityUtils.putBucketReplicationMultipleBackend(srcBucket,
+            destFailBucket, roleArn, destFailLocation, next),
+    ], done));
+
+    afterEach(done => parallel([
+        next => scalityUtils.deleteVersionedBucket(srcBucket, next),
+        next => awsUtils.deleteAllVersions(destFailBucket,
+            `${srcBucket}/${keyPrefix}`, next),
+    ], done));
+
+    [1, 2, 128].forEach(N => {
+        it(`should retry ${N} failed object(s)`, done => {
+            let versionId;
+            let postBody;
+            const keys = [];
+            for (let i = 0; i < N; i++) {
+                keys.push(`${key}-${i}`);
+            }
+            return performRetries(keys, done);
+        });
+    });
+
+    it('should get correct CRR metrics when a retry occurs', function(done) {
+        this.retries(2); // Test is dependent on metrics not expiring.
+        const path = `/_/backbeat/api/metrics/crr/${destFailLocation}`;
+        let prevBacklog;
+        let prevCompletions;
+        let prevFailures;
+        return series([
+            next => makeGETRequest(path, (err, res) => {
+                assert.ifError(err);
+                assert.equal(res.statusCode, 200);
+                getResponseBody(res, (err, body) => {
+                    assert.ifError(err);
+                    prevBacklog = body.backlog.results;
+                    prevCompletions = body.completions.results;
+                    prevFailures = body.failures.results;
+                    return next();
+                });
+            }),
+            next => performRetries([key], next),
+            next => {
+                let shouldContinue = false;
+                return doWhilst(callback =>
+                    makeGETRequest(path, (err, res) => {
+                        assert.ifError(err);
+                        assert.strictEqual(res.statusCode, 200);
+                        getResponseBody(res, (err, body) => {
+                            assert.ifError(err);
+                            const { results } = body.completions;
+                            // We have potentially reached an expiration of
+                            // metrics. In this case, the test's retry should
+                            // avoid continued failure since metrics expire only
+                            // after fifteen minutes.
+                            assert(results.count >= prevCompletions.count,
+                                'the completions result count was decremented');
+                            // If the operation is still in the backlog,
+                            // continue until the metric has been updated.
+                            const delta = results.count - prevCompletions.count;
+                            shouldContinue = delta === 0;
+                            if (shouldContinue) {
+                                return setTimeout(callback, 2000);
+                            }
+                            checkMetrics(prevBacklog, prevCompletions,
+                                prevFailures, body);
+                            return callback();
+                        });
+                    }),
+                () => shouldContinue, next);
+            },
+        ], done);
+    });
+});


### PR DESCRIPTION
Adds the following test cases:
* Tests for failed CRR retries (a single retry and up to 128 concurrent retries). 
* Test checking that the CRR metrics are properly updated when a retry occurs.

Automating these tests is proving especially challenging since we need to update the backbeat pod such that exponential back-off is very short (i.e. one second), so requires a unique backbeat pod with its configuration updated as such. Also, the test relies on deleting and recreating the destination bucket to create failures. This use of buckets is unreliable when multiple tests are using that same bucket. Ideas for strategies to automate these tests are welcome!