### PR TITLE
ft: retain s3-data pvc on helm delete

### DIFF
--- a/kubernetes/zenko/charts/s3-data/templates/pvc.yaml
+++ b/kubernetes/zenko/charts/s3-data/templates/pvc.yaml
@@ -5,6 +5,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ template "s3-data.fullname" . }}
   annotations:
+    "helm.sh/resource-policy": keep
   {{- if .Values.persistentVolume.annotations }}
 {{ toYaml .Values.persistentVolume.annotations | indent 4 }}
   {{- end }}


### PR DESCRIPTION
Prevents helm from deleting the s3-data pvc automatically on `helm delete`