### PR TITLE
ZENKO-1004: fix flaky nodejs E2E tests

### DIFF
--- a/tests/node_tests/backbeat/ReplicationUtility.js
+++ b/tests/node_tests/backbeat/ReplicationUtility.js
@@ -627,21 +627,12 @@ class ReplicationUtility {
 
     compareObjectsAWS(srcBucket, destBucket, key, optionalField, cb) {
         return async.series([
-            next => this.waitUntilReplicated(srcBucket, key, undefined, err => {
-                console.log('compareObjectsAWS:waitUntilReplicated', err);
-                return next(err);
-            }),
-            next => this.getObject(srcBucket, key, (err, data) => {
-                console.log('compareObjectsAWS:getObject', err, data);
-                return next(err, data);
-            }),
+            next => this.waitUntilReplicated(srcBucket, key, undefined, next),
+            next => this.getObject(srcBucket, key, next),
             next => this._setS3Client(awsS3Client)
-                .getObject(destBucket, `${srcBucket}/${key}`, (err, data) => {
-                    console.log('compareObjectsAWS:getObject', err, data);
-                    return next(err, data);
-                }),
+                .getObject(destBucket, `${srcBucket}/${key}`, next),
         ], (err, data) => {
-            console.log('data from  compareObjectsAWS', data);
+            console.log('compareObjectsAWS', err, data);
             this._setS3Client(scalityS3Client);
             if (err) {
                 return cb(err);
@@ -697,29 +688,17 @@ class ReplicationUtility {
 
     compareObjectsAzure(srcBucket, containerName, key, cb) {
         return async.series([
-            next => this.waitUntilReplicated(srcBucket, key, undefined, err => {
-                console.log('compareObjectsAzure:waitUntilReplicated', err);
-                return next(err);
-            }),
-            next => this.getObject(srcBucket, key, (err, data) => {
-                console.log('compareObjectsAzure:getObject', err, data);
-                return next(err, data);
-            }),
+            next => this.waitUntilReplicated(srcBucket, key, undefined, next),
+            next => this.getObject(srcBucket, key, next),
             next => this.azure.getBlobProperties(containerName,
-                `${srcBucket}/${key}`, (err, data) => {
-                    console.log('compareObjectsAzure:getBlobProperties', err, data);
-                    return next(err, data);
-                }),
+                `${srcBucket}/${key}`, next),
             next => this.getBlob(containerName,
-                `${srcBucket}/${key}`, (err, data) => {
-                    console.log('compareObjectsAzure:getBlob', err, data);
-                    return next(err, data);
-                }),
+                `${srcBucket}/${key}`, next),
         ], (err, data) => {
+            console.log('compareObjectsAzure err and data', err, data);
             if (err) {
                 return cb(err);
             }
-            console.log('data from compareObjectsAzure', data);
             const srcData = data[1];
             const destProperties = data[2];
             const destPropResult = destProperties[0];
@@ -749,25 +728,14 @@ class ReplicationUtility {
     compareObjectsGCP(srcBucket, destBucket, key, cb) {
         return async.series({
             wait: next =>
-                this.waitUntilReplicated(srcBucket, key, undefined, err => {
-                    console.log('compareObjectsGCP:waitUntilReplicated', err);
-                    return next(err);
-                }),
-            srcData: next => this.getObject(srcBucket, key, (err, data) => {
-                console.log('compareObjectsGCP:getObject', err, data);
-                return next(err, data);
-            }),
+                this.waitUntilReplicated(srcBucket, key, undefined, next),
+            srcData: next => this.getObject(srcBucket, key, next),
             destMetadata: next => this.getMetadata(destBucket,
-                `${srcBucket}/${key}`, (err, data) => {
-                    console.log('compareObjectsGCP:getMetadata', err, data);
-                    return next(err, data);
-                }),
+                `${srcBucket}/${key}`, next),
             destData: next => this.download(destBucket,
-                `${srcBucket}/${key}`, (err, data) => {
-                    console.log('compareObjectsGCP:download', err, data);
-                    return next(err, data);
-                }),
+                `${srcBucket}/${key}`, next),
         }, (err, data) => {
+            console.log('compareObjectsGCP, ', err, data);
             if (err) {
                 return cb(err);
             }

--- a/tests/node_tests/backbeat/tests/crr/awsBackend.js
+++ b/tests/node_tests/backbeat/tests/crr/awsBackend.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const crypto = require('crypto');
+const uuid = require('uuid/v4');
 const { series, parallel, timesSeries, each } = require('async');
 
 const { scalityS3Client, awsS3Client } = require('../../../s3SDK');
@@ -7,18 +8,11 @@ const ReplicationUtility = require('../../ReplicationUtility');
 
 const scalityUtils = new ReplicationUtility(scalityS3Client);
 const awsUtils = new ReplicationUtility(awsS3Client);
-const srcBucket = `source-bucket-${Date.now()}`;
 const destBucket = process.env.AWS_S3_BACKBEAT_BUCKET_NAME;
 const destLocation = process.env.AWS_S3_BACKEND_DESTINATION_LOCATION;
 const hex = crypto.createHash('md5')
     .update(Math.random().toString())
     .digest('hex');
-const keyPrefix = `${srcBucket}/${hex}`;
-const key = `${keyPrefix}/object-to-replicate-${Date.now()}`;
-const copyKey = `${key}-copy`;
-const copySource = `/${srcBucket}/${key}`;
-// eslint-disable-next-line
-const keyutf8 = `${keyPrefix}/%EA%9D%8崰㈌㒈保轖䳷䀰⺩ቆ楪僷ꈅꓜ퇬枅࿷염곞召㸾⌙ꪊᆐ庍뉆䌗↎幐냂詴 끴鹲萯⇂쫤ᛩ꺶㖭簹릍铰᫫暨鿐魪셑蛃춧㡡竺뫁噛̷ᗰⷑ錜⑔痴䧫㾵᏷ำꎆ꼵껪멷㄀誕㳓腜쒃컹㑻鳃삚舿췈孨੦⮀Ǌ곓⵪꺼꜈嗼뫘悕錸瑺⁤⑬১㵀⡸Ҏ礄䧛졼⮦ٞ쫁퓡垻ㆩꝿ詀펉ᆙ舑䜾힑藪碙ꀎꂰ췊Ᏻ   㘺幽醛잯ද汧Ꟑꛒⶨ쪸숞헹㭔ꡔᘼ뺓ᡆ᡾ᑟ䅅퀭耓弧⢠⇙폪ް蛧⃪Ἔ돫ꕢ븥ヲ캂䝄쟐颺ᓾ둾Ұ껗礞ᾰ瘹蒯硳풛瞋襎奺熝妒컚쉴⿂㽝㝳駵鈚䄖戭䌸᫲ᇁ䙪鸮ᐴ稫ⶭ뀟ھ⦿䴳稉ꉕ捈袿놾띐✯伤䃫⸧ꠏ瘌틳藔ˋ㫣敀䔩㭘식↴⧵佶痊牌ꪌ搒꾛æᤈべ쉴挜炩⽍舘ꆗ줣徭Z䐨 敗羥誜嘳ֶꫜ걵ࣀ묟ኋ拃秷䨸菥䟆곘縧멀煣⧃⏶혣뎧邕⢄⭖陙䣎灏ꗛ僚䌁䠒䲎둘ꪎ傩쿌ᨌ뀻阥눉넠猌ㆯ㰢船戦跏灳蝒礯鞰諾벥煸珬㟑孫鞹Ƭꄹ孙ꢱ钐삺ᓧ鈠䁞〯蘼᫩헸ῖ"`;
 const REPLICATION_TIMEOUT = 300000;
 
 describe('Replication with AWS backend', function() {
@@ -26,129 +20,196 @@ describe('Replication with AWS backend', function() {
     this.retries(3);
     let roleArn = 'arn:aws:iam::root:role/s3-replication-role';
 
-    beforeEach(done => series([
-        next => scalityUtils.createVersionedBucket(srcBucket, next),
-        next => scalityUtils.putBucketReplicationMultipleBackend(srcBucket,
-            destBucket, roleArn, destLocation, next),
-    ], done));
+    beforeEach(function beforeEachF(done) {
+        this.currentTest.srcBucket =
+            `source-bucket-${uuid().replace(/-/g, '')}`;
+        this.currentTest.keyPrefix =
+            `${this.currentTest.srcBucket}/${hex}`;
+        this.currentTest.key =
+            `${this.currentTest.keyPrefix}/object-to-replicate-` +
+            `${uuid().replace(/-/g, '')}`;
+        this.currentTest.copyKey = `${this.currentTest.key}-copy`;
+        this.currentTest.copySource =
+            `/${this.currentTest.srcBucket}/${this.currentTest.key}`;
+        // eslint-disable-next-line
+        this.currentTest.keyutf8 = `${this.currentTest.keyPrefix}/%EA%9D%8崰㈌㒈保轖䳷䀰⺩ቆ楪僷ꈅꓜ퇬枅࿷염곞召㸾⌙ꪊᆐ庍뉆䌗↎幐냂詴 끴鹲萯⇂쫤ᛩ꺶㖭簹릍铰᫫暨鿐魪셑蛃춧㡡竺뫁噛̷ᗰⷑ錜⑔痴䧫㾵᏷ำꎆ꼵껪멷㄀誕㳓腜쒃컹㑻鳃삚舿췈孨੦⮀Ǌ곓⵪꺼꜈嗼뫘悕錸瑺⁤⑬১㵀⡸Ҏ礄䧛졼⮦ٞ쫁퓡垻ㆩꝿ詀펉ᆙ舑䜾힑藪碙ꀎꂰ췊Ᏻ   㘺幽醛잯ද汧Ꟑꛒⶨ쪸숞헹㭔ꡔᘼ뺓ᡆ᡾ᑟ䅅퀭耓弧⢠⇙폪ް蛧⃪Ἔ돫ꕢ븥ヲ캂䝄쟐颺ᓾ둾Ұ껗礞ᾰ瘹蒯硳풛瞋襎奺熝妒컚쉴⿂㽝㝳駵鈚䄖戭䌸᫲ᇁ䙪鸮ᐴ稫ⶭ뀟ھ⦿䴳稉ꉕ捈袿놾띐✯伤䃫⸧ꠏ瘌틳藔ˋ㫣敀䔩㭘식↴⧵佶痊牌ꪌ搒꾛æᤈべ쉴挜炩⽍舘ꆗ줣徭Z䐨 敗羥誜嘳ֶꫜ걵ࣀ묟ኋ拃秷䨸菥䟆곘縧멀煣⧃⏶혣뎧邕⢄⭖陙䣎灏ꗛ僚䌁䠒䲎둘ꪎ傩쿌ᨌ뀻阥눉넠猌ㆯ㰢船戦跏灳蝒礯鞰諾벥煸珬㟑孫鞹Ƭꄹ孙ꢱ钐삺ᓧ鈠䁞〯蘼᫩헸ῖ"`;
+        return series([
+            next => scalityUtils.createVersionedBucket(
+                this.currentTest.srcBucket, next),
+            next => scalityUtils.putBucketReplicationMultipleBackend(
+                this.currentTest.srcBucket, destBucket, roleArn, destLocation,
+                next),
+        ], done);
+    });
 
-    afterEach(done => series([
-        next => scalityUtils.deleteVersionedBucket(srcBucket, next),
-        // Destination location has falsy bucket match property, so we update
-        // the key prefix.
-        next => awsUtils.deleteAllVersions(destBucket,
-            `${srcBucket}/${keyPrefix}`, next),
-    ], done));
+    afterEach(function afterEachF(done) {
+        return series([
+            next => scalityUtils.deleteVersionedBucket(
+                this.currentTest.srcBucket, next),
+            // Destination location has falsy bucket match property, so we
+            // update the key prefix.
+            next => awsUtils.deleteAllVersions(destBucket,
+                `${this.currentTest.srcBucket}/${this.currentTest.keyPrefix}`,
+                next),
+        ], done);
+    });
 
-    it('should replicate an object', done => series([
-        next => scalityUtils.putObject(srcBucket, key, Buffer.alloc(1), next),
-        next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-            undefined, next),
-    ], done));
+    it('should replicate an object', function itF(done) {
+        return series([
+            next => scalityUtils.putObject(this.test.srcBucket, this.test.key,
+                Buffer.alloc(1), next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, undefined, next),
+        ], done);
+    });
 
-    it('should replicate a zero byte object', done => series([
-        next => scalityUtils.putObject(srcBucket, key, undefined, next),
-        next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-            undefined, next),
-    ], done));
+    it('should replicate a zero byte object', function itF(done) {
+        return series([
+            next => scalityUtils.putObject(this.test.srcBucket, this.test.key,
+                undefined, next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, undefined, next),
+        ], done);
+    });
 
     // AWS documentation: the name for a key is a sequence of Unicode characters
     // whose UTF-8 encoding is at most 1024 bytes long.
-    it.skip('should replicate an object with UTF-8 encoding', done => series([
-        next => scalityUtils.putObject(srcBucket, keyutf8, Buffer.alloc(1),
-            next),
-        next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, keyutf8,
-            undefined, next),
-    ], done));
+    it.skip('should replicate an object with UTF-8 encoding',
+    function itF(done) {
+        return series([
+            next => scalityUtils.putObject(this.test.srcBucket,
+                this.test.keyutf8, Buffer.alloc(1), next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.keyutf8, undefined, next),
+        ], done);
+    });
 
-    it('should replicate a copied object', done => series([
-        next => scalityUtils.putObject(srcBucket, key, Buffer.alloc(1), next),
-        next => scalityUtils.copyObject(srcBucket, copySource, copyKey, next),
-        next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, copyKey,
-            undefined, next),
-        // avoid a race with cleanup by ensuring everything is replicated
-        next => scalityUtils.waitUntilReplicated(srcBucket, key, undefined,
-                                                 next),
-    ], done));
+    it('should replicate a copied object', function itF(done) {
+        return series([
+            next => scalityUtils.putObject(this.test.srcBucket,
+                this.test.key, Buffer.alloc(1), next),
+            next => scalityUtils.copyObject(this.test.srcBucket,
+                this.test.copySource, this.test.copyKey, next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.copyKey, undefined, next),
+            // avoid a race with cleanup by ensuring everything is replicated
+            next => scalityUtils.waitUntilReplicated(this.test.srcBucket,
+                this.test.key, undefined, next),
+        ], done);
+    });
 
-    it('should replicate a MPU object: single 0 byte part', done => series([
-        next => scalityUtils.completeSinglePartMPU(srcBucket, key, 0, next),
-        next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-            undefined, next),
-    ], done));
+    it('should replicate a MPU object: single 0 byte part', function itF(done) {
+        return series([
+            next => scalityUtils.completeSinglePartMPU(this.test.srcBucket,
+                this.test.key, 0, next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, undefined, next),
+        ], done);
+    });
 
-    it('should replicate a MPU object: single 1 byte part', done => series([
-        next => scalityUtils.completeSinglePartMPU(srcBucket, key, 1, next),
-        next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-            undefined, next),
-    ], done));
+    it('should replicate a MPU object: single 1 byte part', function itF(done) {
+        return series([
+            next => scalityUtils.completeSinglePartMPU(this.test.srcBucket,
+                this.test.key, 1, next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, undefined, next),
+        ], done);
+    });
 
-    it('should replicate a MPU object: 2 parts', done => series([
-        next => scalityUtils.completeMPUAWS(srcBucket, key, 2, next),
-        next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-            undefined, next),
-    ], done));
+    it('should replicate a MPU object: 2 parts', function itF(done) {
+        return series([
+            next => scalityUtils.completeMPUAWS(this.test.srcBucket,
+                this.test.key, 2, next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, undefined, next),
+        ], done);
+    });
 
-    it('should replicate a MPU object: 10 parts', done => series([
-        next => scalityUtils.completeMPUAWS(srcBucket, key, 10, next),
-        next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-            undefined, next),
-    ], done));
+    it('should replicate a MPU object: 10 parts', function itF(done) {
+        return series([
+            next => scalityUtils.completeMPUAWS(this.test.srcBucket,
+                this.test.key, 10, next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, undefined, next),
+        ], done);
+    });
 
     [undefined,
     `0-${1024 * 1024 * 5}`,
     `${1024 * 1024 * 2}-${1024 * 1024 * 7}`].forEach(range =>
         it('should replicate a MPU with parts copied from another MPU with ' +
-        `byte range '${range}' for each part`, done => series([
-            next => scalityUtils.completeMPUAWS(srcBucket, key, 2, next),
-            next => scalityUtils.completeMPUWithPartCopy(srcBucket, copyKey,
-                copySource, range, 2, next),
-            next => scalityUtils.compareObjectsAWS(srcBucket, destBucket,
-                copyKey, undefined, next),
-            // avoid a race with cleanup by ensuring everything is replicated
-            next => scalityUtils.waitUntilReplicated(srcBucket, key, undefined,
-                                                     next),
-        ], done)));
+        `byte range '${range}' for each part`, function itF(done) {
+            return series([
+                next => scalityUtils.completeMPUAWS(this.test.srcBucket,
+                    this.test.key, 2, next),
+                next => scalityUtils.completeMPUWithPartCopy(
+                    this.test.srcBucket, this.test.copyKey,
+                    this.test.copySource, range, 2, next),
+                next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                    destBucket, this.test.copyKey, undefined, next),
+                // avoid a race at cleanup by ensuring everything is replicated
+                next => scalityUtils.waitUntilReplicated(this.test.srcBucket,
+                    this.test.key, undefined, next),
+            ], done);
+        }));
 
     // Object ACLs would not be applicable on AWS: they should not
     // trigger a replication task at all (i.e. stay in COMPLETED status)
-    it('should not replicate object ACL', done => series([
-        next => scalityUtils.putObject(srcBucket, key, Buffer.alloc(1), next),
-        next => scalityUtils.compareACLsAWS(srcBucket, destBucket, key, next),
-        next => scalityUtils.putObjectACL(srcBucket, key, next),
-        next => scalityUtils.expectReplicationStatus(srcBucket, key, undefined,
-                                                     'COMPLETED', next),
-    ], done));
+    it('should not replicate object ACL', function itF(done) {
+        return series([
+            next => scalityUtils.putObject(this.test.srcBucket, this.test.key,
+                Buffer.alloc(1), next),
+            next => scalityUtils.compareACLsAWS(this.test.srcBucket, destBucket,
+                this.test.key, next),
+            next => scalityUtils.putObjectACL(this.test.srcBucket,
+                this.test.key, next),
+            next => scalityUtils.expectReplicationStatus(this.test.srcBucket,
+                this.test.key, undefined, 'COMPLETED', next),
+        ], done);
+    });
 
     it('should put delete marker on destination bucket when deleting the ' +
-    'source object', done => series([
-        next => scalityUtils.putObject(srcBucket, key, Buffer.alloc(1), next),
-        next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-            undefined, next),
-        next => scalityUtils.deleteObject(srcBucket, key, null, next),
-        next => scalityUtils.assertNoObject(srcBucket, key, next),
-        next => awsUtils.waitUntilDeleted(destBucket, key, 's3', next),
-        next => awsUtils.assertNoObject(destBucket, key, next),
-    ], done));
+    'source object', function itF(done) {
+        return series([
+            next => scalityUtils.putObject(this.test.srcBucket, this.test.key,
+                Buffer.alloc(1), next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, undefined, next),
+            next => scalityUtils.deleteObject(this.test.srcBucket,
+                this.test.key, null, next),
+            next => scalityUtils.assertNoObject(this.test.srcBucket,
+                this.test.key, next),
+            next => awsUtils.waitUntilDeleted(destBucket, this.test.key, 's3',
+                next),
+            next => awsUtils.assertNoObject(destBucket, this.test.key, next),
+        ], done);
+    });
 
