### PR TITLE
Bugfix/zenko 1017 redis fixes

### DIFF
--- a/charts/redis-ha/Chart.yaml
+++ b/charts/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 3.0.0-Z
+version: 3.0.1-Z
 appVersion: 4.0.11
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/charts/redis-ha/templates/redis-ha-configmap.yaml
+++ b/charts/redis-ha/templates/redis-ha-configmap.yaml
@@ -23,7 +23,7 @@ data:
 
   init.bash: |
     MASTER=`redis-cli -h {{ template "redis-ha.fullname" . }} -p {{ .Values.sentinel.port }} sentinel get-master-addr-by-name {{ .Values.redis.masterGroupName }} | grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}'`
-    OLD_IP=`cat /data/conf/ip`
+    GROUP_NAME=`cat /data/conf/group_name`
     REDIS_CONF=/data/conf/redis.conf
     SENTINEL_CONF=/data/conf/sentinel.conf
     R_PATCH=/data/conf/redis.patch
@@ -40,7 +40,6 @@ data:
         else
             sed -i "1s/^/sentinel monitor {{ .Values.redis.masterGroupName }} $1 {{ .Values.redis.port }} {{ .Values.sentinel.quorum }} \n/" $SENTINEL_CONF
         fi
-
     }
     function redis_update(){
         if [[ `grep "slaveof" $REDIS_CONF` ]]; then
@@ -51,10 +50,11 @@ data:
     }
     function setup_defaults(){
         if [[ "$HOSTNAME" == "{{ template "redis-ha.fullname" . }}-server-0" ]]; then
+            echo "Setting this pod as the default master"
             sed -i "s/^.*slaveof.*//" $REDIS_CONF
             sentinel_update "$POD_IP"
         else
-            echo "Setting up slave config.."
+            echo "Setting default slave config.."
             if [[ `grep "slaveof" $REDIS_CONF` ]]; then
                 sed -i 's/^.*slaveof.*/slaveof {{ template "redis-ha.fullname" . }}-server-0.{{ template "redis-ha.fullname" . }} {{ .Values.redis.port }}/' $REDIS_CONF
             else
@@ -64,7 +64,21 @@ data:
             redis_update "{{ template "redis-ha.fullname" . }}-server-0.{{ template "redis-ha.fullname" . }}"
         fi
     }
+    function update_config(){
+        if [[ ! `redis-cli -h $MASTER ping` ]]; then
+           echo "Cannot contact master, replacing dead master with default master"
+           setup_defaults
+        else
+            echo "Found reachable master, updating config"
+            sentinel_update $MASTER
+            redis_update $MASTER
+        fi
+    }
     function patch_conf(){
+        if [[ "$GROUP_NAME" != "{{ .Values.redis.masterGroupName }}" ]]; then
+            echo "Removing references to previous group name"
+            sed -i "s/ $GROUP_NAME / {{ .Values.redis.masterGroupName }} /" $SENTINEL_CONF
+        fi
         {{- range $key, $value := .Values.redis.config }}
         sed -i "s/^.*{{ $key }}.*/{{ $key }} {{ $value }}/" $REDIS_CONF
         {{- end }}
@@ -79,23 +93,20 @@ data:
     if [[ ! -f $REDIS_CONF && ! -f SENTINEL_CONF ]]; then
         cp /readonly-config/redis.conf $REDIS_CONF
         cp /readonly-config/sentinel.conf $SENTINEL_CONF
-        setup_defaults
+        if [[ "$MASTER" ]]; then
+            update_config
+        else
+            setup_defaults
+        fi
     elif [[ "$MASTER" == "" ]]; then
         echo "Found configs but no redis master found! Configuring default master.."
+        patch_conf
         setup_defaults
-        patch_conf
     else
-        if [[ ! `redis-cli -h $MASTER ping` ]]; then
-           echo "Cannot contact master, replacing dead master with default master"
-           setup_defaults
-        else
-            echo "Found reachable master, updating config"
-            sentinel_update $MASTER
-            redis_update $MASTER
-        fi
         patch_conf
+        update_config
     fi
-    echo $POD_IP > /data/conf/ip
+    echo "{{ .Values.redis.masterGroupName }}" > /data/conf/group_name
     chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }} /data/
     echo "Ready..."
 

