### PR TITLE
Revert "ZENKO-1134 [zenko-queue]: cleanup job when it succeeds"

### DIFF
--- a/kubernetes/zenko/charts/zenko-queue/templates/job-config.yaml
+++ b/kubernetes/zenko/charts/zenko-queue/templates/job-config.yaml
@@ -9,10 +9,6 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade,post-rollback
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:
     metadata:


### PR DESCRIPTION
This reverts commit 9e3d3ee5d0d58655ace7e64ab61f85a7b18c774f.

**What does this PR do, and why do we need it?**
Bug was introduced with the above commit that can cause helm installs to fail as a result of helm waiting for queue job to finish (exceeds helm timeout).

**Which issue does this PR fix?**

fixes ZENKO-1134

**Special notes for your reviewers**:
We will revert the commit and the original issue addressed can be handled in a separate PR.
