### PR TITLE
ZENKO-1051 bf: Add support for redis sentinels

### DIFF
--- a/kubernetes/zenko/charts/backbeat/templates/_helpers.tpl
+++ b/kubernetes/zenko/charts/backbeat/templates/_helpers.tpl
@@ -39,3 +39,12 @@ Create the default mongodb replicaset hosts string
 {{- $release := .Release.Name -}}
 {{- range $v := until $count }}{{ $release }}-mongodb-replicaset-{{ $v }}.{{ $release }}-mongodb-replicaset:27017{{ if ne $v (sub $count 1) }},{{- end -}}{{- end -}}
 {{- end -}}
+
+{{/*
+Create the default redis sentinels hosts string
+*/}}
+{{- define "backbeat.redis-hosts" -}}
+{{- $count := (int .Values.redis.replicas) -}}
+{{- $release := .Release.Name -}}
+{{- range $v := until $count }}{{ $release }}-redis-ha-server-{{ $v }}.{{ $release }}-redis-ha:26379{{ if ne $v (sub $count 1) }},{{- end -}}{{- end -}}
+{{- end -}}

--- a/kubernetes/zenko/charts/backbeat/templates/api/deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/api/deployment.yaml
@@ -36,10 +36,10 @@ spec:
               value: "{{- printf "%s-cloudserver" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: EXTENSIONS_REPLICATION_SOURCE_S3_PORT
               value: "80"
-            - name: REDIS_HOST
-              value: "{{- printf "%s-%s" .Release.Name "redis-ha" | trunc 63 | trimSuffix "-" -}}"
-            - name: REDIS_PORT
-              value: "6379"
+            - name: REDIS_SENTINELS
+              value: "{{ template "backbeat.redis-hosts" . }}"
+            - name: REDIS_HA_NAME
+              value: "{{ .Values.redis.sentinel.name }}"
             - name: HEALTHCHECKS_ALLOWFROM
               value: '0.0.0.0/0'
             - name: EXTENSIONS_REPLICATION_SOURCE_AUTH_ACCOUNT

--- a/kubernetes/zenko/charts/backbeat/templates/replication/data_processor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/replication/data_processor_deployment.yaml
@@ -94,10 +94,10 @@ spec:
             {{- end }}
             - name: MONGODB_HOSTS
               value: "{{ template "backbeat.mongodb-hosts" . }}"
-            - name: REDIS_HOST
-              value: "{{- printf "%s-%s" .Release.Name "redis-ha" | trunc 63 | trimSuffix "-" -}}"
-            - name: REDIS_PORT
-              value: "6379"
+            - name: REDIS_SENTINELS
+              value: "{{ template "backbeat.redis-hosts" . }}"
+            - name: REDIS_HA_NAME
+              value: "{{ .Values.redis.sentinel.name }}"
           livenessProbe:
             httpGet:
               path: {{ .Values.health.path.liveness}}

--- a/kubernetes/zenko/charts/backbeat/templates/replication/populator_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/replication/populator_deployment.yaml
@@ -51,10 +51,10 @@ spec:
             {{- end }}
             - name: MONGODB_HOSTS
               value: "{{ template "backbeat.mongodb-hosts" . }}"
-            - name: REDIS_HOST
-              value: "{{- printf "%s-%s" .Release.Name "redis-ha" | trunc 63 | trimSuffix "-" -}}"
-            - name: REDIS_PORT
-              value: "6379"
+            - name: REDIS_SENTINELS
+              value: "{{ template "backbeat.redis-hosts" . }}"
+            - name: REDIS_HA_NAME
+              value: "{{ .Values.redis.sentinel.name }}"
             - name: LOG_LEVEL
               value: {{ .Values.logging.level }}
           livenessProbe:

--- a/kubernetes/zenko/charts/backbeat/templates/replication/status_processor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/replication/status_processor_deployment.yaml
@@ -53,10 +53,10 @@ spec:
             - name: EXTENSIONS_REPLICATION_SOURCE_AUTH_ACCOUNT
               value: Replication
             {{- end }}
-            - name: REDIS_HOST
-              value: "{{- printf "%s-%s" .Release.Name "redis-ha" | trunc 63 | trimSuffix "-" -}}"
-            - name: REDIS_PORT
-              value: "6379"
+            - name: REDIS_SENTINELS
+              value: "{{ template "backbeat.redis-hosts" . }}"
+            - name: REDIS_HA_NAME
+              value: "{{ .Values.redis.sentinel.name }}"
             - name: LOG_LEVEL
               value: {{ .Values.logging.level }}
           livenessProbe:

--- a/kubernetes/zenko/charts/backbeat/values.yaml
+++ b/kubernetes/zenko/charts/backbeat/values.yaml
@@ -10,7 +10,7 @@ global:
 
 image:
   repository: zenko/backbeat
-  tag: 8.0.8-RC5
+  tag: 8.0.9-RC6
   pullPolicy: IfNotPresent
 
 logging:

--- a/kubernetes/zenko/charts/backbeat/values.yaml
+++ b/kubernetes/zenko/charts/backbeat/values.yaml
@@ -21,6 +21,11 @@ mongodb:
   replicaSet: rs0
   replicas: 3
 
+redis:
+  sentinel:
+    name: zenko
+  replicas: 3
+
 health:
   port: 4042
   path:

--- a/kubernetes/zenko/charts/cloudserver/templates/_env.tpl
+++ b/kubernetes/zenko/charts/cloudserver/templates/_env.tpl
@@ -6,10 +6,10 @@ env:
     value: "{{- printf "%s-%s" .Release.Name "redis-ha" | trunc 63 | trimSuffix "-" -}}"
   - name: REDIS_PORT
     value: "6379"
-  - name: REDIS_HA_HOST
-    value: "{{- printf "%s-%s" .Release.Name "redis-ha" | trunc 63 | trimSuffix "-" -}}"
-  - name: REDIS_HA_PORT
-    value: "6379"
+  - name: REDIS_SENTINELS
+    value: "{{ template "backbeat.redis-hosts" . }}"
+  - name: REDIS_HA_NAME
+    value: "{{ .Values.redis.sentinel.name }}"
   - name: CRR_METRICS_HOST
     value: "{{- printf "%s-%s" .Release.Name "backbeat-api" | trunc 63 | trimSuffix "-" -}}"
   - name: CRR_METRICS_PORT

--- a/kubernetes/zenko/charts/cloudserver/templates/_helpers.tpl
+++ b/kubernetes/zenko/charts/cloudserver/templates/_helpers.tpl
@@ -48,3 +48,11 @@ Increases the number of cloudserver replicas by the replicaFactor value
 {{- printf "%d" $factor }}
 {{- end -}}
 
+{{/*
+Create the default redis sentinels hosts string
+*/}}
+{{- define "cloudserver.redis-hosts" -}}
+{{- $count := (int .Values.redisha.replicas) -}}
+{{- $release := .Release.Name -}}
+{{- range $v := until $count }}{{ $release }}-redis-ha-server-{{ $v }}.{{ $release }}-redis-ha:26379{{ if ne $v (sub $count 1) }},{{- end -}}{{- end -}}
+{{- end -}}

--- a/kubernetes/zenko/charts/cloudserver/values.yaml
+++ b/kubernetes/zenko/charts/cloudserver/values.yaml
@@ -84,7 +84,7 @@ replicaFactor: 1
 
 image:
   repository: zenko/cloudserver
-  tag: 8.0.10-RC5
+  tag: 8.0.11-RC6
   pullPolicy: IfNotPresent
 
 proxy:

--- a/kubernetes/zenko/charts/cloudserver/values.yaml
+++ b/kubernetes/zenko/charts/cloudserver/values.yaml
@@ -70,6 +70,11 @@ mongodb:
   replicaSet: rs0
   replicas: 3
 
+redis:
+  sentinel:
+    name: zenko
+  replicas: 3
+
 # Replication factor will deploy n * replicaCount for deployments that need
 # not only HA but high performance and throughput. When Orbit is enabled, there
 # will be an additional stateless single manager pod deployed which serves as the


### PR DESCRIPTION
# Cloudserver CHANGELOG:
Link to container image of [cloudserver](https://hub.docker.com/r/zenko/cloudserver/).

* Merge branch 'bugfix/ZENKO-1051_Add_sentinel_support_to_redis_config' into q/8.0
* ZENKO-1051 Add redis sentinel support
* Merge branch 'bugfix/ZENKO-1013/useBackbeatApiMetrics' into q/8.0
* bf: ZENKO-1013 use backbeat api metrics routes for stats
* bf: ZENKO 876 increase flaky test timeout
* Merge remote-tracking branch 'origin/bugfix/ZENKO-945-arsenal-fix-in-s3' into w/8.0/bugfix/ZENKO-945-arsenal-fix-in-s3
* ZENKO-645: bump arsenal version to have delimiterMaster::filter fix
* Merge remote-tracking branch 'origin/bugfix/ZENKO-1018/use-disabled-status' into w/8.0/bugfix/ZENKO-1018/use-disabled-status
* bugfix: ZENKO-1018 Disabled status for CRR config

# Backbeat CHANGELOG:

Link to container image of [backbeat](https://hub.docker.com/r/zenko/backbeat/).

* bugfix: ZENKO-1024 Add pending counters
* Merge branch 'bugfix/ZENKO-1051_Change_to_sentinel_redis_config' into q/8.0
* ZENKO-1051 Add support for redis sentinels
* Merge branch 'bugfix/ZENKO-1050-pauseResumeRework' into q/8.0
* Merge branch 'bugfix/ZENKO-1052-fixContentTypePromclient' into q/8.0
* Merge branch 'bugfix/ZENKO-1047-disableAPIInternalTime' into q/8.0
* bf: ZENKO-1050 pause/resume should delete schedule
* rf: rename and reuse http request method
* ft: ZENKO-1019 add delete for scheduled resume
* bf: ZENKO-1052 send text/plain type for promclient
* bf: disable api internal start timer
