### PR TITLE
ZENKO-1027 bugfix: redis-ha volume node affinity conflict

### DIFF
--- a/kubernetes/zenko/charts/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/kubernetes/zenko/charts/redis-ha/templates/redis-ha-statefulset.yaml
@@ -12,7 +12,7 @@ spec:
       app: {{ template "redis-ha.name" . }}
   serviceName: {{ template "redis-ha.fullname" . }}
   replicas: {{ .Values.replicas }}
-  podManagementPolicy: {{ .Values.podManagementPolicy }}
+  podManagementPolicy: OrderedReady
   updateStrategy:
     type: RollingUpdate
   template:

--- a/kubernetes/zenko/charts/redis-ha/values.yaml
+++ b/kubernetes/zenko/charts/redis-ha/values.yaml
@@ -8,7 +8,6 @@ image: redis
 tag: 4.0.11-stretch
 ## replicas number for each component
 replicas: 3
-podManagementPolicy: Parallel # Cannot change after first release
 
 ## Redis specific configuration options
 redis:


### PR DESCRIPTION
This fixes the volume node affinity conflict that prevented Redis-HA pods from being scheduled.