-    it('should replicate object tags of the latest version', done => series([
-        next => scalityUtils.putObject(srcBucket, key, Buffer.alloc(1), next),
-        next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-            undefined, next),
-        next => scalityUtils.putObjectTagging(srcBucket, key, undefined, next),
-        next => scalityUtils.compareObjectTagsAWS(srcBucket, destBucket, key,
-            undefined, undefined, next),
-    ], done));
+    it('should replicate object tags of the latest version',
+    function itF(done) {
+        return series([
+            next => scalityUtils.putObject(this.test.srcBucket, this.test.key,
+                Buffer.alloc(1), next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, undefined, next),
+            next => scalityUtils.putObjectTagging(this.test.srcBucket,
+                this.test.key, undefined, next),
+            next => scalityUtils.compareObjectTagsAWS(this.test.srcBucket,
+                destBucket, this.test.key, undefined, undefined, next),
+        ], done);
+    });
 
-    it('should replicate object tags of a previous version', done => {
+    it('should replicate object tags of a previous version',
+    function itF(done) {
         let firstVersionScality = null;
         let firstVersionAWS = null;
         return series([
-            next => scalityUtils.putObject(srcBucket, key, Buffer.alloc(1),
-                next),
-            next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-                undefined, next),
-            next => awsUtils.getHeadObject(destBucket, `${srcBucket}/${key}`,
+            next => scalityUtils.putObject(this.test.srcBucket, this.test.key,
+                Buffer.alloc(1), next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, undefined, next),
+            next => awsUtils.getHeadObject(destBucket,
+                `${this.test.srcBucket}/${this.test.key}`,
         (err, data) => {
                 if (err) {
                     return next(err);
@@ -157,41 +218,47 @@ describe('Replication with AWS backend', function() {
                 firstVersionAWS = data.VersionId;
                 return next();
             }),
-            next => scalityUtils.putObject(srcBucket, key, Buffer.alloc(1),
+            next => scalityUtils.putObject(this.test.srcBucket, this.test.key,
+                Buffer.alloc(1), next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, undefined, next),
+            next => scalityUtils.putObjectTagging(this.test.srcBucket,
+                this.test.key, firstVersionScality, next),
+            next => scalityUtils.compareObjectTagsAWS(this.test.srcBucket,
+                destBucket, this.test.key, firstVersionScality, firstVersionAWS,
                 next),
-            next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-                undefined, next),
-            next => scalityUtils.putObjectTagging(srcBucket, key,
-                firstVersionScality, next),
-            next => scalityUtils.compareObjectTagsAWS(srcBucket, destBucket,
-                key, firstVersionScality, firstVersionAWS, next),
         ], done);
     });
 
     it('should replicate deleting object tags of the latest version',
-    done => series([
-        next => scalityUtils.putObject(srcBucket, key, Buffer.alloc(1), next),
-        next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-            undefined, next),
-        next => scalityUtils.putObjectTagging(srcBucket, key, undefined, next),
-        next => scalityUtils.compareObjectTagsAWS(srcBucket, destBucket, key,
-            undefined, undefined, next),
-        next => scalityUtils.deleteObjectTagging(srcBucket, key, undefined,
-            next),
-        next => scalityUtils.compareObjectTagsAWS(srcBucket, destBucket, key,
-            undefined, undefined, next),
-    ], done));
+    function itF(done) {
+        return series([
+            next => scalityUtils.putObject(this.test.srcBucket, this.test.key,
+                Buffer.alloc(1), next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, undefined, next),
+            next => scalityUtils.putObjectTagging(this.test.srcBucket,
+                this.test.key, undefined, next),
+            next => scalityUtils.compareObjectTagsAWS(this.test.srcBucket,
+                destBucket, this.test.key, undefined, undefined, next),
+            next => scalityUtils.deleteObjectTagging(this.test.srcBucket,
+                this.test.key, undefined, next),
+            next => scalityUtils.compareObjectTagsAWS(this.test.srcBucket,
+                destBucket, this.test.key, undefined, undefined, next),
+        ], done);
+    });
 
     it('should replicate deleting object tags of a previous version',
-    done => {
+    function itF(done) {
         let firstVersionScality = null;
         let firstVersionAWS = null;
         return series([
-            next => scalityUtils.putObject(srcBucket, key, Buffer.alloc(1),
-                next),
-            next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-                undefined, next),
-            next => awsUtils.getHeadObject(destBucket, `${srcBucket}/${key}`,
+            next => scalityUtils.putObject(this.test.srcBucket, this.test.key,
+                Buffer.alloc(1), next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, undefined, next),
+            next => awsUtils.getHeadObject(destBucket,
+                `${this.test.srcBucket}/${this.test.key}`,
             (err, data) => {
                 if (err) {
                     return next(err);
@@ -200,55 +267,66 @@ describe('Replication with AWS backend', function() {
                 firstVersionAWS = data.VersionId;
                 return next();
             }),
-            next => scalityUtils.putObject(srcBucket, key, Buffer.alloc(1),
-                next),
-            next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-                undefined, next),
-            next => scalityUtils.putObjectTagging(srcBucket, key,
-                firstVersionScality, next),
-            next => scalityUtils.compareObjectTagsAWS(srcBucket, destBucket,
-                key, firstVersionScality, firstVersionAWS, next),
-            next => scalityUtils.deleteObjectTagging(srcBucket, key,
-                firstVersionScality, next),
-            next => scalityUtils.compareObjectTagsAWS(srcBucket, destBucket,
-                key, firstVersionScality, firstVersionAWS, next),
+            next => scalityUtils.putObject(this.test.srcBucket, this.test.key,
+                Buffer.alloc(1), next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, undefined, next),
+            next => scalityUtils.putObjectTagging(this.test.srcBucket,
+                this.test.key, firstVersionScality, next),
+            next => scalityUtils.compareObjectTagsAWS(this.test.srcBucket,
+                destBucket, this.test.key, firstVersionScality,
+                firstVersionAWS, next),
+            next => scalityUtils.deleteObjectTagging(this.test.srcBucket,
+                this.test.key, firstVersionScality, next),
+            next => scalityUtils.compareObjectTagsAWS(this.test.srcBucket,
+                destBucket, this.test.key, firstVersionScality,
+                firstVersionAWS, next),
         ], done);
     });
 
-    it('should replicate object tags of the latest MPU version', done =>
-    series([
-        next => scalityUtils.completeMPUAWS(srcBucket, key, 2, next),
-        next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-            undefined, next),
-        next => scalityUtils.putObjectTagging(srcBucket, key, undefined, next),
-        next => scalityUtils.compareObjectTagsAWS(srcBucket, destBucket, key,
-            undefined, undefined, next),
-    ], done));
+    it('should replicate object tags of the latest MPU version',
+    function itF(done) {
+        return series([
+            next => scalityUtils.completeMPUAWS(this.test.srcBucket,
+                this.test.key, 2, next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, undefined, next),
+            next => scalityUtils.putObjectTagging(this.test.srcBucket,
+                this.test.key, undefined, next),
+            next => scalityUtils.compareObjectTagsAWS(this.test.srcBucket,
+                destBucket, this.test.key, undefined, undefined, next),
+        ], done);
+    });
 
     // this test should work in general but with current
     // implementation it's racy since there's a possibility that the
     // COMPLETED replication status may be set before tags are
     // replicated, so skip it for now
     it.skip('should replicate object tags of an MPU version when tagging is ' +
-    'put before replication is complete', done =>
-        series([
-            next => scalityUtils.completeMPUAWS(srcBucket, key, 5, next),
-            next => scalityUtils.putObjectTagging(srcBucket, key, undefined,
-                next),
-            next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-                undefined, next),
-            next => scalityUtils.compareObjectTagsAWS(srcBucket, destBucket,
-                key, undefined, undefined, next),
-        ], done));
+    'put before replication is complete', function itF(done) {
+        return series([
+            next => scalityUtils.completeMPUAWS(this.test.srcBucket,
+                this.test.key, 5, next),
+            next => scalityUtils.putObjectTagging(this.test.srcBucket,
+                this.test.key, undefined, next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, undefined, next),
+            next => scalityUtils.compareObjectTagsAWS(this.test.srcBucket,
+                destBucket, this.test.key, undefined, undefined, next),
+        ], done);
+    });
 
-    it('should replicate object tags of a previous MPU version', done => {
+    it('should replicate object tags of a previous MPU version',
+    function itF(done) {
         let firstVersionScality = null;
         let firstVersionAWS = null;
         return series([
-            next => scalityUtils.completeMPUAWS(srcBucket, key, 2, next),
-            next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-                undefined, next),
-            next => awsUtils.getHeadObject(destBucket, `${srcBucket}/${key}`,
+            next => scalityUtils.completeMPUAWS(this.test.srcBucket,
+                this.test.key, 2, next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, undefined, next),
+            next => awsUtils.getHeadObject(destBucket,
+                `${this.test.srcBucket}/${this.test.key}`,
             (err, data) => {
                 if (err) {
                     return next(err);
@@ -257,57 +335,67 @@ describe('Replication with AWS backend', function() {
                 firstVersionAWS = data.VersionId;
                 return next();
             }),
-            next => scalityUtils.completeMPUAWS(srcBucket, key, 2, next),
-            next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-                undefined, next),
-            next => scalityUtils.putObjectTagging(srcBucket, key,
-                firstVersionScality, next),
-            next => scalityUtils.compareObjectTagsAWS(srcBucket, destBucket,
-                key, firstVersionScality, firstVersionAWS, next),
+            next => scalityUtils.completeMPUAWS(this.test.srcBucket,
+                this.test.key, 2, next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, undefined, next),
+            next => scalityUtils.putObjectTagging(this.test.srcBucket,
+                this.test.key, firstVersionScality, next),
+            next => scalityUtils.compareObjectTagsAWS(this.test.srcBucket,
+                destBucket, this.test.key, firstVersionScality,
+                firstVersionAWS, next),
         ], done);
     });
 
     it('should replicate deleting object tags of the latest MPU version',
-    done => series([
-        next => scalityUtils.completeMPUAWS(srcBucket, key, 2, next),
-        next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-            undefined, next),
-        next => scalityUtils.putObjectTagging(srcBucket, key, undefined, next),
-        next => scalityUtils.compareObjectTagsAWS(srcBucket, destBucket, key,
-            undefined, undefined, next),
-        next => scalityUtils.deleteObjectTagging(srcBucket, key, undefined,
-            next),
-        next => scalityUtils.compareObjectTagsAWS(srcBucket, destBucket, key,
-            undefined, undefined, next),
-    ], done));
+    function itF(done) {
+        return series([
+            next => scalityUtils.completeMPUAWS(this.test.srcBucket,
+                this.test.key, 2, next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, undefined, next),
+            next => scalityUtils.putObjectTagging(this.test.srcBucket,
+                this.test.key, undefined, next),
+            next => scalityUtils.compareObjectTagsAWS(this.test.srcBucket,
+                destBucket, this.test.key, undefined, undefined, next),
+            next => scalityUtils.deleteObjectTagging(this.test.srcBucket,
+                this.test.key, undefined, next),
+            next => scalityUtils.compareObjectTagsAWS(this.test.srcBucket,
+                destBucket, this.test.key, undefined, undefined, next),
+        ], done);
+    });
 
     // this test should work in general but with current
     // implementation it's racy since there's a possibility that the
     // COMPLETED replication status may be set before tags are
     // replicated, so skip it for now
     it.skip('should replicate object tags of an MPU version when tagging is ' +
-    'put and then deleted before replication is complete', done =>
-        series([
-            next => scalityUtils.completeMPUAWS(srcBucket, key, 5, next),
-            next => scalityUtils.putObjectTagging(srcBucket, key, undefined,
-                next),
-            next => scalityUtils.deleteObjectTagging(srcBucket, key, undefined,
-                next),
-            next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-                undefined, next),
-            next => scalityUtils.compareObjectTagsAWS(srcBucket, destBucket,
-                key, undefined, undefined, next),
-        ], done));
+    'put and then deleted before replication is complete', function itF(done) {
+        return series([
+            next => scalityUtils.completeMPUAWS(this.test.srcBucket,
+                this.test.key, 5, next),
+            next => scalityUtils.putObjectTagging(this.test.srcBucket,
+                this.test.key, undefined, next),
+            next => scalityUtils.deleteObjectTagging(this.test.srcBucket,
+                this.test.key, undefined, next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, undefined, next),
+            next => scalityUtils.compareObjectTagsAWS(this.test.srcBucket,
+                destBucket, this.test.key, undefined, undefined, next),
+        ], done);
+    });
 
     it('should replicate deleting object tags of a previous MPU version',
-    done => {
+    function itF(done) {
         let firstVersionScality = null;
         let firstVersionAWS = null;
         return series([
-            next => scalityUtils.completeMPUAWS(srcBucket, key, 2, next),
-            next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-                undefined, next),
-            next => awsUtils.getHeadObject(destBucket, `${srcBucket}/${key}`,
+            next => scalityUtils.completeMPUAWS(this.test.srcBucket,
+                this.test.key, 2, next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, undefined, next),
+            next => awsUtils.getHeadObject(destBucket,
+                `${this.test.srcBucket}/${this.test.key}`,
             (err, data) => {
                 if (err) {
                     return next(err);
@@ -316,211 +404,271 @@ describe('Replication with AWS backend', function() {
                 firstVersionAWS = data.VersionId;
                 return next();
             }),
-            next => scalityUtils.completeMPUAWS(srcBucket, key, 2, next),
-            next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-                undefined, next),
-            next => scalityUtils.putObjectTagging(srcBucket, key,
-                firstVersionScality, next),
-            next => scalityUtils.compareObjectTagsAWS(srcBucket, destBucket,
-                key, firstVersionScality, firstVersionAWS, next),
-            next => scalityUtils.deleteObjectTagging(srcBucket, key,
-                firstVersionScality, next),
-            next => scalityUtils.compareObjectTagsAWS(srcBucket, destBucket,
-                key, firstVersionScality, firstVersionAWS, next),
+            next => scalityUtils.completeMPUAWS(this.test.srcBucket,
+                this.test.key, 2, next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, undefined, next),
+            next => scalityUtils.putObjectTagging(this.test.srcBucket,
+                this.test.key, firstVersionScality, next),
+            next => scalityUtils.compareObjectTagsAWS(this.test.srcBucket,
+                destBucket, this.test.key, firstVersionScality,
+                firstVersionAWS, next),
+            next => scalityUtils.deleteObjectTagging(this.test.srcBucket,
+                this.test.key, firstVersionScality, next),
+            next => scalityUtils.compareObjectTagsAWS(this.test.srcBucket,
+                destBucket, this.test.key, firstVersionScality,
+                firstVersionAWS, next),
         ], done);
     });
 
-    it('should replicate an object with custom user metadata', done =>
-    series([
-        next => scalityUtils.putObjectWithUserMetadata(srcBucket, key,
-            Buffer.alloc(1), next),
-        next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-            'Metadata', next),
-    ], done));
+    it('should replicate an object with custom user metadata',
+    function itF(done) {
+        return series([
+            next => scalityUtils.putObjectWithUserMetadata(this.test.srcBucket,
+                this.test.key, Buffer.alloc(1), next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, 'Metadata', next),
+        ], done);
+    });
 
-    it('should replicate an object with content-type', done => series([
-        next => scalityUtils.putObjectWithContentType(srcBucket, key,
-            Buffer.alloc(1), next),
-        next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-            'ContentType', next),
-    ], done));
+    it('should replicate an object with content-type', function itF(done) {
+        return series([
+            next => scalityUtils.putObjectWithContentType(this.test.srcBucket,
+                this.test.key, Buffer.alloc(1), next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, 'ContentType', next),
+        ], done);
+    });
 
-    it('should replicate an object with cache control', done => series([
-        next => scalityUtils.putObjectWithCacheControl(srcBucket, key,
-            Buffer.alloc(1), next),
-        next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-            'CacheControl', next),
-    ], done));
+    it('should replicate an object with cache control', function itF(done) {
+        return series([
+            next => scalityUtils.putObjectWithCacheControl(this.test.srcBucket,
+                this.test.key, Buffer.alloc(1), next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, 'CacheControl', next),
+        ], done);
+    });
 
-    it('should replicate an object with content disposition', done =>
-    series([
-        next => scalityUtils.putObjectWithContentDisposition(srcBucket, key,
-            Buffer.alloc(1), next),
-        next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-            'ContentDisposition', next),
-    ], done));
+    it('should replicate an object with content disposition',
+    function itF(done) {
+        return series([
+            next => scalityUtils.putObjectWithContentDisposition(
+                this.test.srcBucket, this.test.key, Buffer.alloc(1), next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, 'ContentDisposition', next),
+        ], done);
+    });
 
-    it('should replicate an object with content encoding', done =>
-    series([
-        next => scalityUtils.putObjectWithContentEncoding(srcBucket, key,
-            Buffer.alloc(1), next),
-        next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-            'ContentEncoding', next),
-    ], done));
+    it('should replicate an object with content encoding', function itF(done) {
+        return series([
+            next => scalityUtils.putObjectWithContentEncoding(
+                this.test.srcBucket, this.test.key, Buffer.alloc(1), next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, 'ContentEncoding', next),
+        ], done);
+    });
 
-    it('should replicate an object with content language', done =>
-    series([
-        next => scalityUtils.putObjectWithContentLanguage(srcBucket, key,
-            Buffer.alloc(1), next),
-        next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-            'ContentLanguage', next),
-    ], done));
+    it('should replicate an object with content language', function itF(done) {
+        return series([
+            next => scalityUtils.putObjectWithContentLanguage(
+                this.test.srcBucket, this.test.key, Buffer.alloc(1), next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, 'ContentLanguage', next),
+        ], done);
+    });
 
