### PR TITLE
Bump versions to RC5

### DIFF
--- a/eve/ci-values.yml
+++ b/eve/ci-values.yml
@@ -48,6 +48,7 @@ cloudserver:
   replicaCount: 0
   env:
     MPU_TESTING: 'yes'
+    PUSH_STATS: 'false'
 
 backbeat:
   lifecycle:

--- a/kubernetes/zenko/Chart.yaml
+++ b/kubernetes/zenko/Chart.yaml
@@ -1,6 +1,6 @@
 name: zenko
-version: 1.0.0
-appVersion: 1.0.0
+version: 1.0.0-RC5
+appVersion: 1.0.0-RC5
 kubeVersion: "^1.8.0-0"
 description: Zenko is the open source multi-cloud data controller
 home: https://www.zenko.io/

--- a/kubernetes/zenko/charts/backbeat/Chart.yaml
+++ b/kubernetes/zenko/charts/backbeat/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Zenko Backbeat
 name: backbeat
-version: 1.0.0
+version: 1.0.0-RC5

--- a/kubernetes/zenko/charts/backbeat/values.yaml
+++ b/kubernetes/zenko/charts/backbeat/values.yaml
@@ -10,7 +10,7 @@ global:
 
 image:
   repository: zenko/backbeat
-  tag: 8.0.7-RC4
+  tag: 8.0.8-RC5
   pullPolicy: IfNotPresent
 
 logging:

--- a/kubernetes/zenko/charts/cloudserver/Chart.yaml
+++ b/kubernetes/zenko/charts/cloudserver/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.1.5"
 description: A Helm chart for Kubernetes
 name: cloudserver
-version: 1.0.0
+version: 1.0.0-RC5

--- a/kubernetes/zenko/charts/cloudserver/values.yaml
+++ b/kubernetes/zenko/charts/cloudserver/values.yaml
@@ -79,7 +79,7 @@ replicaFactor: 1
 
 image:
   repository: zenko/cloudserver
-  tag: 8.0.9
+  tag: 8.0.10-RC5
   pullPolicy: IfNotPresent
 
 proxy:

--- a/kubernetes/zenko/charts/s3-data/Chart.yaml
+++ b/kubernetes/zenko/charts/s3-data/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: s3-data
-version: 1.0.0
+version: 1.0.0-RC5

--- a/kubernetes/zenko/charts/s3-data/values.yaml
+++ b/kubernetes/zenko/charts/s3-data/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: zenko/cloudserver
-  tag: 8.0.9
+  tag: 8.0.10-RC5
   pullPolicy: IfNotPresent
 service:
   name: s3-data


### PR DESCRIPTION
## Cloudserver CHANGELOG
* Merge branch 'feature/ZENKO-925-increaseMetricsExpiry' into q/8.0
* ft: ZENKO-925 increase metrics expiry to 24hrs
* ZNC-22: DOC: Add developer bootstrap guide
* Merge branch 'bugfix/ZENKO-903/getBucketListOnReport' into q/8.0
* Merge branch 'bugfix/ZENKO-916-doNotReplicateACLChange' into q/8.0
* bf: ZENKO-903 add tests for report itemCount
* improvement: update arsenal
* bf: ZENKO-922 add redis disconnect tests
* bf: ZENKO-916 do not replicate ACL change
* Merge remote-tracking branch 'origin/bugfix/S3C-1586/listing_while_upgrade' into w/8.0/bugfix/S3C-1586/listing_while_upgrade
* Do not parse list entries from MD6.4.7

## Backbeat CHANGELOG:
* Merge branch 'feature/ZENKO-925-increaseMetricsExpiry' into q/8.0
* ft: increase metrics expiry window to 24hrs
* bf: ZENKO-917 publish consumer current offset to zk