### PR TITLE
improvement: ZENKO-1004 Write file on MD5 mismatch

### DIFF
--- a/tests/node_tests/backbeat/ReplicationUtility.js
+++ b/tests/node_tests/backbeat/ReplicationUtility.js
@@ -21,15 +21,15 @@ class ReplicationUtility {
     _compareObjectBody(body1, body2) {
         const digest1 = crypto.createHash('md5').update(body1).digest('hex');
         const digest2 = crypto.createHash('md5').update(body2).digest('hex');
-        // if (digest1 !== digest2) {
-        //     // dump data for later investigation
-        //     const filePrefix = `${process.env.CIRCLE_ARTIFACTS}/` +
-        //               `genericStaas_backbeat_md5_mismatch_body`;
-        //     fs.writeFileSync(`${filePrefix}1.bin`, body1);
-        //     fs.writeFileSync(`${filePrefix}2.bin`, body2);
-        //     console.error('md5 mismatch: data dumped in ' +
-        //                   `${filePrefix}{1,2}.bin`);
-        // }
+        if (digest1 !== digest2) {
+            // dump data for later investigation
+            const filePrefix = 'backbeat_md5_mismatch_body';
+            const artifactsDirectory = `${process.cwd()}/../../artifacts`;
+            fs.writeFileSync(`${artifactsDirectory}/${filePrefix}1.bin`, body1);
+            fs.writeFileSync(`${artifactsDirectory}/${filePrefix}2.bin`, body2);
+            console.error('md5 mismatch: data dumped in ' +
+                `${filePrefix}{1,2}.bin`);
+        }
         assert.strictEqual(digest1, digest2);
     }
 


### PR DESCRIPTION
When there is an MD5 content mismatch for replicated objects, write the file contents to the build artifacts for further investigation.