-    it('should replicate an object copy with custom user metadata', done =>
-    series([
-        next => scalityUtils.putObjectWithUserMetadata(srcBucket, key,
-            Buffer.alloc(1), next),
-        next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-            undefined, next),
-        next => scalityUtils.copyObject(srcBucket, copySource, copyKey, next),
-        next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, copyKey,
-            'Metadata', next),
-    ], done));
+    it('should replicate an object copy with custom user metadata',
+    function itF(done) {
+        return series([
+            next => scalityUtils.putObjectWithUserMetadata(this.test.srcBucket,
+                this.test.key, Buffer.alloc(1), next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, undefined, next),
+            next => scalityUtils.copyObject(this.test.srcBucket,
+                this.test.copySource, this.test.copyKey, next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.copyKey, 'Metadata', next),
+        ], done);
+    });
 
-    it('should replicate an object copy with content-type', done =>
-    series([
-        next => scalityUtils.putObjectWithContentType(srcBucket, key,
-            Buffer.alloc(1), next),
-        next => scalityUtils.copyObject(srcBucket, copySource, copyKey, next),
-        next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, copyKey,
-            'ContentType', next),
-        // avoid a race with cleanup by ensuring everything is replicated
-        next => scalityUtils.waitUntilReplicated(srcBucket, key, undefined,
-                                                 next),
-    ], done));
+    it('should replicate an object copy with content-type', function itF(done) {
+        return series([
+            next => scalityUtils.putObjectWithContentType(this.test.srcBucket,
+                this.test.key, Buffer.alloc(1), next),
+            next => scalityUtils.copyObject(this.test.srcBucket,
+                this.test.copySource, this.test.copyKey, next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.copyKey, 'ContentType', next),
+            // avoid a race with cleanup by ensuring everything is replicated
+            next => scalityUtils.waitUntilReplicated(this.test.srcBucket,
+                this.test.key, undefined, next),
+        ], done);
+    });
 
-    it('should replicate an object copy with cache control', done =>
-    series([
-        next => scalityUtils.putObjectWithCacheControl(srcBucket, key,
-            Buffer.alloc(1), next),
-        next => scalityUtils.copyObject(srcBucket, copySource, copyKey, next),
-        next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, copyKey,
-            'CacheControl', next),
-        // avoid a race with cleanup by ensuring everything is replicated
-        next => scalityUtils.waitUntilReplicated(srcBucket, key, undefined,
-                                                 next),
-    ], done));
+    it('should replicate an object copy with cache control',
+    function itF(done) {
+        return series([
+            next => scalityUtils.putObjectWithCacheControl(this.test.srcBucket,
+                this.test.key, Buffer.alloc(1), next),
+            next => scalityUtils.copyObject(this.test.srcBucket,
+                this.test.copySource, this.test.copyKey, next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.copyKey, 'CacheControl', next),
+            // avoid a race with cleanup by ensuring everything is replicated
+            next => scalityUtils.waitUntilReplicated(this.test.srcBucket,
+                this.test.key, undefined, next),
+        ], done);
+    });
 
-    it('should replicate an object copy with content disposition', done =>
-    series([
-        next => scalityUtils.putObjectWithContentDisposition(srcBucket, key,
-            Buffer.alloc(1), next),
-        next => scalityUtils.copyObject(srcBucket, copySource, copyKey, next),
-        next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, copyKey,
-            'ContentDisposition', next),
-        // avoid a race with cleanup by ensuring everything is replicated
-        next => scalityUtils.waitUntilReplicated(srcBucket, key, undefined,
-                                                 next),
-    ], done));
+    it('should replicate an object copy with content disposition',
+    function itF(done) {
+        return series([
+            next => scalityUtils.putObjectWithContentDisposition(
+                this.test.srcBucket, this.test.key, Buffer.alloc(1), next),
+            next => scalityUtils.copyObject(this.test.srcBucket,
+                this.test.copySource, this.test.copyKey, next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.copyKey, 'ContentDisposition', next),
+            // avoid a race with cleanup by ensuring everything is replicated
+            next => scalityUtils.waitUntilReplicated(this.test.srcBucket,
+                this.test.key, undefined, next),
+        ], done);
+    });
 
-    it('should replicate an object copy with content encoding', done =>
-    series([
-        next => scalityUtils.putObjectWithContentEncoding(srcBucket, key,
-            Buffer.alloc(1), next),
-        next => scalityUtils.copyObject(srcBucket, copySource, copyKey, next),
-        next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, copyKey,
-            'ContentEncoding', next),
-        // avoid a race with cleanup by ensuring everything is replicated
-        next => scalityUtils.waitUntilReplicated(srcBucket, key, undefined,
-                                                 next),
-    ], done));
+    it('should replicate an object copy with content encoding',
+    function itF(done) {
+        return series([
+            next => scalityUtils.putObjectWithContentEncoding(
+                this.test.srcBucket, this.test.key, Buffer.alloc(1), next),
+            next => scalityUtils.copyObject(this.test.srcBucket,
+                this.test.copySource, this.test.copyKey, next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.copyKey, 'ContentEncoding', next),
+            // avoid a race with cleanup by ensuring everything is replicated
+            next => scalityUtils.waitUntilReplicated(this.test.srcBucket,
+                this.test.key, undefined, next),
+        ], done);
+    });
 
-    it('should replicate an object copy with content language', done =>
-    series([
-        next => scalityUtils.putObjectWithContentLanguage(srcBucket, key,
-            Buffer.alloc(1), next),
-        next => scalityUtils.copyObject(srcBucket, copySource, copyKey, next),
-        next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, copyKey,
-            'ContentLanguage', next),
-        // avoid a race with cleanup by ensuring everything is replicated
-        next => scalityUtils.waitUntilReplicated(srcBucket, key, undefined,
-                                                 next),
-    ], done));
+    it('should replicate an object copy with content language',
+    function itF(done) {
+        return series([
+            next => scalityUtils.putObjectWithContentLanguage(
+                this.test.srcBucket, this.test.key, Buffer.alloc(1), next),
+            next => scalityUtils.copyObject(this.test.srcBucket,
+                this.test.copySource, this.test.copyKey, next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.copyKey, 'ContentLanguage', next),
+            // avoid a race with cleanup by ensuring everything is replicated
+            next => scalityUtils.waitUntilReplicated(this.test.srcBucket,
+                this.test.key, undefined, next),
+        ], done);
+    });
 
-    it('should replicate an MPU object with custom user metadata', done =>
-    series([
-        next => scalityUtils.completeMPUAWSWithProperties(srcBucket, key,
-            2, next),
-        next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-            'Metadata', next),
-    ], done));
+    it('should replicate an MPU object with custom user metadata',
+    function itF(done) {
+        return series([
+            next => scalityUtils.completeMPUAWSWithProperties(
+                this.test.srcBucket, this.test.key, 2, next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, 'Metadata', next),
+        ], done);
+    });
 
-    it('should replicate an MPU object with content-type', done => series([
-        next => scalityUtils.completeMPUAWSWithProperties(srcBucket, key, 2,
-            next),
-        next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-            'ContentType', next),
-    ], done));
+    it('should replicate an MPU object with content-type', function itF(done) {
+        return series([
+            next => scalityUtils.completeMPUAWSWithProperties(
+                this.test.srcBucket, this.test.key, 2, next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, 'ContentType', next),
+        ], done);
+    });
 
-    it('should replicate an MPU object with cache control', done => series([
-        next => scalityUtils.completeMPUAWSWithProperties(srcBucket, key,
-            Buffer.alloc(1), next),
-        next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-            'CacheControl', next),
-    ], done));
+    it('should replicate an MPU object with cache control', function itF(done) {
+        return series([
+            next => scalityUtils.completeMPUAWSWithProperties(
+                this.test.srcBucket, this.test.key, Buffer.alloc(1), next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, 'CacheControl', next),
+        ], done);
+    });
 
-    it('should replicate an MPU object with content disposition', done =>
-    series([
-        next => scalityUtils.completeMPUAWSWithProperties(srcBucket, key,
-            Buffer.alloc(1), next),
-        next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-            'ContentDisposition', next),
-    ], done));
+    it('should replicate an MPU object with content disposition',
+    function itF(done) {
+        return series([
+            next => scalityUtils.completeMPUAWSWithProperties(
+                this.test.srcBucket, this.test.key, Buffer.alloc(1), next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, 'ContentDisposition', next),
+        ], done);
+    });
 
-    it('should replicate an MPU object with content encoding', done =>
-    series([
-        next => scalityUtils.completeMPUAWSWithProperties(srcBucket, key,
-            Buffer.alloc(1), next),
-        next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-            'ContentEncoding', next),
-    ], done));
+    it('should replicate an MPU object with content encoding',
+    function itF(done) {
+        return series([
+            next => scalityUtils.completeMPUAWSWithProperties(
+                this.test.srcBucket, this.test.key, Buffer.alloc(1), next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, 'ContentEncoding', next),
+        ], done);
+    });
 
-    it('should replicate an MPU object with content language', done =>
-    series([
-        next => scalityUtils.completeMPUAWSWithProperties(srcBucket, key,
-            Buffer.alloc(1), next),
-        next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-            'ContentLanguage', next),
-    ], done));
+    it('should replicate an MPU object with content language',
+    function itF(done) {
+        return series([
+            next => scalityUtils.completeMPUAWSWithProperties(
+                this.test.srcBucket, this.test.key, Buffer.alloc(1), next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, 'ContentLanguage', next),
+        ], done);
+    });
 });
 
 describe('Replication with AWS backend: source AWS location', function() {
     this.timeout(REPLICATION_TIMEOUT);
     let roleArn = 'arn:aws:iam::root:role/s3-replication-role';
 
-    beforeEach(done => series([
-        next => scalityUtils.createVersionedBucketAWS(srcBucket, next),
-        next => scalityUtils.putBucketReplicationMultipleBackend(srcBucket,
-            destBucket, roleArn, destLocation, next),
-    ], done));
+    beforeEach(function beforeEachF(done) {
+        this.currentTest.srcBucket = `source-bucket-${Date.now()}`;
+        this.currentTest.keyPrefix = `${this.currentTest.srcBucket}/${hex}`;
+        this.currentTest.key =
+            `${this.currentTest.keyPrefix}/object-to-replicate-${Date.now()}`;
+        return series([
+            next => scalityUtils.createVersionedBucketAWS(
+                this.currentTest.srcBucket, next),
+            next => scalityUtils.putBucketReplicationMultipleBackend(
+                this.currentTest.srcBucket, destBucket, roleArn, destLocation,
+                next),
+        ], done);
+    });
 
-    afterEach(done => series([
-        next => scalityUtils.deleteVersionedBucket(srcBucket, next),
-        // Destination location has falsy bucket match property, so we update
-        // the key prefix.
-        next => awsUtils.deleteAllVersions(destBucket,
-            `${srcBucket}/${keyPrefix}`, next),
-    ], done));
+    afterEach(function afterEachF(done) {
+        return series([
+            next => scalityUtils.deleteVersionedBucket(
+                this.currentTest.srcBucket, next),
+            // Destination location has falsy bucket match property, so we update
+            // the key prefix.
+            next => awsUtils.deleteAllVersions(destBucket,
+                `${this.currentTest.srcBucket}/${this.currentTest.keyPrefix}`,
+                next),
+        ], done);
+    });
 
-    it('should replicate an object', done => series([
-        next => scalityUtils.putObject(srcBucket, key, Buffer.alloc(1), next),
-        next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-            undefined, next),
-    ], done));
+    it('should replicate an object', function itF(done) {
+        return series([
+            next => scalityUtils.putObject(this.test.srcBucket, this.test.key,
+                Buffer.alloc(1), next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, undefined, next),
+        ], done);
+    });
 
-    it('should replicate a MPU object: 2 parts', done => series([
-        next => scalityUtils.completeMPUAWS(srcBucket, key, 2, next),
-        next => scalityUtils.compareObjectsAWS(srcBucket, destBucket, key,
-            undefined, next),
-    ], done));
+    it('should replicate a MPU object: 2 parts', function itF(done) {
+        return series([
+            next => scalityUtils.completeMPUAWS(this.test.srcBucket,
+                this.test.key, 2, next),
+            next => scalityUtils.compareObjectsAWS(this.test.srcBucket,
+                destBucket, this.test.key, undefined, next),
+        ], done);
+    });
 });

--- a/tests/node_tests/backbeat/tests/crr/azureBackend.js
+++ b/tests/node_tests/backbeat/tests/crr/azureBackend.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const crypto = require('crypto');
+const uuid = require('uuid/v4');
 const { series } = require('async');
 
 const { scalityS3Client } = require('../../../s3SDK');
@@ -9,17 +10,9 @@ const ReplicationUtility = require('../../ReplicationUtility');
 const utils = new ReplicationUtility(scalityS3Client, sharedBlobSvc);
 const destContainer = process.env.AZURE_BACKBEAT_CONTAINER_NAME;
 const destLocation = process.env.AZURE_BACKEND_DESTINATION_LOCATION;
-const srcBucket = `source-bucket-${Date.now()}`;
 const hex = crypto.createHash('md5')
     .update(Math.random().toString())
     .digest('hex');
