### PR TITLE
ZENKO-1134 feature: cleanup config job

### DIFF
--- a/kubernetes/zenko/charts/zenko-queue/templates/job-config.yaml
+++ b/kubernetes/zenko/charts/zenko-queue/templates/job-config.yaml
@@ -9,6 +9,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade,post-rollback
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:
     metadata:


### PR DESCRIPTION
<!--
Thank you for contributing to Zenko!

Please enter applicable information below.
-->

**What does this PR do, and why do we need it?**

This PR adds a Helm hook that will delete the `zenko-queue-config` `job` after it succeeds once. It will delete all the associated pods in `Error` state.

**Which issue does this PR fix?**

fixes ZENKO-1134

**Special notes for your reviewers**:
