### PR TITLE
improvement: create bootstrap lists from global or replica count

### DIFF
--- a/kubernetes/zenko/charts/backbeat/templates/_helpers.tpl
+++ b/kubernetes/zenko/charts/backbeat/templates/_helpers.tpl
@@ -35,16 +35,34 @@ Create chart name and version as used by the chart label.
 Create the default mongodb replicaset hosts string
 */}}
 {{- define "backbeat.mongodb-hosts" -}}
-{{- $count := (atoi (printf "%d" (int64 .Values.mongodb.replicas))) -}}
+{{- $count := (int ( default .Values.global.nodeCount .Values.mongodb.replicas)) -}}
 {{- $release := .Release.Name -}}
 {{- range $v := until $count }}{{ $release }}-mongodb-replicaset-{{ $v }}.{{ $release }}-mongodb-replicaset:27017{{ if ne $v (sub $count 1) }},{{- end -}}{{- end -}}
+{{- end -}}
+
+{{/*
+Create default queue hosts string
+*/}}
+{{- define "backbeat.queue-hosts" -}}
+{{- $count := (int (default .Values.global.nodeCount .Values.queue.replicas)) -}}
+{{- $release := .Release.Name -}}
+{{- range $v := until $count }}{{ $release }}-zenko-queue-{{ $v }}.{{ $release }}-zenko-queue-headless:9092{{ if ne $v (sub $count 1) }},{{- end -}}{{- end -}}
+{{- end -}}
+
+{{/*
+Create default quorum hosts string
+*/}}
+{{- define "backbeat.quorum-hosts" -}}
+{{- $count := (int (default .Values.global.nodeCount .Values.quorum.replicas)) -}}
+{{- $release := .Release.Name -}}
+{{- range $v := until $count }}{{ $release }}-zenko-quorum-{{ $v }}.{{ $release }}-zenko-quorum-headless:2181{{ if ne $v (sub $count 1) }},{{- end -}}{{- end -}}
 {{- end -}}
 
 {{/*
 Create the default redis sentinels hosts string
 */}}
 {{- define "backbeat.redis-hosts" -}}
-{{- $count := (int .Values.redis.replicas) -}}
+{{- $count := (int (default .Values.global.nodeCount .Values.redis.replicas)) -}}
 {{- $release := .Release.Name -}}
 {{- range $v := until $count }}{{ $release }}-redis-ha-server-{{ $v }}.{{ $release }}-redis-ha:26379{{ if ne $v (sub $count 1) }},{{- end -}}{{- end -}}
 {{- end -}}
@@ -53,6 +71,6 @@ Create the default redis sentinels hosts string
 Create the default replicaCount for backbeat replication data processors
 */}}
 {{- define "backbeat.replication.dataProcessor.replicaCount" -}}
-{{- $count := mul .Values.replication.dataProcessor.replicaFactor .Values.replication.dataProcessor.replicaCount -}}
+{{- $count := mul .Values.replication.dataProcessor.replicaFactor (default .Values.global.nodeCount .Values.replication.dataProcessor.replicaCount) -}}
 {{- printf "%d" $count }}
 {{- end -}}

--- a/kubernetes/zenko/charts/backbeat/templates/replication/data_processor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/replication/data_processor_deployment.yaml
@@ -49,9 +49,9 @@ spec:
             - name: ZOOKEEPER_AUTO_CREATE_NAMESPACE
               value: "1"
             - name: ZOOKEEPER_CONNECTION_STRING
-              value: "{{- printf "%s-zenko-quorum:2181" .Release.Name | trunc 63 | trimSuffix "-" -}}"
+              value: "{{ template "backbeat.quorum-hosts" . }}"
             - name: KAFKA_HOSTS
-              value: "{{- printf "%s-zenko-queue:9092" .Release.Name | trunc 63 | trimSuffix "-" -}}"
+              value: "{{ template "backbeat.queue-hosts" . }}"
             - name: LOG_LEVEL
               value: {{ .Values.logging.level }}
             - name: EXTENSIONS_REPLICATION_SOURCE_S3_HOST

