### PR TITLE
bf: ZENKO-916 modify ACL replication test case

### DIFF
--- a/charts/cloudserver/values.yaml
+++ b/charts/cloudserver/values.yaml
@@ -79,7 +79,7 @@ replicaFactor: 1
 
 image:
   repository: zenko/cloudserver
-  tag: 8.0.8-RC4
+  tag: 8.0.9
   pullPolicy: IfNotPresent
 
 proxy:

--- a/tests/node_tests/backbeat/ReplicationUtility.js
+++ b/tests/node_tests/backbeat/ReplicationUtility.js
@@ -507,6 +507,20 @@ class ReplicationUtility {
         this.azure.deleteBlob(containerName, blob, options, cb);
     }
 
+    expectReplicationStatus(bucketName, key, versionId, expectedStatus, cb) {
+        this.s3.headObject({
+            Bucket: bucketName,
+            Key: key,
+            VersionId: versionId,
+        }, (err, data) => {
+            if (err) {
+                return cb(err);
+            }
+            assert.strictEqual(data.ReplicationStatus, expectedStatus);
+            return cb();
+        });
+    }
+
     // Continue getting head object while the status is PENDING or PROCESSING.
     waitUntilReplicated(bucketName, key, versionId, cb) {
         let status;

--- a/tests/node_tests/backbeat/tests/crr/awsBackend.js
+++ b/tests/node_tests/backbeat/tests/crr/awsBackend.js
@@ -110,12 +110,14 @@ describe('Replication with AWS backend', function() {
                                                      next),
         ], done)));
 
-    // Object ACLs would not be applicable on AWS.
+    // Object ACLs would not be applicable on AWS: they should not
+    // trigger a replication task at all (i.e. stay in COMPLETED status)
     it('should not replicate object ACL', done => series([
         next => scalityUtils.putObject(srcBucket, key, Buffer.alloc(1), next),
         next => scalityUtils.compareACLsAWS(srcBucket, destBucket, key, next),
         next => scalityUtils.putObjectACL(srcBucket, key, next),
-        next => scalityUtils.compareACLsAWS(srcBucket, destBucket, key, next),
+        next => scalityUtils.expectReplicationStatus(srcBucket, key, undefined,
+                                                     'COMPLETED', next),
     ], done));
 
     it('should put delete marker on destination bucket when deleting the ' +


### PR DESCRIPTION
Instead of waiting for replication and expecting no change, expect the
replication status to stay COMPLETED. This because we don't want ACLs
to trigger a replication at all as it would break transient source by
reading the data from the local source which has been deleted already.
