### PR TITLE
ZENKO-1016 Improvement: Add tagging to flaky node e2e tests

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -228,7 +228,7 @@ test-node-flaky:
 	$(call test-node)
 
 test: | install-common install-zenko test-e2e test-node dump-logs
-test-latest: | install-common get-latest-commit install-latest-zenko test-e2e test-node-flaky dump-logs
+test-latest: | install-common get-latest-commit install-latest-zenko test-e2e test-node test-node-flaky dump-logs
 .PHONY: test test-latest
 test-local:
 	make NO_SIM=true NO_INSTALL=true -e test

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -62,6 +62,8 @@ BACKBEAT_BRANCH := development/8.0
 BACKBEAT_IMAGE_NAME := backbeat
 BACKBEAT_IMAGE := $(IMAGE_REGISTRY)/$(IMAGE_REPO)/$(BACKBEAT_IMAGE_NAME)
 
+NODE_TEST_TAGS := not:flaky
+
 artifacts:
 	@mkdir -p $@
 
@@ -217,11 +219,16 @@ test-node: | build-node-e2e
 		--rm --restart=Never --namespace $(HELM_NAMESPACE) --attach=True \
 		$(shell ../eve/workers/ci_env.sh env) \
 		--env CLOUDSERVER_ENDPOINT="http://$(ZENKO_HELM_RELEASE)-cloudserver:80" \
+		--env MOCHA_TAGS="$(NODE_TEST_TAGS)" \
 		-- ./npm_chain.sh test_crr test_api test_crr_pause_resume test_location_quota
 .PHONY: test-node
 
-test: | install-common install-zenko test-e2e test-node
-test-latest: | install-common get-latest-commit install-latest-zenko test-e2e test-node
+test-node-flaky:
+	$(eval NODE_TEST_TAGS = is:flaky)
+	$(call test-node)
+
+test: | install-common install-zenko test-e2e test-node dump-logs
+test-latest: | install-common get-latest-commit install-latest-zenko test-e2e test-node-flaky dump-logs
 .PHONY: test test-latest
 test-local:
 	make NO_SIM=true NO_INSTALL=true -e test

--- a/tests/node_tests/backbeat/tests/api/objectMonitor.js
+++ b/tests/node_tests/backbeat/tests/api/objectMonitor.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 const crypto = require('crypto');
 const request = require('request');
 const { series, waterfall, doWhilst } = require('async');
+const tags = require('mocha-tags');
 
 const { scalityS3Client, awsS3Client } = require('../../../s3SDK');
 const ReplicationUtility = require('../../ReplicationUtility');
@@ -42,7 +43,8 @@ function getAndCheckResponse(path, expectedBody, cb) {
     () => shouldContinue, cb);
 }
 
-describe('Backbeat object monitor CRR metrics', function() {
+tags('flaky')
+.describe('Backbeat object monitor CRR metrics', function() {
     this.timeout(REPLICATION_TIMEOUT);
     let roleArn = 'arn:aws:iam::root:role/s3-replication-role';
 

--- a/tests/node_tests/backbeat/tests/api/objectMonitor.js
+++ b/tests/node_tests/backbeat/tests/api/objectMonitor.js
@@ -43,7 +43,7 @@ function getAndCheckResponse(path, expectedBody, cb) {
     () => shouldContinue, cb);
 }
 
-tags('flaky')
+tags('flaky') // Tracking via ZENKO-1022
 .describe('Backbeat object monitor CRR metrics', function() {
     this.timeout(REPLICATION_TIMEOUT);
     let roleArn = 'arn:aws:iam::root:role/s3-replication-role';

--- a/tests/node_tests/backbeat/tests/crr/oneToMany.js
+++ b/tests/node_tests/backbeat/tests/crr/oneToMany.js
@@ -27,6 +27,7 @@ const copyKey = `${key}-copy`;
 const copySource = `/${srcBucket}/${key}`;
 const REPLICATION_TIMEOUT = 300000;
 
+
 describe('Replication with AWS, Azure, and GCP backends (one-to-many)',
 function() {
     this.timeout(REPLICATION_TIMEOUT);

--- a/tests/node_tests/package.json
+++ b/tests/node_tests/package.json
@@ -11,11 +11,12 @@
     "test"
   ],
   "dependencies": {
+    "@google-cloud/storage": "^1.6.0",
     "async": "2.1.2",
     "aws-sdk": "2.28.0",
     "azure-storage": "^2.10.0",
-    "@google-cloud/storage": "^1.6.0",
     "mocha": "^5.2.0",
+    "mocha-tags": "^1.0.1",
     "request": "^2.87.0"
   },
   "scripts": {

--- a/tests/node_tests/package.json
+++ b/tests/node_tests/package.json
@@ -20,11 +20,11 @@
     "request": "^2.87.0"
   },
   "scripts": {
-    "test_crr": "mocha --exit -t 10000 --recursive backbeat/tests/crr",
-    "test_api": "mocha --exit -t 10000 --recursive backbeat/tests/api",
-    "test_retry": "mocha --exit -t 10000 --recursive backbeat/tests/retry",
-    "test_crr_pause_resume": "mocha --exit -t 10000 --recursive backbeat/tests/crr-pause-resume",
-    "test_location_quota": "mocha --exit -t 10000 --recursive locationQuota/tests"
+    "test_crr": "mocha --tags ${MOCHA_TAGS} --exit -t 10000 --recursive backbeat/tests/crr",
+    "test_api": "mocha --tags ${MOCHA_TAGS} --exit -t 10000 --recursive backbeat/tests/api",
+    "test_retry": "mocha --tags ${MOCHA_TAGS} --exit -t 10000 --recursive backbeat/tests/retry",
+    "test_crr_pause_resume": "mocha --tags ${MOCHA_TAGS} --exit -t 10000 --recursive backbeat/tests/crr-pause-resume",
+    "test_location_quota": "mocha --tags ${MOCHA_TAGS} -exit -t 10000 --recursive locationQuota/tests"
   },
   "author": ""
 }


### PR DESCRIPTION
To help improve the CI, add tags to flaky test. These test will be skipped during normal test runs, to help with the endless rebuilding, and will be run during the nightly build to prevent loss of test coverage.