--- a/kubernetes/zenko/charts/backbeat/templates/replication/populator_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/replication/populator_deployment.yaml
@@ -28,9 +28,9 @@ spec:
             - name: ZOOKEEPER_AUTO_CREATE_NAMESPACE
               value: "1"
             - name: ZOOKEEPER_CONNECTION_STRING
-              value: "{{- printf "%s-zenko-quorum:2181" .Release.Name | trunc 63 | trimSuffix "-" -}}"
+              value: "{{ template "backbeat.quorum-hosts" . }}"
             - name: KAFKA_HOSTS
-              value: "{{- printf "%s-zenko-queue:9092" .Release.Name | trunc 63 | trimSuffix "-" -}}"
+              value: "{{ template "backbeat.queue-hosts" . }}"
             {{- if .Values.global.orbit.enabled }}
             - name: REMOTE_MANAGEMENT_DISABLE
               value: "0"

--- a/kubernetes/zenko/charts/backbeat/templates/replication/status_processor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/replication/status_processor_deployment.yaml
@@ -29,9 +29,9 @@ spec:
             - name: ZOOKEEPER_AUTO_CREATE_NAMESPACE
               value: "1"
             - name: ZOOKEEPER_CONNECTION_STRING
-              value: "{{- printf "%s-zenko-quorum:2181" .Release.Name | trunc 63 | trimSuffix "-" -}}"
+              value: "{{ template "backbeat.quorum-hosts" . }}"
             - name: KAFKA_HOSTS
-              value: "{{- printf "%s-zenko-queue:9092" .Release.Name | trunc 63 | trimSuffix "-" -}}"
+              value: "{{ template "backbeat.queue-hosts" . }}"
             - name: MONGODB_HOSTS
               value: "{{ template "backbeat.mongodb-hosts" . }}"
             - name: EXTENSIONS_REPLICATION_SOURCE_S3_HOST

--- a/kubernetes/zenko/charts/backbeat/values.yaml
+++ b/kubernetes/zenko/charts/backbeat/values.yaml
@@ -3,6 +3,7 @@
 # Declare variables to be passed into your templates.
 
 global:
+  nodeCount: 3
   orbit:
     enabled: true
   locationConstraints: {}
@@ -19,17 +20,23 @@ logging:
 
 mongodb:
   replicaSet: rs0
-  replicas: 3
+  replicas:
 
 redis:
   sentinel:
     name: zenko
-  replicas: 3
+  replicas:
 
 health:
   port: 4042
   path:
     liveness: /_/health/readiness
+
+queue:
+  replicas:
+
+quorum:
+  replicas:
 
 api:
   replicaCount: 1

--- a/kubernetes/zenko/charts/cloudserver/templates/_helpers.tpl
+++ b/kubernetes/zenko/charts/cloudserver/templates/_helpers.tpl
@@ -35,7 +35,7 @@ Create chart name and version as used by the chart label.
 Create the default mongodb replicaset hosts string
 */}}
 {{- define "cloudserver.mongodb-hosts" -}}
-{{- $count := (atoi (printf "%d" (int64 .Values.mongodb.replicas))) -}}
+{{- $count := (int (default .Values.global.nodeCount .Values.mongodb.replicas)) -}}
 {{- $release := .Release.Name -}}
 {{- range $v := until $count }}{{ $release }}-mongodb-replicaset-{{ $v }}.{{ $release }}-mongodb-replicaset:27017{{ if ne $v (sub $count 1) }},{{- end -}}{{- end -}}
 {{- end -}}
@@ -44,7 +44,7 @@ Create the default mongodb replicaset hosts string
 Increases the number of cloudserver replicas by the replicaFactor value
 */}}
 {{- define "cloudserver.replicaFactor" -}}
-{{- $factor := mul .Values.replicaFactor .Values.replicaCount -}}
+{{- $factor := mul .Values.replicaFactor (default .Values.global.nodeCount .Values.replicaCount) -}}
 {{- printf "%d" $factor }}
 {{- end -}}
 
@@ -52,7 +52,7 @@ Increases the number of cloudserver replicas by the replicaFactor value
 Create the default redis sentinels hosts string
 */}}
 {{- define "cloudserver.redis-hosts" -}}