--- a/charts/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/charts/redis-ha/templates/redis-ha-statefulset.yaml
@@ -3,13 +3,12 @@ kind: StatefulSet
 metadata:
   name: {{ template "redis-ha.fullname" . }}-server
   labels:
-    name: {{ template "redis-ha.fullname" . }}
-    release: {{ .Release.Name }}
-    app: {{ template "redis-ha.fullname" . }}
+{{ include "labels.standard" . | indent 4 }}
 spec:
   selector:
     matchLabels:
-{{ include "labels.standard" . | indent 6 }}
+      release: {{ .Release.Name }}
+      app: {{ template "redis-ha.name" . }}
   serviceName: {{ template "redis-ha.fullname" . }}
   replicas: {{ .Values.replicas }}
   updateStrategy:
@@ -22,10 +21,8 @@ spec:
 {{ toYaml .Values.podAnnotations . | indent 8 }}
       {{- end }}
       labels:
-{{ include "labels.standard" . | indent 8 }}
-      {{- if .Values.extraLabels }}
-{{ toYaml .Values.extraLabels | indent 8 }}
-      {{- end }}
+        release: {{ .Release.Name }}
+        app: {{ template "redis-ha.name" . }}
     spec:
       {{- if .Values.nodeSelector }}
       nodeSelector:

--- a/charts/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/charts/redis-ha/templates/redis-ha-statefulset.yaml
@@ -11,6 +11,7 @@ spec:
       app: {{ template "redis-ha.name" . }}
   serviceName: {{ template "redis-ha.fullname" . }}
   replicas: {{ .Values.replicas }}
+  podManagementPolicy: {{ .Values.podManagementPolicy }}
   updateStrategy:
     type: RollingUpdate
   template:

--- a/charts/redis-ha/values.yaml
+++ b/charts/redis-ha/values.yaml
@@ -6,7 +6,7 @@ image: redis
 tag: 4.0.11-stretch
 ## replicas number for each component
 replicas: 3
-podManagementPolicy: OrderedReady # Cannot change after first release
+podManagementPolicy: Parallel # Cannot change after first release
 
 ## Redis specific configuration options
 redis:

--- a/charts/redis-ha/values.yaml
+++ b/charts/redis-ha/values.yaml
@@ -11,7 +11,7 @@ podManagementPolicy: Parallel # Cannot change after first release
 ## Redis specific configuration options
 redis:
   port: 6379
-  masterGroupName: mymaster
+  masterGroupName: zenko
   auth: false          # Not yet implemented - Configures redis with AUTH (requirepass & masterauth conf params)
   # Any additional redis conf settings can be set as key value pairs as seen below
   config:

--- a/charts/zenko/requirements.lock
+++ b/charts/zenko/requirements.lock
@@ -19,7 +19,7 @@ dependencies:
   version: 3.5.3-Z
 - name: redis-ha
   repository: file://../redis-ha
-  version: 3.0.0-Z
+  version: 3.0.1-Z
 - name: grafana
   repository: file://../grafana
   version: 1.11.6-Z
@@ -29,5 +29,5 @@ dependencies:
 - name: zookeeper
   repository: file://../zenko-quorum
   version: 1.0.0-Z
-digest: sha256:ea905dc1b9d70750b88be8af1b74f715380758766b9668a7f8ea696a7e74444a
-generated: 2018-08-16T11:18:47.994842466-07:00
+digest: sha256:18e412339304c981f2fc038683270549e85c44c90b37dd4507438de189be73f7
+generated: 2018-08-17T12:28:19.584402697-07:00

--- a/charts/zenko/requirements.yaml
+++ b/charts/zenko/requirements.yaml
@@ -20,7 +20,7 @@ dependencies:
   version: "3.5.3-Z"
   repository: "file://../mongodb-replicaset"
 - name: redis-ha
-  version: "3.0.0-Z"
+  version: "3.0.1-Z"
   repository: "file://../redis-ha"
   condition: redis-ha.enabled
 - name: grafana


### PR DESCRIPTION
Fixes:

- Ability to upgrade redis in general (at the helm level)
- When persistence is disabled, the init script would not copy over the config when needed
    - Also adds more stability to the chart

Feature:

- Switched to parallel pod management for quicker startup and cleanups.
    - Does not affect upgrades which are still rolling upgrades
    - Allows us to change the redis master group to `zenko` instead of `mymaster`