### PR TITLE
[cloudserver] bugfix: redis-hosts template typo

### DIFF
--- a/kubernetes/zenko/charts/cloudserver/templates/_env.tpl
+++ b/kubernetes/zenko/charts/cloudserver/templates/_env.tpl
@@ -7,7 +7,7 @@ env:
   - name: REDIS_PORT
     value: "6379"
   - name: REDIS_SENTINELS
-    value: "{{ template "backbeat.redis-hosts" . }}"
+    value: "{{ template "cloudserver.redis-hosts" . }}"
   - name: REDIS_HA_NAME
     value: "{{ .Values.redis.sentinel.name }}"
   - name: CRR_METRICS_HOST

--- a/kubernetes/zenko/charts/cloudserver/templates/_helpers.tpl
+++ b/kubernetes/zenko/charts/cloudserver/templates/_helpers.tpl
@@ -52,7 +52,7 @@ Increases the number of cloudserver replicas by the replicaFactor value
 Create the default redis sentinels hosts string
 */}}
 {{- define "cloudserver.redis-hosts" -}}
-{{- $count := (int .Values.redisha.replicas) -}}
+{{- $count := (int .Values.redis.replicas) -}}
 {{- $release := .Release.Name -}}
 {{- range $v := until $count }}{{ $release }}-redis-ha-server-{{ $v }}.{{ $release }}-redis-ha:26379{{ if ne $v (sub $count 1) }},{{- end -}}{{- end -}}
 {{- end -}}


### PR DESCRIPTION
<!--
Thank you for contributing to Zenko!

Please enter applicable information below.
-->

**What does this PR do, and why do we need it?**

Fixes a typo that didn't prevent Zenko from templating properly but it may cause issues in the future.
