### PR TITLE
ZENKO-1001 bugfix: Prometheus upgrades from RC4

### DIFF
--- a/charts/prometheus/README.md
+++ b/charts/prometheus/README.md
@@ -128,6 +128,9 @@ Parameter | Description | Default
 `alertmanager.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
 `alertmanager.service.servicePort` | alertmanager service port | `80`
 `alertmanager.service.type` | type of alertmanager service to create | `ClusterIP`
+`alertmanager.headless.annotations` | annotations for alertmanager headless service | `{}`
+`alertmanager.headless.labels` | labels for alertmanager headless service | `{}`
+`alertmanager.headless.servicePort` | alertmanager headless service port | `80`
 `alertmanagerFiles.alertmanager.yml` | Prometheus alertmanager configuration | example configuration
 `configmapReload.name` | configmap-reload container name | `configmap-reload`
 `configmapReload.image.repository` | configmap-reload container image repository | `jimmidyson/configmap-reload`
@@ -253,6 +256,9 @@ Parameter | Description | Default
 `server.service.nodePort` | Port to be used as the service NodePort (ignored if `server.service.type` is not `NodePort`) | `0`
 `server.service.servicePort` | Prometheus server service port | `80`
 `server.service.type` | type of Prometheus server service to create | `ClusterIP`
+`server.headless.annotations` | annotations for Prometheus server headless service | `{}`
+`server.headless.labels` | labels for Prometheus server headless service | `{}`
+`server.headless.servicePort` | Prometheus server headless service port | `80`
 `serviceAccounts.alertmanager.create` | If true, create the alertmanager service account | `true`
 `serviceAccounts.alertmanager.name` | name of the alertmanager service account to use or create | `{{ prometheus.alertmanager.fullname }}`
 `serviceAccounts.kubeStateMetrics.create` | If true, create the kubeStateMetrics service account | `true`

--- a/charts/prometheus/templates/alertmanager-service-headless.yaml
+++ b/charts/prometheus/templates/alertmanager-service-headless.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.alertmanager.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Values.alertmanager.headless.annotations }}
+  annotations:
+{{ toYaml .Values.alertmanager.headless.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app: {{ template "prometheus.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.alertmanager.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- if .Values.alertmanager.headless.labels }}
+{{ toYaml .Values.alertmanager.headless.labels | indent 4 }}
+{{- end }}
+  name: {{ template "prometheus.alertmanager.fullname" . }}-headless
+spec:
+  clusterIP: None
+  ports:
+    - name: http
+      port: {{ .Values.alertmanager.headless.servicePort }}
+      protocol: TCP
+      targetPort: 9093
+{{- if .Values.alertmanager.headless.enableMeshPeer }}
+    - name: meshpeer
+      port: 6783
+      protocol: TCP
+      targetPort: 6783
+{{- end }}
+  selector:
+    app: {{ template "prometheus.name" . }}
+    component: "{{ .Values.alertmanager.name }}"
+    release: {{ .Release.Name }}
+{{- end }}

--- a/charts/prometheus/templates/alertmanager-statefulset.yaml
+++ b/charts/prometheus/templates/alertmanager-statefulset.yaml
@@ -16,6 +16,7 @@ spec:
       app: {{ template "prometheus.name" . }}
       release: {{ .Release.Name }}
   replicas: {{ .Values.alertmanager.replicaCount }}
+  podManagementPolicy: Parallel
   template:
     metadata:
     {{- if .Values.alertmanager.podAnnotations }}

--- a/charts/prometheus/templates/server-service-headless.yaml
+++ b/charts/prometheus/templates/server-service-headless.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Values.server.headless.annotations }}
+  annotations:
+{{ toYaml .Values.server.headless.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app: {{ template "prometheus.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: "{{ .Values.server.name }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- if .Values.server.headless.labels }}
+{{ toYaml .Values.server.headless.labels | indent 4 }}
+{{- end }}
+  name: {{ template "prometheus.server.fullname" . }}-headless
+spec:
+  clusterIP: None
+  ports:
+    - name: http
+      port: {{ .Values.server.headless.servicePort }}
+      protocol: TCP
+      targetPort: 9090
+  selector:
+    app: {{ template "prometheus.name" . }}
+    component: "{{ .Values.server.name }}"
+    release: {{ .Release.Name }}

--- a/charts/prometheus/templates/server-statefulset.yaml
+++ b/charts/prometheus/templates/server-statefulset.yaml
@@ -19,6 +19,7 @@ spec:
       app: {{ template "prometheus.name" . }}
       release: {{ .Release.Name }}
   replicas: {{ .Values.server.replicaCount }}
+  podManagementPolicy: Parallel
   template:
     metadata:
     {{- if .Values.server.podAnnotations }}

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -176,10 +176,7 @@ alertmanager:
   service:
     annotations: {}
     labels: {}
-
-    # Exposed as a headless service:
-    # https://kubernetes.io/docs/concepts/services-networking/service/#headless-services
-    clusterIP: None
+    clusterIP: ""
 
     ## Enabling peer mesh service end points for enabling the HA alert manager
     ## Ref: https://github.com/prometheus/alertmanager/blob/master/README.md
@@ -195,6 +192,16 @@ alertmanager:
     servicePort: 80
     # nodePort: 30000
     type: ClusterIP
+
+  headless:
+    annotations: {}
+    labels: {}
+
+    ## Enabling peer mesh service end points for enabling the HA alert manager
+    ## Ref: https://github.com/prometheus/alertmanager/blob/master/README.md
+    # enableMeshPeer : true
+
+    servicePort: 80
 
 ## Monitors ConfigMap changes and POSTs to a URL
 ## Ref: https://github.com/jimmidyson/configmap-reload
@@ -619,10 +626,7 @@ server:
   service:
     annotations: {}
     labels: {}
-
-    # Exposed as a headless service:
-    # https://kubernetes.io/docs/concepts/services-networking/service/#headless-services
-    clusterIP: None
+    clusterIP: ""
 
     ## List of IP addresses at which the Prometheus server service is available
     ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
@@ -633,6 +637,11 @@ server:
     loadBalancerSourceRanges: []
     servicePort: 80
     type: ClusterIP
+
+  headless:
+    annotations: {}
+    labels: {}
+    servicePort: 80
 
   ## Prometheus server pod termination grace period
   ##

--- a/tests/zenko_e2e/conftest.py
+++ b/tests/zenko_e2e/conftest.py
@@ -57,7 +57,7 @@ def prometheus_client():
 
     url = os.getenv('PROMETHEUS_ENDPOINT')
     if not url:
-        url = 'http://{}-prometheus-server:9090'.format(zenko_helm_release())
+        url = 'http://{}-prometheus-server:80'.format(zenko_helm_release())
 
     return zenko_e2e.prometheus.client.PrometheusClient(prometheus_url=url)
 

--- a/tests/zenko_e2e/prometheus/test_basic.py
+++ b/tests/zenko_e2e/prometheus/test_basic.py
@@ -18,6 +18,7 @@ POD = 'kubernetes-pods'
 @pytest.mark.parametrize('job,name', [
     (SERVICE, '{}-cloudserver'.format(zenko_helm_release())),
     (POD, '{}-zenko-queue-0'.format(zenko_helm_release())),
+    (POD, '{}-mongodb-replicaset-0'.format(zenko_helm_release())),
 ])
 def test_prometheus_targets(prometheus_client, k8s_namespace,
                             zenko_helm_release, job, name):


### PR DESCRIPTION
These changes allow Prometheus upgrades from RC4 (and older)
to be smooth for the Pre-GA release (and possibly future releases).