-{{- $count := (int .Values.redisha.replicas) -}}
+{{- $count := (int (default .Values.global.nodeCount .Values.redis.replicas)) -}}
 {{- $release := .Release.Name -}}
 {{- range $v := until $count }}{{ $release }}-redis-ha-server-{{ $v }}.{{ $release }}-redis-ha:26379{{ if ne $v (sub $count 1) }},{{- end -}}{{- end -}}
 {{- end -}}

--- a/kubernetes/zenko/charts/cloudserver/values.yaml
+++ b/kubernetes/zenko/charts/cloudserver/values.yaml
@@ -3,6 +3,7 @@
 # Declare variables to be passed into your templates.
 
 global:
+  nodeCount: 3
   orbit:
     enabled: true
     endpoint: https://api.zenko.io
@@ -68,18 +69,15 @@ env: {}
 
 mongodb:
   replicaSet: rs0
-  replicas: 3
 
 redis:
   sentinel:
     name: zenko
-  replicas: 3
 
 # Replication factor will deploy n * replicaCount for deployments that need
 # not only HA but high performance and throughput. When Orbit is enabled, there
 # will be an additional stateless single manager pod deployed which serves as the
 # "manager" for reporting metrics. This manager pod currently cannot scale replicas.
-replicaCount: 3
 replicaFactor: 1
 
 image:

--- a/kubernetes/zenko/charts/zenko-nfs/templates/_helpers.tpl
+++ b/kubernetes/zenko/charts/zenko-nfs/templates/_helpers.tpl
@@ -35,7 +35,7 @@ Create chart name and version as used by the chart label.
 Create the default mongodb replicaset hosts string
 */}}
 {{- define "zenko-nfs.mongodb-hosts" -}}
-{{- $count := (atoi (printf "%d" (int64 .Values.mongodb.replicas))) -}}
+{{- $count := (int .Values.mongodb.replicas) | default  (int .Values.global.nodeCount) -}}
 {{- $release := .Release.Name -}}
 {{- range $v := until $count }}{{ $release }}-mongodb-replicaset-{{ $v }}.{{ $release }}-mongodb-replicaset:27017{{ if ne $v (sub $count 1) }},{{- end -}}{{- end -}}
 {{- end -}}

--- a/kubernetes/zenko/values.yaml
+++ b/kubernetes/zenko/values.yaml
@@ -1,11 +1,18 @@
 # Default values for zenko.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-
-# By default, MongoDB, Redis-HA, Zenko-Queue, and Zenko-Quorum
-# will use this value for their replica count. Typically, this
-# is equivalent to the number of nodes in a Kubernetes Cluster.
-nodeCount: &nodeCount 3
+global:
+  # By default, MongoDB, Redis-HA, Zenko-Queue, and Zenko-Quorum
+  # will use this value for their replica count. Typically, this
+  # is equivalent to the number of nodes in a Kubernetes Cluster.
+  nodeCount: &nodeCount 3
+  orbit:
+    enabled: true
+    endpoint: https://api.zenko.io
+    # When 'orbit.enabled' is 'true', these aren't used, please use
+    # https://zenko.io to manage your deployment
+  locationConstraints: {}
+  replicationEndpoints: []
 
 ingress:
   enabled: false
@@ -24,20 +31,9 @@ ingress:
     #   hosts:
     #     - zenko.example.com
 
-global:
-  orbit:
-    enabled: true
-    endpoint: https://api.zenko.io
-    # When 'orbit.enabled' is 'true', these aren't used, please use
-    # https://zenko.io to manage your deployment
-  locationConstraints: {}
-  replicationEndpoints: []
-
 cloudserver:
   replicaCount: *nodeCount
   replicaFactor: 10
-  mongodb:
-    replicas: *nodeCount
   endpoint: zenko.local
   users: {}
     # accountName:
@@ -61,13 +57,9 @@ backbeat:
       replicaCount: *nodeCount
   ingestion:
     enabled: false
-  mongodb:
-    replicas: *nodeCount
 
 zenko-nfs:
   enabled: false
-  mongodb:
-    replicas: *nodeCount
 
 prometheus:
   rbac:


### PR DESCRIPTION
Allows for the backbeat chart and cloudserver chart to create bootstrap lists of all statefulsets based off global `nodeCount` or `replica` count if custom configuration is needed but default to the global `nodeCount`