### PR TITLE
ZENKO-1029 feature: prometheus soft anti-affinity

### DIFF
--- a/eve/ci-values.yml
+++ b/eve/ci-values.yml
@@ -41,11 +41,13 @@ global:
   orbit:
     endpoint: "http://ciutil-orbit-simulator:4222"
     managerMode: "poll"
+    workerMode: "poll"
 
 cloudserver:
   image:
     pullPolicy: Always
-  replicaCount: 0
+  replicaCount: 3
+  replicaFactor: 1
   env:
     MPU_TESTING: 'yes'
     PUSH_STATS: 'false'

--- a/kubernetes/zenko/charts/cloudserver/templates/manager-deployment.yaml
+++ b/kubernetes/zenko/charts/cloudserver/templates/manager-deployment.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: {{ template "cloudserver.fullname" . }}-manager
   labels:
-    app: {{ template "cloudserver.name" . }}
+    app: {{ template "cloudserver.name" . }}-manager
     chart: {{ template "cloudserver.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -12,7 +12,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ template "cloudserver.name" . }}
+      app: {{ template "cloudserver.name" . }}-manager
       release: {{ .Release.Name }}
   template:
     metadata:
@@ -21,7 +21,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/certificate.yaml") . | sha256sum }}
         {{- end }}
       labels:
-        app: {{ template "cloudserver.name" . }}
+        app: {{ template "cloudserver.name" . }}-manager
         release: {{ .Release.Name }}
     spec:
       containers:

--- a/kubernetes/zenko/charts/prometheus/OWNERS
+++ b/kubernetes/zenko/charts/prometheus/OWNERS
@@ -1,6 +1,0 @@
-approvers:
-- mgoodness
-- gianrubio
-reviewers:
-- mgoodness
-- gianrubio

--- a/kubernetes/zenko/charts/prometheus/README.md
+++ b/kubernetes/zenko/charts/prometheus/README.md
@@ -118,6 +118,7 @@ Parameter | Description | Default
 `alertmanager.persistentVolume.subPath` | Subdirectory of alertmanager data Persistent Volume to mount | `""`
 `alertmanager.podAnnotations` | annotations to be added to alertmanager pods | `{}`
 `alertmanager.replicaCount` | desired number of alertmanager pods | `1`
+`alertmanager.podManagementPolicy` | podManagementPolicy of the statefulset | `OrderedReady`
 `alertmanager.priorityClassName` | alertmanager priorityClassName | `nil`
 `alertmanager.resources` | alertmanager pod resource requests & limits | `{}`
 `alertmanager.securityContext` | Custom [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for Alert Manager containers | `{}`
@@ -246,6 +247,7 @@ Parameter | Description | Default
 `server.podAnnotations` | annotations to be added to Prometheus server pods | `{}`
 `server.statefulsetAnnotations` | annotations to be added to Prometheus server stateful set | `{}'
 `server.replicaCount` | desired number of Prometheus server pods | `1`
+`server.podManagementPolicy` | podManagementPolicy of the statefulset | `OrderedReady`
 `server.resources` | Prometheus server resource requests and limits | `{}`
 `server.securityContext` | Custom [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for server containers | `{}`
 `server.service.annotations` | annotations for Prometheus server service | `{}`

--- a/kubernetes/zenko/charts/prometheus/templates/alertmanager-statefulset.yaml
+++ b/kubernetes/zenko/charts/prometheus/templates/alertmanager-statefulset.yaml
@@ -16,7 +16,7 @@ spec:
       app: {{ template "prometheus.name" . }}
       release: {{ .Release.Name }}
   replicas: {{ .Values.alertmanager.replicaCount }}
-  podManagementPolicy: Parallel
+  podManagementPolicy: {{ .Values.alertmanager.podManagementPolicy }}
   template:
     metadata:
     {{- if .Values.alertmanager.podAnnotations }}

--- a/kubernetes/zenko/charts/prometheus/templates/server-statefulset.yaml
+++ b/kubernetes/zenko/charts/prometheus/templates/server-statefulset.yaml
@@ -19,7 +19,7 @@ spec:
       app: {{ template "prometheus.name" . }}
       release: {{ .Release.Name }}
   replicas: {{ .Values.server.replicaCount }}
-  podManagementPolicy: Parallel
+  podManagementPolicy: {{ .Values.server.podManagementPolicy }}
   template:
     metadata:
     {{- if .Values.server.podAnnotations }}
@@ -146,7 +146,7 @@ spec:
     {{- end }}
     {{- if .Values.server.affinity }}
       affinity:
-{{ toYaml .Values.server.affinity | indent 8 }}
+{{ tpl .Values.server.affinity . | indent 8 }}
     {{- end }}
       terminationGracePeriodSeconds: {{ .Values.server.terminationGracePeriodSeconds }}
       volumes:

--- a/kubernetes/zenko/charts/prometheus/values.yaml
+++ b/kubernetes/zenko/charts/prometheus/values.yaml
@@ -158,6 +158,8 @@ alertmanager:
 
   replicaCount: 1
 
+  podManagementPolicy: OrderedReady
+
   ## alertmanager resource requests and limits
   ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
@@ -607,6 +609,8 @@ server:
     # iam.amazonaws.com/role: prometheus
 
   replicaCount: 1
+
+  podManagementPolicy: OrderedReady
 
   ## Prometheus server resource requests and limits
   ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/kubernetes/zenko/charts/redis-ha/templates/redis-ha-pdb.yaml
+++ b/kubernetes/zenko/charts/redis-ha/templates/redis-ha-pdb.yaml
@@ -9,5 +9,6 @@ spec:
   selector:
     matchLabels:
       release: {{ .Release.Name }}
+      app: {{ template "redis-ha.name" . }}
 {{ toYaml .Values.podDisruptionBudget | indent 2 }}
 {{- end }}

--- a/kubernetes/zenko/values.yaml
+++ b/kubernetes/zenko/values.yaml
@@ -69,7 +69,6 @@ zenko-nfs:
     replicas: *nodeCount
 
 prometheus:
-  enabled: true
   rbac:
     create: true
   alertmanager:
@@ -82,6 +81,17 @@ prometheus:
     enabled: false
   server:
     replicaCount: 2
+    affinity: |
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 5
+          podAffinityTerm:
+            topologyKey: "kubernetes.io/hostname"
+            labelSelector:
+              matchLabels:
+                app: {{ template "prometheus.name" . }}
+                release: {{ .Release.Name | quote }}
+                component: server
 
 mongodb-replicaset:
   replicaSetName: rs0
@@ -128,7 +138,6 @@ redis-ha:
   replicas: *nodeCount
 
 grafana:
-  enabled: true
   sidecar:
     image: zenko/grafana-sidecar:latest
     datasources:

--- a/tests/node_tests/backbeat/tests/crr/azureBackend.js
+++ b/tests/node_tests/backbeat/tests/crr/azureBackend.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const crypto = require('crypto');
+const tags = require('mocha-tags');
 const { series } = require('async');
 
 const { scalityS3Client } = require('../../../s3SDK');
@@ -22,7 +23,8 @@ const keyutf8 = `${keyPrefix}/%EA%9D%8B崰㈌㒈保轖䳷䀰⺩ቆ楪秲ⴝ㿅�
 '%EA%9D%8B崰㈌㒈保轖䳷䀰⺩ቆ楪秲ⴝ㿅鼎僷ꈅꓜ퇬枅࿷염곞召㸾⌙ꪊᆐ庍뉆䌗↎舳㷖족幐鸆蹪幐䎺誧洗靁麀厷ℷ쫤ᛩ꺶㖭簹릍铰᫫眘쁽暨鿐魪셑蛃춧㡡竺뫁噛̷ᗰⷑ錜⑔痴䧫㾵᏷ำꎆ꼵껪멷㄀誕㳓腜쒃컹㑻鳃삚舿췈孨੦⮀Ǌ곓⵪꺼꜈嗼뫘悕錸瑺⁤⑬১㵀⡸Ҏ礄䧛졼⮦ٞ쫁퓡厈譤擵泶鵇俻縫륒㜓垻ㆩꝿ詀펉ᆙ舑䜾힑藪碙ꀎꂰ췊Ᏻ   㘺幽醛잯ද汧Ꟑꛒⶨ쪸숞헹㭔ꡔᘼ뺓ᡆ᡾ᑟ䅅퀭耓弧⢠⇙폪ް蛧⃪Ἔ돫ꕢ븥ヲ캂䝄쟐颺ᓾ둾Ұ껗礞ᾰ瘹蒯硳풛瞋襎奺熝妒컚쉴⿂㽝㝳駵鈚䄖戭䌸᫲ᇁ䙪鸮ᐴ稫ⶭ뀟ھ⦿䴳稉ꉕ捈袿놾띐✯伤䃫⸧ꠏ瘌틳藔ˋ㫣敀䔩㭘식↴⧵佶痊牌ꪌ搒꾛æᤈべ쉴挜炩⽍舘ꆗ줣겤뒑徭Z䐨 敗羥誜嘳ֶꫜ걵ࣀ묟ኋ拃秷膤䨸菥䟆곘縧멀煣卲챸⧃⏶혣뎧邕⢄⭖陙䣎灏ꗛ僚䌁䠒䲎둘ꪎ傩쿌ᨌ뀻阥눉넠猌ㆯ㰢船戦跏灳蝒礯鞰諾벥煸珬㟑孫鞹Ƭꄹ孙ꢱ钐삺韦帇곎矇૧ਔ뙞밺㊑ک씌촃Ȅ頰ᖅ懚ホῐ꠷㯢먈㝹୥밷㮇䘖桲阥黾噘흳뵿澚㷞꫽鲂♤蔏앜嶃쎘嵥撞㒲 댦坪繤삮憫푇噻琕䖰虣誗릊翿뱩䁞ሑ唫ꇘ苉钽뗑☧≳䟟踬ᶄꎶ愚쒄ꣷ鯍裊鮕漨踒ꠍ목탬툖氭锰ꌒ⬧䨑렌肣꾯༭炢뤂㉥ˠٸ൪㤌ᶟ訧ᜒೳ揪Ⴛ摖㸣᳑⹞걀ꢢ䏹" 똣왷䉑摴둜辍㫣ზ㥌甦鵗⾃ꗹ빖ꓡ㲑㩝〯蘼᫩헸ῖ"'; // eslint-disable-line
 const REPLICATION_TIMEOUT = 300000;
 
-describe('Replication with Azure backend', function() {
+tags('flaky') // Tracking via ZENKO-1036
+.describe('Replication with Azure backend', function() {
     this.timeout(REPLICATION_TIMEOUT);
     this.retries(3);
     let roleArn = 'arn:aws:iam::root:role/s3-replication-role';


### PR DESCRIPTION
In order to don't lose data in case of server failures,
soft podAntiAffinity has been added for the Prometheus server
Also, the Prometheus chart has been updated to have
`podManagementPolicy` set to `OrderedReady` for the server and
alertmanager statefulsets in order to prevent volume
node affinity conflicts.