### PR TITLE
ZENKO-1026 move manager out of cloudserver service

### DIFF
--- a/eve/ci-values.yml
+++ b/eve/ci-values.yml
@@ -41,11 +41,13 @@ global:
   orbit:
     endpoint: "http://ciutil-orbit-simulator:4222"
     managerMode: "poll"
+    workerMode: "poll"
 
 cloudserver:
   image:
     pullPolicy: Always
-  replicaCount: 0
+  replicaCount: 3
+  replicaFactor: 1
   env:
     MPU_TESTING: 'yes'
     PUSH_STATS: 'false'

--- a/kubernetes/zenko/charts/cloudserver/templates/manager-deployment.yaml
+++ b/kubernetes/zenko/charts/cloudserver/templates/manager-deployment.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: {{ template "cloudserver.fullname" . }}-manager
   labels:
-    app: {{ template "cloudserver.name" . }}
+    app: {{ template "cloudserver.name" . }}-manager
     chart: {{ template "cloudserver.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -12,7 +12,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ template "cloudserver.name" . }}
+      app: {{ template "cloudserver.name" . }}-manager
       release: {{ .Release.Name }}
   template:
     metadata:
@@ -21,7 +21,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/certificate.yaml") . | sha256sum }}
         {{- end }}
       labels:
-        app: {{ template "cloudserver.name" . }}
+        app: {{ template "cloudserver.name" . }}-manager
         release: {{ .Release.Name }}
     spec:
       containers:


### PR DESCRIPTION
This takes out the manager pod from the cloudserver service so it doesn't have to handle requests along side manager duties.

Note: As pointed out, the manager pod will still service requests that originate from secure channel (browser, search, CRR ops, etc)