-const keyPrefix = `${srcBucket}/${hex}`;
-const key = `${keyPrefix}/object-to-replicate-${Date.now()}`;
-const copyKey = `${key}-copy`;
-const copySource = `/${srcBucket}/${key}`;
-// Blob name with 1024 character Azure blob name limit.
-const keyutf8 = `${keyPrefix}/%EA%9D%8B崰㈌㒈保轖䳷䀰⺩ቆ楪秲ⴝ㿅鼎ꓜ퇬枅࿷염곞召㸾⌙ꪊᆐ庍뉆䌗幐鸆䛃➟녩ˍ뙪臅⠙≼绒벊냂詴 끴鹲萯⇂㭢䈊퉉楝舳㷖족痴䧫㾵᏷ำꎆ꼵껪멷㄀誕㳓腜쒃컹㑻鳃삚舿췈孨੦⮀Ǌ곓⵪꺼꜈嗼뫘悕錸瑺⁤⑬১㵀⡸Ҏ礄䧛졼⮦ٞ쫁퓡厈譤擵泶鵇俻縫륒㜓垻ㆩꝿ詀펉ᆙ舑䜾힑藪碙ꀎꂰ췊Ᏻ   㘺幽醛잯ද汧Ꟑꛒⶨ쪸숞헹㭔ꡔᘼ뺓ᡆ᡾ᑟ䅅퀭耓弧⢠⇙폪ް蛧⃪Ἔ돫ꕢ븥ヲ캂䝄쟐颺ᓾ둾Ұ껗礞ᾰ瘹蒯硳풛瞋襎奺熝妒컚쉴⿂㽝㝳駵鈚䄖戭䌸᫲ᇁ䙪鸮ᐴ稫ⶭ뀟ھ⦿䴳稉ꉕ捈袿놾띐✯伤䃫⸧ꠏ瘌틳藔ˋ㫣敀䔩㭘식↴⧵佶痊牌ꪌ搒꾛æᤈべ쉴挜炩⽍舘ꆗ줣겤뒑徭Z䐨 敗羥誜嘳ֶꫜ걵ࣀ묟ኋ拃秷膤䨸菥䟆곘縧멀煣卲챸⧃⏶혣뎧邕⢄⭖陙䣎灏ꗛ僚䌁䠒䲎둘ꪎ傩쿌ᨌ뀻阥눉넠猌ㆯ㰢船戦跏灳蝒礯鞰諾벥煸珬㟑孫鞹Ƭꄹ孙ꢱ钐삺韦帇곎矇૧ਔ뙞밺㊑ک씌촃Ȅ頰ᖅ懚ホῐ꠷㯢먈㝹୥밷㮇䘖桲阥黾噘흳뵿澚㷞꫽鲂♤蔏앜嶃쎘嵥撞㒲 댦坪繤삮憫푇噻琕䖰⒣鯤蕆힀혙狶噕皩溊烻ᓧ鈠ᴥ徰穆ꘛ蹕綻表虣誗릊翿뱩䁞ሑ唫ꇘ苉钽뗑☧≳䟟踬ᶄꎶ愚쒄ꣷ鯍裊鮕漨踒ꠍ픸Ä☶莒浏钸목탬툖氭锰ꌒ⬧䨑렌肣꾯༭炢뤂㉥ˠٸ൪㤌ᶟ訧ᜒೳ揪Ⴛ摖㸣᳑⹞걀ꢢ䏹" 똣왷䉑摴둜辍㫣ზ㥌甦鵗⾃ꗹ빖ꓡ㲑㩝〯蘼᫩헸ῖ"` + // eslint-disable-line
-'%EA%9D%8B崰㈌㒈保轖䳷䀰⺩ቆ楪秲ⴝ㿅鼎僷ꈅꓜ퇬枅࿷염곞召㸾⌙ꪊᆐ庍뉆䌗↎舳㷖족幐鸆蹪幐䎺誧洗靁麀厷ℷ쫤ᛩ꺶㖭簹릍铰᫫眘쁽暨鿐魪셑蛃춧㡡竺뫁噛̷ᗰⷑ錜⑔痴䧫㾵᏷ำꎆ꼵껪멷㄀誕㳓腜쒃컹㑻鳃삚舿췈孨੦⮀Ǌ곓⵪꺼꜈嗼뫘悕錸瑺⁤⑬১㵀⡸Ҏ礄䧛졼⮦ٞ쫁퓡厈譤擵泶鵇俻縫륒㜓垻ㆩꝿ詀펉ᆙ舑䜾힑藪碙ꀎꂰ췊Ᏻ   㘺幽醛잯ද汧Ꟑꛒⶨ쪸숞헹㭔ꡔᘼ뺓ᡆ᡾ᑟ䅅퀭耓弧⢠⇙폪ް蛧⃪Ἔ돫ꕢ븥ヲ캂䝄쟐颺ᓾ둾Ұ껗礞ᾰ瘹蒯硳풛瞋襎奺熝妒컚쉴⿂㽝㝳駵鈚䄖戭䌸᫲ᇁ䙪鸮ᐴ稫ⶭ뀟ھ⦿䴳稉ꉕ捈袿놾띐✯伤䃫⸧ꠏ瘌틳藔ˋ㫣敀䔩㭘식↴⧵佶痊牌ꪌ搒꾛æᤈべ쉴挜炩⽍舘ꆗ줣겤뒑徭Z䐨 敗羥誜嘳ֶꫜ걵ࣀ묟ኋ拃秷膤䨸菥䟆곘縧멀煣卲챸⧃⏶혣뎧邕⢄⭖陙䣎灏ꗛ僚䌁䠒䲎둘ꪎ傩쿌ᨌ뀻阥눉넠猌ㆯ㰢船戦跏灳蝒礯鞰諾벥煸珬㟑孫鞹Ƭꄹ孙ꢱ钐삺韦帇곎矇૧ਔ뙞밺㊑ک씌촃Ȅ頰ᖅ懚ホῐ꠷㯢먈㝹୥밷㮇䘖桲阥黾噘흳뵿澚㷞꫽鲂♤蔏앜嶃쎘嵥撞㒲 댦坪繤삮憫푇噻琕䖰虣誗릊翿뱩䁞ሑ唫ꇘ苉钽뗑☧≳䟟踬ᶄꎶ愚쒄ꣷ鯍裊鮕漨踒ꠍ목탬툖氭锰ꌒ⬧䨑렌肣꾯༭炢뤂㉥ˠٸ൪㤌ᶟ訧ᜒೳ揪Ⴛ摖㸣᳑⹞걀ꢢ䏹" 똣왷䉑摴둜辍㫣ზ㥌甦鵗⾃ꗹ빖ꓡ㲑㩝〯蘼᫩헸ῖ"'; // eslint-disable-line
 const REPLICATION_TIMEOUT = 300000;
 
 describe('Replication with Azure backend', function() {
@@ -27,123 +20,204 @@ describe('Replication with Azure backend', function() {
     this.retries(3);
     let roleArn = 'arn:aws:iam::root:role/s3-replication-role';
 
-    beforeEach(done => series([
-        next => utils.createVersionedBucket(srcBucket, next),
-        next => utils.putBucketReplicationMultipleBackend(srcBucket,
-            destContainer, roleArn, destLocation, next),
-    ], done));
+    beforeEach(function beforeEachF(done) {
+        this.currentTest.srcBucket =
+            `source-bucket-${uuid().replace(/-/g, '')}`;
+        this.currentTest.keyPrefix =
+            `${this.currentTest.srcBucket}/${hex}`;
+        this.currentTest.key =
+            `${this.currentTest.keyPrefix}/object-to-replicate-` +
+            `${uuid().replace(/-/g, '')}`;
+        this.currentTest.copyKey =
+            `${this.currentTest.key}-copy`;
+        this.currentTest.copySource =
+            `/${this.currentTest.srcBucket}/${this.currentTest.key}`;
+        // Blob name with 1024 character Azure blob name limit.
+        this.currentTest.keyutf8 = `${this.currentTest.keyPrefix}/%EA%9D%8B崰㈌㒈保轖䳷䀰⺩ቆ楪秲ⴝ㿅鼎ꓜ퇬枅࿷염곞召㸾⌙ꪊᆐ庍뉆䌗幐鸆䛃➟녩ˍ뙪臅⠙≼绒벊냂詴 끴鹲萯⇂㭢䈊퉉楝舳㷖족痴䧫㾵᏷ำꎆ꼵껪멷㄀誕㳓腜쒃컹㑻鳃삚舿췈孨੦⮀Ǌ곓⵪꺼꜈嗼뫘悕錸瑺⁤⑬১㵀⡸Ҏ礄䧛졼⮦ٞ쫁퓡厈譤擵泶鵇俻縫륒㜓垻ㆩꝿ詀펉ᆙ舑䜾힑藪碙ꀎꂰ췊Ᏻ   㘺幽醛잯ද汧Ꟑꛒⶨ쪸숞헹㭔ꡔᘼ뺓ᡆ᡾ᑟ䅅퀭耓弧⢠⇙폪ް蛧⃪Ἔ돫ꕢ븥ヲ캂䝄쟐颺ᓾ둾Ұ껗礞ᾰ瘹蒯硳풛瞋襎奺熝妒컚쉴⿂㽝㝳駵鈚䄖戭䌸᫲ᇁ䙪鸮ᐴ稫ⶭ뀟ھ⦿䴳稉ꉕ捈袿놾띐✯伤䃫⸧ꠏ瘌틳藔ˋ㫣敀䔩㭘식↴⧵佶痊牌ꪌ搒꾛æᤈべ쉴挜炩⽍舘ꆗ줣겤뒑徭Z䐨 敗羥誜嘳ֶꫜ걵ࣀ묟ኋ拃秷膤䨸菥䟆곘縧멀煣卲챸⧃⏶혣뎧邕⢄⭖陙䣎灏ꗛ僚䌁䠒䲎둘ꪎ傩쿌ᨌ뀻阥눉넠猌ㆯ㰢船戦跏灳蝒礯鞰諾벥煸珬㟑孫鞹Ƭꄹ孙ꢱ钐삺韦帇곎矇૧ਔ뙞밺㊑ک씌촃Ȅ頰ᖅ懚ホῐ꠷㯢먈㝹୥밷㮇䘖桲阥黾噘흳뵿澚㷞꫽鲂♤蔏앜嶃쎘嵥撞㒲 댦坪繤삮憫푇噻琕䖰⒣鯤蕆힀혙狶噕皩溊烻ᓧ鈠ᴥ徰穆ꘛ蹕綻表虣誗릊翿뱩䁞ሑ唫ꇘ苉钽뗑☧≳䟟踬ᶄꎶ愚쒄ꣷ鯍裊鮕漨踒ꠍ픸Ä☶莒浏钸목탬툖氭锰ꌒ⬧䨑렌肣꾯༭炢뤂㉥ˠٸ൪㤌ᶟ訧ᜒೳ揪Ⴛ摖㸣᳑⹞걀ꢢ䏹" 똣왷䉑摴둜辍㫣ზ㥌甦鵗⾃ꗹ빖ꓡ㲑㩝〯蘼᫩헸ῖ"` + // eslint-disable-line
+        '%EA%9D%8B崰㈌㒈保轖䳷䀰⺩ቆ楪秲ⴝ㿅鼎僷ꈅꓜ퇬枅࿷염곞召㸾⌙ꪊᆐ庍뉆䌗↎舳㷖족幐鸆蹪幐䎺誧洗靁麀厷ℷ쫤ᛩ꺶㖭簹릍铰᫫眘쁽暨鿐魪셑蛃춧㡡竺뫁噛̷ᗰⷑ錜⑔痴䧫㾵᏷ำꎆ꼵껪멷㄀誕㳓腜쒃컹㑻鳃삚舿췈孨੦⮀Ǌ곓⵪꺼꜈嗼뫘悕錸瑺⁤⑬১㵀⡸Ҏ礄䧛졼⮦ٞ쫁퓡厈譤擵泶鵇俻縫륒㜓垻ㆩꝿ詀펉ᆙ舑䜾힑藪碙ꀎꂰ췊Ᏻ   㘺幽醛잯ද汧Ꟑꛒⶨ쪸숞헹㭔ꡔᘼ뺓ᡆ᡾ᑟ䅅퀭耓弧⢠⇙폪ް蛧⃪Ἔ돫ꕢ븥ヲ캂䝄쟐颺ᓾ둾Ұ껗礞ᾰ瘹蒯硳풛瞋襎奺熝妒컚쉴⿂㽝㝳駵鈚䄖戭䌸᫲ᇁ䙪鸮ᐴ稫ⶭ뀟ھ⦿䴳稉ꉕ捈袿놾띐✯伤䃫⸧ꠏ瘌틳藔ˋ㫣敀䔩㭘식↴⧵佶痊牌ꪌ搒꾛æᤈべ쉴挜炩⽍舘ꆗ줣겤뒑徭Z䐨 敗羥誜嘳ֶꫜ걵ࣀ묟ኋ拃秷膤䨸菥䟆곘縧멀煣卲챸⧃⏶혣뎧邕⢄⭖陙䣎灏ꗛ僚䌁䠒䲎둘ꪎ傩쿌ᨌ뀻阥눉넠猌ㆯ㰢船戦跏灳蝒礯鞰諾벥煸珬㟑孫鞹Ƭꄹ孙ꢱ钐삺韦帇곎矇૧ਔ뙞밺㊑ک씌촃Ȅ頰ᖅ懚ホῐ꠷㯢먈㝹୥밷㮇䘖桲阥黾噘흳뵿澚㷞꫽鲂♤蔏앜嶃쎘嵥撞㒲 댦坪繤삮憫푇噻琕䖰虣誗릊翿뱩䁞ሑ唫ꇘ苉钽뗑☧≳䟟踬ᶄꎶ愚쒄ꣷ鯍裊鮕漨踒ꠍ목탬툖氭锰ꌒ⬧䨑렌肣꾯༭炢뤂㉥ˠٸ൪㤌ᶟ訧ᜒೳ揪Ⴛ摖㸣᳑⹞걀ꢢ䏹" 똣왷䉑摴둜辍㫣ზ㥌甦鵗⾃ꗹ빖ꓡ㲑㩝〯蘼᫩헸ῖ"'; // eslint-disable-line
+        return series([
+            next => utils.createVersionedBucket(
+                this.currentTest.srcBucket, next),
+            next => utils.putBucketReplicationMultipleBackend(
+                this.currentTest.srcBucket, destContainer, roleArn,
+                destLocation, next),
+        ], done);
+    });
 
-    afterEach(done => series([
-        next => utils.deleteAllBlobs(destContainer, `${srcBucket}/${keyPrefix}`,
-            next),
-        next => utils.deleteVersionedBucket(srcBucket, next),
-    ], done));
+    afterEach(function afterEachF(done) {
+        return series([
+            next => utils.deleteAllBlobs(destContainer,
+                `${this.currentTest.srcBucket}/` +
+                `${this.currentTest.keyPrefix}`,
+                next),
+            next => utils.deleteVersionedBucket(
+                this.currentTest.srcBucket, next),
+        ], done);
+    });
 
-    it('should replicate an object', done => series([
-        next => utils.putObject(srcBucket, key, Buffer.alloc(1), next),
-        next => utils.compareObjectsAzure(srcBucket, destContainer, key, next),
-    ], done));
+    it('should replicate an object', function itF(done) {
+        return series([
+            next => utils.putObject(this.test.srcBucket, this.test.key,
+                Buffer.alloc(1), next),
+            next => utils.compareObjectsAzure(this.test.srcBucket,
+                destContainer, this.test.key, next),
+        ], done);
+    });
 
-    it('should replicate a zero byte object', done => series([
-        next => utils.putObject(srcBucket, key, undefined, next),
-        next => utils.compareObjectsAzure(srcBucket, destContainer, key, next),
-    ], done));
+    it('should replicate a zero byte object', function itF(done) {
+        return series([
+            next => utils.putObject(this.test.srcBucket, this.test.key,
+                undefined, next),
+            next => utils.compareObjectsAzure(this.test.srcBucket,
+                destContainer, this.test.key, next),
+        ], done);
+    });
 
-    it.skip('should replicate an object with UTF-8 encoding', done => series([
-        next => utils.putObject(srcBucket, keyutf8, Buffer.alloc(1), next),
-        next => utils.compareObjectsAzure(srcBucket, destContainer, keyutf8,
-            next),
-    ], done));
+    it.skip('should replicate an object with UTF-8 encoding',
+    function itF(done) {
+        return series([
+            next => utils.putObject(this.test.srcBucket,
+                this.test.keyutf8, Buffer.alloc(1), next),
+            next => utils.compareObjectsAzure(this.test.srcBucket,
+                destContainer, this.test.keyutf8, next),
+        ], done);
+    });
 
-    it('should replicate a copied object', done => series([
-        next => utils.putObject(srcBucket, key, Buffer.alloc(1), next),
-        next => utils.copyObject(srcBucket, copySource, copyKey, next),
-        next => utils.compareObjectsAzure(srcBucket, destContainer, copyKey,
-            next),
-        // avoid a race with cleanup by ensuring everything is replicated
-        next => utils.waitUntilReplicated(srcBucket, key, undefined, next),
-    ], done));
+    it('should replicate a copied object', function itF(done) {
+        return series([
+            next => utils.putObject(this.test.srcBucket, this.test.key,
+                Buffer.alloc(1), next),
+            next => utils.copyObject(this.test.srcBucket,
+                this.test.copySource, this.test.copyKey, next),
+            next => utils.compareObjectsAzure(this.test.srcBucket,
+                destContainer, this.test.copyKey, next),
+            // avoid a race with cleanup by ensuring everything is replicated
+            next => utils.waitUntilReplicated(this.test.srcBucket,
+                this.test.key, undefined, next),
+        ], done);
+    });
 
-    it('should replicate a MPU object: 2 parts', done => series([
-        next => utils.completeMPUAWS(srcBucket, key, 2, next),
-        next => utils.compareObjectsAzure(srcBucket, destContainer, key, next),
-    ], done));
+    it('should replicate a MPU object: 2 parts', function itF(done) {
+        return series([
+            next => utils.completeMPUAWS(this.test.srcBucket,
+                this.test.key, 2, next),
+            next => utils.compareObjectsAzure(this.test.srcBucket,
+                destContainer, this.test.key, next),
+        ], done);
+    });
 
-    it('should replicate a MPU object: 10 parts', done => series([
-        next => utils.completeMPUAWS(srcBucket, key, 10, next),
-        next => utils.compareObjectsAzure(srcBucket, destContainer, key, next),
-    ], done));
+    it('should replicate a MPU object: 10 parts', function itF(done) {
+        return series([
+            next => utils.completeMPUAWS(this.test.srcBucket,
+                this.test.key, 10, next),
+            next => utils.compareObjectsAzure(this.test.srcBucket,
+                destContainer, this.test.key, next),
+        ], done);
+    });
 
     [undefined,
     `0-${1024 * 1024 * 5}`,
     `${1024 * 1024 * 2}-${1024 * 1024 * 7}`].forEach(range =>
-        it('should replicate a MPU with parts copied from another MPU with ' +
-        `byte range '${range}' for each part`, done => series([
-            next => utils.completeMPUAWS(srcBucket, key, 2, next),
-            next => utils.completeMPUWithPartCopy(srcBucket, copyKey,
-                copySource, range, 2, next),
-            next => utils.compareObjectsAzure(srcBucket, destContainer, copyKey,
+        it('should replicate a MPU with parts copied from another MPU ' +
+        `with byte range '${range}' for each part`, function itF(done) {
+            return series([
+                next => utils.completeMPUAWS(this.test.srcBucket,
+                    this.test.key, 2, next),
+                next => utils.completeMPUWithPartCopy(this.test.srcBucket,
+                    this.test.copyKey, this.test.copySource, range, 2,
+                    next),
+                next => utils.compareObjectsAzure(this.test.srcBucket,
+                    destContainer, this.test.copyKey, next),
+                // avoid a race with cleanup by ensuring everything is
+                // replicated
+                next => utils.waitUntilReplicated(this.test.srcBucket,
+                    this.test.key, undefined, next),
+            ], done);
+        }));
+
+    it('should delete the destination object when putting a delete ' +
+    'marker on the source object', function itF(done) {
+        return series([
+            next => utils.putObject(this.test.srcBucket, this.test.key,
+                Buffer.alloc(1), next),
+            next => utils.compareObjectsAzure(this.test.srcBucket,
+                destContainer, this.test.key, next),
+            next => utils.deleteObject(this.test.srcBucket, this.test.key,
+                null, next),
+            next => utils.assertNoObject(this.test.srcBucket, this.test.key,
                 next),
-            // avoid a race with cleanup by ensuring everything is replicated
-            next => utils.waitUntilReplicated(srcBucket, key, undefined, next),
-        ], done)));
+            next => utils.waitUntilDeleted(destContainer,
+                `${this.test.srcBucket}/${this.test.key}`, 'azure', next),
+            next => utils.getBlobToText(destContainer,
+                `${this.test.srcBucket}/${this.test.key}`,
+                err => {
+                    assert.strictEqual(err.code, 'BlobNotFound');
+                    return next();
+                }),
+        ], done);
+    });
 
-    it('should delete the destination object when putting a delete marker on ' +
-    'the source object', done => series([
-        next => utils.putObject(srcBucket, key, Buffer.alloc(1), next),
-        next => utils.compareObjectsAzure(srcBucket, destContainer, key, next),
-        next => utils.deleteObject(srcBucket, key, null, next),
-        next => utils.assertNoObject(srcBucket, key, next),
-        next => utils.waitUntilDeleted(destContainer, `${srcBucket}/${key}`,
-            'azure', next),
-        next => utils.getBlobToText(destContainer, `${srcBucket}/${key}`,
-            err => {
-                assert.strictEqual(err.code, 'BlobNotFound');
-                return next();
-            }),
-    ], done));
-
-    it('should replicate object tags of the latest version', done =>
-    series([
-        next => utils.putObject(srcBucket, key, Buffer.alloc(1), next),
-        next => utils.compareObjectsAzure(srcBucket, destContainer, key, next),
-        next => utils.putObjectTagging(srcBucket, key, undefined, next),
-        next => utils.compareObjectTagsAzure(srcBucket, destContainer, key,
-            undefined, next),
-    ], done));
+    it('should replicate object tags of the latest version',
+    function itF(done) {
+        return series([
+            next => utils.putObject(this.test.srcBucket, this.test.key,
+                Buffer.alloc(1), next),
+            next => utils.compareObjectsAzure(this.test.srcBucket,
+                destContainer, this.test.key, next),
+            next => utils.putObjectTagging(this.test.srcBucket, this.test.key,
+                undefined, next),
+            next => utils.compareObjectTagsAzure(this.test.srcBucket,
+                destContainer, this.test.key, undefined, next),
+        ], done);
+    });
 
     it('should replicate deleting object tags of the latest version',
-    done => series([
-        next => utils.putObject(srcBucket, key, Buffer.alloc(1), next),
-        next => utils.compareObjectsAzure(srcBucket, destContainer, key, next),
-        next => utils.putObjectTagging(srcBucket, key, undefined, next),
-        next => utils.compareObjectTagsAzure(srcBucket, destContainer, key,
-            undefined, next),
-        next => utils.deleteObjectTagging(srcBucket, key, undefined, next),
-        next => utils.compareObjectTagsAzure(srcBucket, destContainer, key,
-            undefined, next),
-    ], done));
+    function itF(done) {
+        return series([
+            next => utils.putObject(this.test.srcBucket, this.test.key,
+                Buffer.alloc(1), next),
+            next => utils.compareObjectsAzure(this.test.srcBucket,
+                destContainer, this.test.key, next),
+            next => utils.putObjectTagging(this.test.srcBucket, this.test.key,
+                undefined, next),
+            next => utils.compareObjectTagsAzure(this.test.srcBucket,
+                destContainer, this.test.key, undefined, next),
+            next => utils.deleteObjectTagging(this.test.srcBucket,
+                this.test.key, undefined, next),
+            next => utils.compareObjectTagsAzure(this.test.srcBucket,
+                destContainer, this.test.key, undefined, next),
+        ], done);   
+    });
 
-    it('should replicate an object with properties', done => series([
-        next => utils.putObjectWithProperties(srcBucket, key, Buffer.alloc(1),
-            next),
-        next => utils.compareAzureObjectProperties(srcBucket, destContainer,
-            key, next),
-    ], done));
+    it('should replicate an object with properties', function itF(done) {
+        return series([
+            next => utils.putObjectWithProperties(this.test.srcBucket,
+                this.test.key, Buffer.alloc(1), next),
+            next => utils.compareAzureObjectProperties(this.test.srcBucket,
+                destContainer, this.test.key, next),
+        ], done);
+    });
 
-    it('should replicate a copied object with properties', done => series([
-        next => utils.putObjectWithProperties(srcBucket, key, Buffer.alloc(1),
-            next),
-        next => utils.copyObject(srcBucket, copySource, copyKey, next),
-        next => utils.compareAzureObjectProperties(srcBucket, destContainer,
-            copyKey, next),
-        // avoid a race with cleanup by ensuring everything is replicated
-        next => utils.waitUntilReplicated(srcBucket, key, undefined, next),
-    ], done));
+    it('should replicate a copied object with properties', function itF(done) {
+        return series([
+            next => utils.putObjectWithProperties(this.test.srcBucket,
+                this.test.key, Buffer.alloc(1), next),
+            next => utils.copyObject(this.test.srcBucket, this.test.copySource,
+                this.test.copyKey, next),
+            next => utils.compareAzureObjectProperties(this.test.srcBucket,
+                destContainer, this.test.copyKey, next),
+            // avoid a race with cleanup by ensuring everything is replicated
+            next => utils.waitUntilReplicated(this.test.srcBucket,
+                this.test.key, undefined, next),
+        ], done);
+    });
 
-    it('should replicate a MPU object with properties', done => series([
-        next => utils.completeMPUAWSWithProperties(srcBucket, key, 2, next),
-        next => utils.compareAzureObjectProperties(srcBucket, destContainer,
-            key, next),
-    ], done));
+    it('should replicate a MPU object with properties', function itF(done) {
+        return series([
+            next => utils.completeMPUAWSWithProperties(this.test.srcBucket,
+                this.test.key, 2, next),
+            next => utils.compareAzureObjectProperties(this.test.srcBucket,
+                destContainer, this.test.key, next),
+        ], done);
+    });
 });

--- a/tests/node_tests/backbeat/tests/crr/gcpBackend.js
+++ b/tests/node_tests/backbeat/tests/crr/gcpBackend.js
@@ -1,24 +1,19 @@
 const assert = require('assert');
 const crypto = require('crypto');
+const uuid = require('uuid/v4');
 const { series } = require('async');
 
 const { scalityS3Client } = require('../../../s3SDK');
 const gcpStorage = require('../../gcpStorage');
 const ReplicationUtility = require('../../ReplicationUtility');
 
-const utils = new ReplicationUtility(scalityS3Client, undefined, gcpStorage);
+const utils = new ReplicationUtility(scalityS3Client, undefined,
+    gcpStorage);
 const destBucket = process.env.GCP_CRR_BUCKET_NAME;
 const destGCPLocation = process.env.GCP_BACKEND_DESTINATION_LOCATION;
-const srcBucket = `source-bucket-${Date.now()}`;
 const hex = crypto.createHash('md5')
     .update(Math.random().toString())
     .digest('hex');
-const filePrefix = `${srcBucket}/${hex}`;
-const file = `${filePrefix}/object-to-replicate-${Date.now()}`;
-const copyFile = `${file}-copy`;
-const copySource = `/${srcBucket}/${file}`;
-// eslint-disable-next-line
-const fileutf8 = `${filePrefix}/%EA%9D%8B崰㈌㒈保轖䳷䀰⺩ቆ楪僷ꈅꓜ퇬枅࿷염곞召㸾⌙ꪊᆐ庍뉆䌗↎幐냂詴 끴鹲萯⇂쫤ᛩ꺶㖭簹릍铰᫫暨鿐魪셑蛃춧㡡竺뫁噛̷ᗰⷑ錜⑔痴䧫㾵᏷ำꎆ꼵껪멷㄀誕㳓腜쒃컹㑻鳃삚舿췈孨੦⮀Ǌ곓⵪꺼꜈嗼뫘悕錸瑺⁤⑬১㵀⡸Ҏ礄䧛졼⮦ٞ쫁퓡厈譤擵泶鵇俻縫륒㜓垻ㆩꝿ詀펉ᆙ舑䜾힑藪碙ꀎꂰ췊Ᏻ   㘺幽醛잯ද汧Ꟑꛒⶨ쪸숞헹㭔ꡔᘼ뺓ᡆ᡾ᑟ䅅퀭耓弧⢠⇙폪ް蛧⃪Ἔ돫ꕢ븥ヲ캂䝄쟐颺ᓾ둾Ұ껗礞ᾰ瘹蒯硳풛瞋襎奺熝妒컚쉴⿂㽝㝳駵鈚䄖戭䌸᫲ᇁ䙪鸮ᐴ稫ⶭ뀟ھ⦿䴳稉ꉕ捈袿놾띐✯伤䃫⸧ꠏ瘌틳藔ˋ㫣敀䔩㭘식↴⧵佶痊牌ꪌ搒꾛æᤈべ쉴挜炩⽍舘ꆗ줣徭Z䐨 敗羥誜嘳ֶꫜ걵ࣀ묟ኋ拃秷䨸菥䟆곘縧멀煣⧃⏶혣뎧邕⢄⭖陙䣎灏ꗛ僚䌁䠒䲎둘ꪎ傩쿌ᨌ뀻阥눉넠猌ㆯ㰢船戦跏灳蝒礯鞰諾벥煸珬㟑孫鞹Ƭꄹ孙ꢱ钐삺ᓧ鈠䁞〯蘼᫩헸ῖ"`; // eslint-disable-line
 const REPLICATION_TIMEOUT = 300000;
 
 describe('Replication with GCP backend', function() {
@@ -26,116 +21,200 @@ describe('Replication with GCP backend', function() {
     this.retries(3);
     let roleArn = 'arn:aws:iam::root:role/s3-replication-role';
 
-    beforeEach(done => series([
-        next => utils.createVersionedBucket(srcBucket, next),
-        next => utils.putBucketReplicationMultipleBackend(srcBucket,
-            destBucket, roleArn, destGCPLocation, next),
-    ], done));
+    beforeEach(function beforeEachF(done) {
+        this.currentTest.srcBucket =
+            `source-bucket-${uuid().replace(/-/g, '')}`;
+        this.currentTest.filePrefix =
+            `${this.currentTest.srcBucket}/${hex}`;
+        this.currentTest.file =
+            `${this.currentTest.filePrefix}/object-to-replicate-` +
+            `${uuid().replace(/-/g, '')}`;
+        this.currentTest.copyFile = `${this.currentTest.file}-copy`;
+        this.currentTest.copySource = `/${this.currentTest.srcBucket}` +
+            `/${this.currentTest.file}`;
+        // eslint-disable-next-line
+        this.currentTest.fileutf8 = `${this.currentTest.filePrefix}/%EA%9D%8B崰㈌㒈保轖䳷䀰⺩ቆ楪僷ꈅꓜ퇬枅࿷염곞召㸾⌙ꪊᆐ庍뉆䌗↎幐냂詴 끴鹲萯⇂쫤ᛩ꺶㖭簹릍铰᫫暨鿐魪셑蛃춧㡡竺뫁噛̷ᗰⷑ錜⑔痴䧫㾵᏷ำꎆ꼵껪멷㄀誕㳓腜쒃컹㑻鳃삚舿췈孨੦⮀Ǌ곓⵪꺼꜈嗼뫘悕錸瑺⁤⑬১㵀⡸Ҏ礄䧛졼⮦ٞ쫁퓡厈譤擵泶鵇俻縫륒㜓垻ㆩꝿ詀펉ᆙ舑䜾힑藪碙ꀎꂰ췊Ᏻ   㘺幽醛잯ද汧Ꟑꛒⶨ쪸숞헹㭔ꡔᘼ뺓ᡆ᡾ᑟ䅅퀭耓弧⢠⇙폪ް蛧⃪Ἔ돫ꕢ븥ヲ캂䝄쟐颺ᓾ둾Ұ껗礞ᾰ瘹蒯硳풛瞋襎奺熝妒컚쉴⿂㽝㝳駵鈚䄖戭䌸᫲ᇁ䙪鸮ᐴ稫ⶭ뀟ھ⦿䴳稉ꉕ捈袿놾띐✯伤䃫⸧ꠏ瘌틳藔ˋ㫣敀䔩㭘식↴⧵佶痊牌ꪌ搒꾛æᤈべ쉴挜炩⽍舘ꆗ줣徭Z䐨 敗羥誜嘳ֶꫜ걵ࣀ묟ኋ拃秷䨸菥䟆곘縧멀煣⧃⏶혣뎧邕⢄⭖陙䣎灏ꗛ僚䌁䠒䲎둘ꪎ傩쿌ᨌ뀻阥눉넠猌ㆯ㰢船戦跏灳蝒礯鞰諾벥煸珬㟑孫鞹Ƭꄹ孙ꢱ钐삺ᓧ鈠䁞〯蘼᫩헸ῖ"`; // eslint-disable-line
+        return series([
+            next => utils.createVersionedBucket(
+                this.currentTest.srcBucket, next),
+            next => utils.putBucketReplicationMultipleBackend(
+                this.currentTest.srcBucket, destBucket, roleArn,
+                destGCPLocation, next),
+        ], done);
+    });
 
-    afterEach(done => series([
-        next => utils.deleteVersionedBucket(srcBucket, next),
-        next => utils.deleteAllFiles(destBucket, filePrefix, next),
-    ], done));
+    afterEach(function afterEachF(done) {
+        return series([
+            next => utils.deleteVersionedBucket(
+                this.currentTest.srcBucket, next),
+            next => utils.deleteAllFiles(destBucket,
+                this.currentTest.filePrefix, next),
+        ], done);
+    });
 
-    it('should replicate an object', done => series([
-        next => utils.putObject(srcBucket, file, Buffer.alloc(1), next),
-        next => utils.compareObjectsGCP(srcBucket, destBucket, file, next),
-    ], done));
+    it('should replicate an object', function itF(done) {
+        return series([
+            next => utils.putObject(this.test.srcBucket, this.test.file,
+                Buffer.alloc(1), next),
+            next => utils.compareObjectsGCP(this.test.srcBucket,
+                destBucket, this.test.file, next),
+        ], done);
+    });
 
-    it.skip('should replicate an object with UTF-8 encoding', done => series([
-        next => utils.putObject(srcBucket, fileutf8, Buffer.alloc(1), next),
-        next => utils.compareObjectsGCP(srcBucket, destBucket, fileutf8, next),
-    ], done));
+    it.skip('should replicate an object with UTF-8 encoding',
+    function itF(done) {
+        return series([
+            next => utils.putObject(this.test.srcBucket,
+                this.test.fileutf8, Buffer.alloc(1), next),
+            next => utils.compareObjectsGCP(this.test.srcBucket,
+                destBucket, this.test.fileutf8, next),
+        ], done);
+    });
 
-    it('should replicate a copied object', done => series([
-        next => utils.putObject(srcBucket, file, Buffer.alloc(1), next),
-        next => utils.copyObject(srcBucket, copySource, copyFile, next),
-        next => utils.compareObjectsGCP(srcBucket, destBucket, copyFile, next),
-        next => utils.waitUntilReplicated(srcBucket, file, undefined, next),
-    ], done));
+    it('should replicate a copied object', function itF(done) {
+        return series([
+            next => utils.putObject(this.test.srcBucket, this.test.file,
+                Buffer.alloc(1), next),
+            next => utils.copyObject(this.test.srcBucket,
+                this.test.copySource, this.test.copyFile, next),
+            next => utils.compareObjectsGCP(this.test.srcBucket,
+                destBucket, this.test.copyFile, next),
+            next => utils.waitUntilReplicated(this.test.srcBucket,
+                this.test.file, undefined, next),
+        ], done);
+    });
 
-    it('should replicate a MPU object: 2 parts', done => series([
-        next => utils.completeMPUGCP(srcBucket, file, 2, next),
-        next => utils.compareObjectsGCP(srcBucket, destBucket, file, next),
-    ], done));
+    it('should replicate a MPU object: 2 parts', function itF(done) {
+        return series([
+            next => utils.completeMPUGCP(this.test.srcBucket,
+                this.test.file, 2, next),
+            next => utils.compareObjectsGCP(this.test.srcBucket,
+                destBucket, this.test.file, next),
+        ], done);
+    });
 
-    it('should replicate a MPU object: 10 parts', done => series([
-        next => utils.completeMPUGCP(srcBucket, file, 10, next),
-        next => utils.compareObjectsGCP(srcBucket, destBucket, file, next),
-    ], done));
+    it('should replicate a MPU object: 10 parts', function itF(done) {
+        return series([
+            next => utils.completeMPUGCP(this.test.srcBucket,
+                this.test.file, 10, next),
+            next => utils.compareObjectsGCP(this.test.srcBucket,
+                destBucket, this.test.file, next),
+        ], done);
+    });
 
     // GCP MPUs are limited to 1024 parts, so check that we can still replicate
     // and source MPU that is greater than 1024 parts.
-    it.skip('should replicate a MPU object: 1025 parts', done => series([
-        next => utils.completeMPUGCP(srcBucket, file, 1025, next),
-        next => utils.compareObjectsGCP(srcBucket, destBucket, file, next),
-    ], done));
+    it.skip('should replicate a MPU object: 1025 parts',
+    function itF(done) {
+        return series([
+            next => utils.completeMPUGCP(this.test.srcBucket,
+                this.test.file, 1025, next),
+            next => utils.compareObjectsGCP(this.test.srcBucket,
+                destBucket, this.test.file, next),
+        ], done);
+    });
 
     [undefined,
     `0-${1024 * 1024 * 5}`,
     `${1024 * 1024 * 2}-${1024 * 1024 * 7}`].forEach(range =>
-        it('should replicate a MPU with parts copied from another MPU with ' +
-        `byte range '${range}' for each part`, done => series([
-            next => utils.completeMPUGCP(srcBucket, file, 2, next),
-            next => utils.completeMPUWithPartCopy(srcBucket, copyFile,
-                copySource, range, 2, next),
-            next => utils.compareObjectsGCP(srcBucket, destBucket, file, next),
-        ], done)));
+        it('should replicate a MPU with parts copied from another MPU ' +
+        `with byte range '${range}' for each part`, function itF(done) {
+            return series([
+                next => utils.completeMPUGCP(this.test.srcBucket,
+                    this.test.file, 2, next),
+                next => utils.completeMPUWithPartCopy(this.test.srcBucket,
+                    this.test.copyFile, this.test.copySource, range, 2,
+                    next),
+                next => utils.compareObjectsGCP(this.test.srcBucket,
+                    destBucket, this.test.file, next),
+            ], done);
+        }));
 
-    it.skip('should delete the destination object when putting a delete marker on ' +
-    'the source object', done => series([
-        next => utils.putObject(srcBucket, file, Buffer.alloc(1), next),
-        next => utils.compareObjectsGCP(srcBucket, destBucket, file, next),
-        next => utils.deleteObject(srcBucket, file, null, next),
-        next => utils.assertNoObject(srcBucket, file, next),
-        next => utils.waitUntilDeleted(destBucket, file, 'gcp', next),
-        next => utils.getMetadata(destBucket, `${srcBucket}/${file}`, err => {
-            assert.strictEqual(err.message,
-                `No such object: ${destBucket}/${srcBucket}/${file}`);
-            return next();
-        }),
-    ], done));
+    it.skip('should delete the destination object when putting a ' +
+    'delete marker on the source object', function itF(done) {
+        return series([
+            next => utils.putObject(this.test.srcBucket, this.test.file,
+                Buffer.alloc(1), next),
+            next => utils.compareObjectsGCP(this.test.srcBucket,
+                destBucket, this.test.file, next),
+            next => utils.deleteObject(this.test.srcBucket,
+                this.test.file, null, next),
+            next => utils.assertNoObject(this.test.srcBucket,
+                this.test.file, next),
+            next => utils.waitUntilDeleted(destBucket, this.test.file,
+                'gcp', next),
+            next => utils.getMetadata(destBucket,
+                `${this.test.srcBucket}/${this.test.file}`, err => {
+                assert.strictEqual(err.message,
+                    `No such object: ${destBucket}/` +
+                    `${this.test.srcBucket}/${this.test.file}`);
+                return next();
+            }),
+        ], done);
+    });
 
-    it('should replicate object tags of the latest version', done =>
-    series([
-        next => utils.putObject(srcBucket, file, Buffer.alloc(1), next),
-        next => utils.compareObjectsGCP(srcBucket, destBucket, file, next),
-        next => utils.putObjectTagging(srcBucket, file, undefined, next),
-        next => utils.compareObjectTagsGCP(srcBucket, destBucket, file,
-            undefined, next),
-    ], done));
+    it('should replicate object tags of the latest version',
+    function itF(done) {
+        return series([
+            next => utils.putObject(this.test.srcBucket, this.test.file,
+                Buffer.alloc(1), next),
+            next => utils.compareObjectsGCP(this.test.srcBucket,
+                destBucket, this.test.file, next),
+            next => utils.putObjectTagging(this.test.srcBucket,
+                this.test.file, undefined, next),
+            next => utils.compareObjectTagsGCP(this.test.srcBucket,
+                destBucket, this.test.file, undefined, next),
+        ], done);
+    });
 
     it('should replicate deleting object tags of the latest version',
-    done => series([
-        next => utils.putObject(srcBucket, file, Buffer.alloc(1), next),
-        next => utils.compareObjectsGCP(srcBucket, destBucket, file, next),
-        next => utils.putObjectTagging(srcBucket, file, undefined, next),
-        next => utils.compareObjectTagsGCP(srcBucket, destBucket, file,
-            undefined, next),
-        next => utils.deleteObjectTagging(srcBucket, file, undefined, next),
-        next => utils.compareObjectTagsGCP(srcBucket, destBucket, file,
-            undefined, next),
-    ], done));
+    function itF(done) {
+        return series([
+            next => utils.putObject(this.test.srcBucket, this.test.file,
+                Buffer.alloc(1), next),
+            next => utils.compareObjectsGCP(this.test.srcBucket,
+                destBucket, this.test.file, next),
+            next => utils.putObjectTagging(this.test.srcBucket,
+                this.test.file, undefined, next),
+            next => utils.compareObjectTagsGCP(this.test.srcBucket,
+                destBucket, this.test.file, undefined, next),
+            next => utils.deleteObjectTagging(this.test.srcBucket,
+                this.test.file, undefined, next),
+            next => utils.compareObjectTagsGCP(this.test.srcBucket,
+                destBucket, this.test.file, undefined, next),
+        ], done);
+    });
 
-    it('should replicate an object with properties', done => series([
-        next => utils.putObjectWithProperties(srcBucket, file, Buffer.alloc(1),
-            next),
-        next => utils.compareGCPObjectProperties(srcBucket, destBucket, file,
-            next),
-    ], done));
+    it('should replicate an object with properties', function itF(done) {
+        return series([
+            next => utils.putObjectWithProperties(this.test.srcBucket,
+                this.test.file, Buffer.alloc(1), next),
+            next => utils.compareGCPObjectProperties(this.test.srcBucket,
+                destBucket, this.test.file, next),
+        ], done);
+    });
 
-    it('should replicate a copied object with properties', done => series([
-        next => utils.putObjectWithProperties(srcBucket, file, Buffer.alloc(1),
-            next),
-        next => utils.copyObject(srcBucket, copySource, copyFile, next),
-        next => utils.compareGCPObjectProperties(srcBucket, destBucket,
-            copyFile, next),
-        next => utils.waitUntilReplicated(srcBucket, file, undefined, next),
-    ], done));
+    it('should replicate a copied object with properties',
+    function itF(done) {
+        return series([
+            next => utils.putObjectWithProperties(this.test.srcBucket,
+                this.test.file, Buffer.alloc(1), next),
+            next => utils.copyObject(this.test.srcBucket,
+                this.test.copySource, this.test.copyFile, next),
+            next => utils.compareGCPObjectProperties(this.test.srcBucket,
+                destBucket, this.test.copyFile, next),
+            next => utils.waitUntilReplicated(this.test.srcBucket,
+                this.test.file, undefined, next),
+        ], done);
+    });
 
-    it('should replicate a MPU object with properties', done => series([
-        next => utils.completeMPUGCPWithProperties(srcBucket, file, 2, next),
-        next => utils.compareGCPObjectProperties(srcBucket, destBucket,
-            file, next),
-    ], done));
+    it('should replicate a MPU object with properties',
+    function itF(done) {
+        return series([
+            next => utils.completeMPUGCPWithProperties(
+                this.test.srcBucket, this.test.file, 2, next),
+            next => utils.compareGCPObjectProperties(this.test.srcBucket,
+                destBucket, this.test.file, next),
+        ], done);
+    });
 });

--- a/tests/node_tests/backbeat/tests/crr/oneToMany.js
+++ b/tests/node_tests/backbeat/tests/crr/oneToMany.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const crypto = require('crypto');
+const uuid = require('uuid/v4');
 const { series, parallel } = require('async');
 
 const { scalityS3Client, awsS3Client } = require('../../../s3SDK');
@@ -10,7 +11,6 @@ const ReplicationUtility = require('../../ReplicationUtility');
 const utils =
     new ReplicationUtility(scalityS3Client, sharedBlobSvc, gcpStorage);
 const awsUtils = new ReplicationUtility(awsS3Client);
-const srcBucket = `source-bucket-${Date.now()}`;
 const awsDestBucket = process.env.AWS_S3_BACKBEAT_BUCKET_NAME;
 const destContainer = process.env.AZURE_BACKBEAT_CONTAINER_NAME;
 const gcpDestBucket = process.env.GCP_CRR_BUCKET_NAME;
@@ -20,11 +20,6 @@ const destGCPLocation = process.env.GCP_BACKEND_DESTINATION_LOCATION;
 const hex = crypto.createHash('md5')
     .update(Math.random().toString())
     .digest('hex');
-const keyPrefix = `${srcBucket}/${hex}`;
-const destKeyPrefix = `${srcBucket}/${keyPrefix}`;
-const key = `${keyPrefix}/object-to-replicate-${Date.now()}`;
-const copyKey = `${key}-copy`;
-const copySource = `/${srcBucket}/${key}`;
 const REPLICATION_TIMEOUT = 300000;
 
 
@@ -36,63 +31,115 @@ function() {
     const storageClass =
         `${destAWSLocation},${destAzureLocation},${destGCPLocation}`;
 
-    beforeEach(done => series([
-        next => utils.createVersionedBucket(srcBucket, next),
-        next => utils.putBucketReplicationMultipleBackend(srcBucket,
-            'placeholder', roleArn, storageClass, next),
-    ], done));
+    beforeEach(function beforeEachF(done) {
+        this.currentTest.srcBucket =
+            `source-bucket-${uuid().replace(/-/g, '')}`;
+        this.currentTest.keyPrefix =
+            `${this.currentTest.srcBucket}/${hex}`;
+        this.currentTest.destKeyPrefix =
+            `${this.currentTest.srcBucket}/${this.currentTest.keyPrefix}`;
+        this.currentTest.key =
+            `${this.currentTest.keyPrefix}/object-to-replicate-` +
+            `${uuid().replace(/-/g, '')}`;
+        this.currentTest.copyKey = `${this.currentTest.key}-copy`;
+        this.currentTest.copySource = `/${this.currentTest.srcBucket}/` +
+            `${this.currentTest.key}`;
+        return series([
+            next => utils.createVersionedBucket(
+                this.currentTest.srcBucket, next),
+            next => utils.putBucketReplicationMultipleBackend(
+                this.currentTest.srcBucket, 'placeholder', roleArn,
+                storageClass, next),
+        ], done);
+    });
 
-    afterEach(done => series([
-        next => awsUtils.deleteAllVersions(awsDestBucket, destKeyPrefix, next),
-        next => utils.deleteAllBlobs(destContainer, destKeyPrefix, next),
-        next => utils.deleteAllFiles(gcpDestBucket, destKeyPrefix, next),
-        next => utils.deleteVersionedBucket(srcBucket, next),
-    ], done));
+    afterEach(function afterEachF(done) {
+        return series([
+            next => awsUtils.deleteAllVersions(awsDestBucket,
+                this.currentTest.destKeyPrefix, next),
+            next => utils.deleteAllBlobs(destContainer,
+                this.currentTest.destKeyPrefix, next),
+            next => utils.deleteAllFiles(gcpDestBucket,
+                this.currentTest.destKeyPrefix, next),
+            next => utils.deleteVersionedBucket(
+                this.currentTest.srcBucket, next),
+        ], done);
+    });
 
-    it('should replicate an object', done => series([
-        next => utils.putObject(srcBucket, key, Buffer.alloc(1), next),
-        next => utils.compareObjectsOneToMany(srcBucket, awsDestBucket,
-            destContainer, gcpDestBucket, key, next),
-    ], done));
+    it('should replicate an object',function itF(done) {
+        return series([
+            next => utils.putObject(this.test.srcBucket, this.test.key,
+                Buffer.alloc(1), next),
+            next => utils.compareObjectsOneToMany(this.test.srcBucket,
+                awsDestBucket, destContainer, gcpDestBucket,
+                this.test.key, next),
+        ], done);
+    });
 
-    it('should replicate a zero byte object', done => series([
-        next => utils.putObject(srcBucket, key, undefined, next),
-        next => utils.compareObjectsOneToMany(srcBucket, awsDestBucket,
-            destContainer, gcpDestBucket, key, next),
-    ], done));
+    it('should replicate a zero byte object', function itF(done) {
+        return series([
+            next => utils.putObject(this.test.srcBucket, this.test.key,
+                undefined, next),
+            next => utils.compareObjectsOneToMany(this.test.srcBucket,
+                awsDestBucket, destContainer, gcpDestBucket,
+                this.test.key, next),
+        ], done);
+    });
 
-    it('should replicate a copied object', done => series([
-        next => utils.putObject(srcBucket, key, Buffer.alloc(1), next),
-        next => utils.copyObject(srcBucket, copySource, copyKey, next),
-        next => utils.compareObjectsOneToMany(srcBucket, awsDestBucket,
-            destContainer, gcpDestBucket, copyKey, next),
-        // Avoid a race with cleanup by ensuring everything is replicated.
-        next => utils.waitUntilReplicated(srcBucket, key, undefined, next),
-    ], done));
+    it('should replicate a copied object', function itF(done) {
+        return series([
+            next => utils.putObject(this.test.srcBucket, this.test.key,
+                Buffer.alloc(1), next),
+            next => utils.copyObject(this.test.srcBucket,
+                this.test.copySource, this.test.copyKey, next),
+            next => utils.compareObjectsOneToMany(this.test.srcBucket,
+                awsDestBucket,
+                destContainer, gcpDestBucket, this.test.copyKey, next),
+            // Avoid a race with cleanup by ensuring everything is 
+            // replicated.
+            next => utils.waitUntilReplicated(this.test.srcBucket,
+                this.test.key, undefined, next),
+        ], done);
+    });
 
-    it('should replicate a MPU object: 2 parts', done => series([
-        next => utils.completeMPUAWS(srcBucket, key, 2, next),
-        next => utils.compareObjectsOneToMany(srcBucket, awsDestBucket,
-            destContainer, gcpDestBucket, key, next),
-    ], done));
+    it('should replicate a MPU object: 2 parts', function itF(done) {
+        return series([
+            next => utils.completeMPUAWS(this.test.srcBucket,
+                this.test.key, 2, next),
+            next => utils.compareObjectsOneToMany(this.test.srcBucket,
+                awsDestBucket,
+                destContainer, gcpDestBucket, this.test.key, next),
+        ], done);
+    });
 
-    it('should replicate a MPU object: 10 parts', done => series([
-        next => utils.completeMPUAWS(srcBucket, key, 10, next),
-        next => utils.compareObjectsOneToMany(srcBucket, awsDestBucket,
-            destContainer, gcpDestBucket, key, next),
-    ], done));
+    it('should replicate a MPU object: 10 parts', function itF(done) {
+        return series([
+            next => utils.completeMPUAWS(this.test.srcBucket,
+                this.test.key, 10, next),
+            next => utils.compareObjectsOneToMany(this.test.srcBucket,
+                awsDestBucket, destContainer, gcpDestBucket,
+                this.test.key, next),
+        ], done);
+    });
 
     [undefined,
     `0-${1024 * 1024 * 5}`,
     `${1024 * 1024 * 2}-${1024 * 1024 * 7}`].forEach(range =>
-        it('should replicate a MPU with parts copied from another MPU with ' +
-        `byte range '${range}' for each part`, done => series([
-            next => utils.completeMPUAWS(srcBucket, key, 2, next),
-            next => utils.completeMPUWithPartCopy(srcBucket, copyKey,
-                copySource, range, 2, next),
-            next => utils.compareObjectsOneToMany(srcBucket, awsDestBucket,
-                destContainer, gcpDestBucket, copyKey, next),
-            // avoid a race with cleanup by ensuring everything is replicated
-            next => utils.waitUntilReplicated(srcBucket, key, undefined, next),
-        ], done)));
+        it.skip('should replicate a MPU with parts copied from another MPU ' +
+        `with byte range '${range}' for each part`, function itF(done) {
+            return series([
+                next => utils.completeMPUAWS(this.test.srcBucket,
+                    this.test.key, 2, next),
+                next => utils.completeMPUWithPartCopy(this.test.srcBucket,
+                    this.test.copyKey, this.test.copySource, range, 2,
+                    next),
+                next => utils.compareObjectsOneToMany(this.test.srcBucket,
+                    awsDestBucket, destContainer, gcpDestBucket,
+                    this.test.copyKey, next),
+                // avoid a race with cleanup by ensuring everything is
+                //replicated
+                next => utils.waitUntilReplicated(this.test.srcBucket,
+                    this.test.key, undefined, next),
+            ], done);
+        }));
 });


### PR DESCRIPTION
Here are the steps in this PR that will hopefully fix some of the known flakiness in Zenko tests:

- use different  `sourceBucket` names for each test, to avoid conflicts during the tear down in afterEach
- use `uuid` instead of `Date.now()` to generate unique bucket names
- raise wait timer between checking replication statuses for the crr pause resume tests
- Skipping MPU replication by range tests in 1-M scenarios, ticket for that test is opened here: https://scality.atlassian.net/browse/ZENKO-1015