### PR TITLE
ZENKO-1085 bugfix: backbeat liveness probes

### DIFF
--- a/kubernetes/zenko/charts/backbeat/templates/gc/deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/gc/deployment.yaml
@@ -41,10 +41,6 @@ spec:
             httpGet:
               path: {{ .Values.health.path.liveness}}
               port: {{ .Values.health.port }}
-          readinessProbe:
-            httpGet:
-              path: {{ .Values.health.path.readiness }}
-              port: {{ .Values.health.port }}
           resources:
 {{ toYaml .Values.garbageCollector.consumer.resources | indent 12 }}
     {{- with .Values.garbageCollector.consumer.nodeSelector }}

--- a/kubernetes/zenko/charts/backbeat/templates/ingestion/consumer_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/ingestion/consumer_deployment.yaml
@@ -44,10 +44,6 @@ spec:
             httpGet:
               path: {{ .Values.health.path.liveness }}
               port: {{ .Values.health.port }}
-          readinessProbe:
-            httpGet:
-              path: {{ .Values.health.path.readiness }}
-              port: {{ .Values.health.port }}
           resources:
 {{ toYaml .Values.ingestion.consumer.resources | indent 12 }}
     {{- with .Values.ingestion.consumer.nodeSelector }}

--- a/kubernetes/zenko/charts/backbeat/templates/ingestion/producer_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/ingestion/producer_deployment.yaml
@@ -43,10 +43,6 @@ spec:
             httpGet:
               path: {{ .Values.health.path.liveness }}
               port: {{ .Values.health.port }}
-          readinessProbe:
-            httpGet:
-              path: {{ .Values.health.path.readiness }}
-              port: {{ .Values.health.port }}
           resources:
 {{ toYaml .Values.ingestion.producer.resources | indent 12 }}
     {{- with .Values.ingestion.producer.nodeSelector }}

--- a/kubernetes/zenko/charts/backbeat/templates/lifecycle/bucket_processor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/lifecycle/bucket_processor_deployment.yaml
@@ -63,10 +63,6 @@ spec:
             httpGet:
               path: {{ .Values.health.path.liveness}}
               port: {{ .Values.health.port }}
-          readinessProbe:
-            httpGet:
-              path: {{ .Values.health.path.readiness }}
-              port: {{ .Values.health.port }}
           resources:
 {{ toYaml .Values.lifecycle.bucketProcessor.resources | indent 12 }}
     {{- with .Values.lifecycle.bucketProcessor.nodeSelector }}

--- a/kubernetes/zenko/charts/backbeat/templates/lifecycle/conductor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/lifecycle/conductor_deployment.yaml
@@ -53,10 +53,6 @@ spec:
             httpGet:
               path: {{ .Values.health.path.liveness}}
               port: {{ .Values.health.port }}
-          readinessProbe:
-            httpGet:
-              path: {{ .Values.health.path.readiness }}
-              port: {{ .Values.health.port }}
           resources:
 {{ toYaml .Values.lifecycle.conductor.resources | indent 12 }}
     {{- with .Values.lifecycle.conductor.nodeSelector }}

--- a/kubernetes/zenko/charts/backbeat/templates/lifecycle/object_processor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/lifecycle/object_processor_deployment.yaml
@@ -63,10 +63,6 @@ spec:
             httpGet:
               path: {{ .Values.health.path.liveness}}
               port: {{ .Values.health.port }}
-          readinessProbe:
-            httpGet:
-              path: {{ .Values.health.path.readiness }}
-              port: {{ .Values.health.port }}
           resources:
 {{ toYaml .Values.lifecycle.objectProcessor.resources | indent 12 }}
     {{- with .Values.lifecycle.objectProcessor.nodeSelector }}

--- a/kubernetes/zenko/charts/backbeat/templates/replication/data_processor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/replication/data_processor_deployment.yaml
@@ -102,10 +102,6 @@ spec:
             httpGet:
               path: {{ .Values.health.path.liveness}}
               port: {{ .Values.health.port }}
-          readinessProbe:
-            httpGet:
-              path: {{ .Values.health.path.readiness }}
-              port: {{ .Values.health.port }}
           {{- if not .Values.global.orbit.enabled }}
           volumeMounts:
             - name: auth-config

--- a/kubernetes/zenko/charts/backbeat/templates/replication/populator_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/replication/populator_deployment.yaml
@@ -61,10 +61,6 @@ spec:
             httpGet:
               path: {{ .Values.health.path.liveness}}
               port: {{ .Values.health.port }}
-          readinessProbe:
-            httpGet:
-              path: {{ .Values.health.path.readiness }}
-              port: {{ .Values.health.port }}
           resources:
 {{ toYaml .Values.replication.populator.resources | indent 12 }}
     {{- with .Values.replication.populator.nodeSelector }}

--- a/kubernetes/zenko/charts/backbeat/templates/replication/status_processor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/replication/status_processor_deployment.yaml
@@ -63,10 +63,6 @@ spec:
             httpGet:
               path: {{ .Values.health.path.liveness}}
               port: {{ .Values.health.port }}
-          readinessProbe:
-            httpGet:
-              path: {{ .Values.health.path.readiness }}
-              port: {{ .Values.health.port }}
           resources:
 {{ toYaml .Values.replication.statusProcessor.resources | indent 12 }}
     {{- with .Values.replication.statusProcessor.nodeSelector }}

--- a/kubernetes/zenko/charts/backbeat/values.yaml
+++ b/kubernetes/zenko/charts/backbeat/values.yaml
@@ -29,8 +29,7 @@ redis:
 health:
   port: 4042
   path:
-    liveness: /_/health/liveness
-    readiness: /_/health/readiness
+    liveness: /_/health/readiness
 
 api:
   replicaCount: 1


### PR DESCRIPTION
There is no point on having readiness probes for
the Backbeat pods since they don't serve requests
(except for BackbeatAPI).

Also, the **readiness** probe route is more appropriate for
the **liveness** probe since it detects when a connection
to a dependency (i.e. Zookeeper) is lost and
Kubernetes can take advantage of that to restart
pods and allow them to reconnect properly. This is
necessary since the Backbeat pods don't seem to recover
on their own from these disconnections.