### PR TITLE
bump cloudserver chart version

### DIFF
--- a/kubernetes/zenko/charts/cloudserver/Chart.yaml
+++ b/kubernetes/zenko/charts/cloudserver/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "8.0.14"
 description: A Helm chart for Kubernetes
 name: cloudserver
-version: 1.0.0-RC6
+version: 1.0.0-RC7


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
Missing cloudserver chart bumped to RC7
