### PR TITLE
ZENKO-965 bugfix: incorrect Grafana password

### DIFF
--- a/kubernetes/zenko/charts/grafana/templates/deployment.yaml
+++ b/kubernetes/zenko/charts/grafana/templates/deployment.yaml
@@ -24,8 +24,9 @@ spec:
       labels:
         app: {{ template "grafana.name" . }}
         release: {{ .Release.Name }}
-{{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+{{- with .Values.podAnnotations }}
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:


### PR DESCRIPTION
The issue of Grafana having the wrong password is most likely due to https://github.com/helm/charts/issues/2627. These changes add a checksum annotation to the deployment, which increases the chances of the password stored in the secret been the same one stored on the Grafana server. However, it's not a guarantee.
The only way to guarantee it is by specifying a password on the values.yaml file.