### PR TITLE
bugfix: redis chart corner cases

### DIFF
--- a/kubernetes/zenko/charts/redis-ha/Chart.yaml
+++ b/kubernetes/zenko/charts/redis-ha/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 3.0.2-Z
+version: 3.0.3-Z
 appVersion: 4.0.11
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png

--- a/kubernetes/zenko/charts/redis-ha/README.md
+++ b/kubernetes/zenko/charts/redis-ha/README.md
@@ -8,16 +8,22 @@
 $ helm install stable/redis-ha
 ```
 
-By default this chart install one master pod containing redis master container and sentinel container, 2 sentinels and 1 redis slave.
+By default this chart install 3 pods total:
+ * one pod containing a redis master and sentinel containers
+ * two pods each containing redis slave and sentinel containers.
 
 ## Introduction
 
-This chart bootstraps a [Redis](https://redis.io) highly available master/slave configuration that is managed by Redis Sentinel. 
+This chart bootstraps a [Redis](https://redis.io) highly available master/slave statefulset in a [Kubernetes](http://kubernetes.io) cluster using the Helm package manager. 
 
 ## Prerequisites
 
 - Kubernetes 1.5+ with Beta APIs enabled
 - PV provisioner support in the underlying infrastructure
+
+## Upgrading the Chart
+
+Please note that there have been a number of changes simplifying the redis management strategy (for better failover and elections) in the 3.x version of this chart. These changes allow the use of official [redis](https://hub.docker.com/_/redis/) images that do not require special RBAC or ServiceAccount roles. As a result when upgrading from version >=2.0.1 to >=3.0.0 of this chart, `Role`, `RoleBinding`, and `ServiceAccount` resources should be deleted manually.
 
 ## Installing the Chart
 
@@ -41,7 +47,6 @@ $ helm delete <chart-name>
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
-
 ## Configuration
 
 The following table lists the configurable parameters of the Redis chart and their default values.
@@ -55,18 +60,17 @@ The following table lists the configurable parameters of the Redis chart and the
 | `replicas`                       | Number of redis master/slave pods                                                                                            | 3                                                         |
 | `nodeSelector`                   | Node labels for pod assignment                                                                                               | {}                                                        |
 | `tolerations`                    | Toleration labels for pod assignment                                                                                         | []                                                        |
-| `affinity`                       | Affinity for pod assignment                                                                                                  | hard antiaffinity between pods                            |
-| `annotations`                    | See Appliance mode                                                                                                           | ``                                                        |
-| `redis.config`                   | Valid redis config options can be added prior to install and will be applied to each server                                  | see values.yaml                                           |
-| `sentinel.config`                | Valid sentinel config options can be added prior to install and will be applied to each server                               | see values.yaml                                           |
+| `podAntiAffinity.server`         | Antiaffinity for pod assignment of servers, `hard` or `soft`                                                                 | `soft`                                                    |
+| `redis.config`                   | Any valid redis config options in this section will be applied to each server (see below)                                    | see values.yaml                                           |
+| `sentinel.config`                | Any valid sentinel config options in this section will be applied to each sentinel (see below)                               | see values.yaml                                           |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```bash
 $ helm install \
-  --set image=quay.io/smile/redis \
-  --set tag=4.0.6r2 \
+  --set image=redis \
+  --set tag=4.0.11-stretch \
     stable/redis-ha
 ```
 
@@ -80,3 +84,15 @@ $ helm install -f values.yaml stable/redis-ha
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
+## Custom Redis and Sentinel config options
+
+This chart allow for any valid redis or sentinel config option to be passed as a key value pair through the `values.yaml` file.
+
+[Example redis.conf](http://download.redis.io/redis-stable/redis.conf)
+[Example sentinel.conf](http://download.redis.io/redis-stable/sentinel.conf)
+
+For example `repl-timeout 60` would be added to the `redis.config` section of the `values.yaml` as:
+
+```yml
+    repl-timeout: "60"
+```

--- a/kubernetes/zenko/charts/redis-ha/templates/NOTES.txt
+++ b/kubernetes/zenko/charts/redis-ha/templates/NOTES.txt
@@ -7,9 +7,9 @@ To connect to your Redis server:
 1. Get the randomly generated redis password:
    echo $(kubectl get secret {{ template "redis-ha.fullname" . }} -o "jsonpath={.data['auth']}" | base64 -D)
 
-2. Connect to the Redis master pod that you can use as a client:
+2. Connect to the Redis master pod that you can use as a client. By default the {{ template "redis-ha.fullname" . }}-server-0 pod is configured as the master:
 
-   kubectl exec -it $(kubectl get pod -o jsonpath='{range .items[*]}{.metadata.name} {.status.containerStatuses[0].state}{"\n"}{end}' -l redis-role=master | grep running | awk '{print $1}') bash
+   kubectl exec -it {{ template "redis-ha.fullname" . }}-server-0 bash -n {{ .Release.Namespace }}
 
 3. Connect using the Redis CLI (inside container):
 

--- a/kubernetes/zenko/charts/redis-ha/templates/redis-auth-secret.yaml
+++ b/kubernetes/zenko/charts/redis-ha/templates/redis-auth-secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.enabled -}}
+{{- if .Values.auth -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "redis-ha.fullname" . }}
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+type: Opaque
+data:
+  auth: {{ .Values.redisPassword | b64enc | quote }}
+{{- end -}}
+{{- end }}

--- a/kubernetes/zenko/charts/redis-ha/templates/redis-ha-configmap.yaml
+++ b/kubernetes/zenko/charts/redis-ha/templates/redis-ha-configmap.yaml
@@ -14,6 +14,10 @@ data:
     {{- range $key, $value := .Values.redis.config }}
     {{ $key }} {{ $value }}
     {{- end }}
+{{- if .Values.auth }}
+    requirepass replace-default-auth
+    masterauth replace-default-auth
+{{- end }}
 
   sentinel.conf: |
     dir "/data"
@@ -21,92 +25,76 @@ data:
     {{- range $key, $value := .Values.sentinel.config }}
     sentinel {{ $key }} {{ $root.Values.redis.masterGroupName }} {{ $value }}
     {{- end }}
+{{- if .Values.auth }}
+    sentinel auth-pass {{ .Values.redis.masterGroupName }} replace-default-auth
+{{- end }}
 
   init.bash: |
     MASTER=`redis-cli -h {{ template "redis-ha.fullname" . }} -p {{ .Values.sentinel.port }} sentinel get-master-addr-by-name {{ .Values.redis.masterGroupName }} | grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}'`
-    GROUP_NAME=`cat /data/conf/group_name`
     REDIS_CONF=/data/conf/redis.conf
     SENTINEL_CONF=/data/conf/sentinel.conf
-    R_PATCH=/data/conf/redis.patch
-    S_PATCH=/data/conf/sentinel.patch
-
-    set -ex
+    
+    set -e
     function sentinel_update(){
-        #if [[ "$OLD_IP" != "" && "$OLD_IP" != "$POD_IP" ]]; then
-        #    echo "Removing references to previous IP"
-        #    sed -i "s/*.sentinel known.*$OLD_IP//" $SENTINEL_CONF
-        #fi
-        if [[ `grep "sentinel monitor" $SENTINEL_CONF` ]]; then
-            sed -i "s/^.*sentinel monitor.*/sentinel monitor {{ .Values.redis.masterGroupName }} $1 {{ .Values.redis.port }} {{ .Values.sentinel.quorum }}/" $SENTINEL_CONF
-        else
-            sed -i "1s/^/sentinel monitor {{ .Values.redis.masterGroupName }} $1 {{ .Values.redis.port }} {{ .Values.sentinel.quorum }} \n/" $SENTINEL_CONF
-        fi
+        echo "Updating sentinel config"
+        sed -i "1s/^/sentinel monitor {{ .Values.redis.masterGroupName }} $1 {{ .Values.redis.port }} {{ .Values.sentinel.quorum }} \n/" $SENTINEL_CONF
     }
     function redis_update(){
-        if [[ `grep "slaveof" $REDIS_CONF` ]]; then
-            sed -i "s/^.*slaveof.*/slaveof $1 {{ .Values.redis.port }}/" $REDIS_CONF
-        else
-           echo "slaveof $1 {{ .Values.redis.port }}" >> $REDIS_CONF
-        fi
+        echo "Updating redis config"
+        echo "slaveof $1 {{ .Values.redis.port }}" >> $REDIS_CONF
     }
     function setup_defaults(){
+        echo "Setting up defaults"
         if [[ "$HOSTNAME" == "{{ template "redis-ha.fullname" . }}-server-0" ]]; then
             echo "Setting this pod as the default master"
             sed -i "s/^.*slaveof.*//" $REDIS_CONF
             sentinel_update "$POD_IP"
         else
             echo "Setting default slave config.."
-            if [[ `grep "slaveof" $REDIS_CONF` ]]; then
-                sed -i 's/^.*slaveof.*/slaveof {{ template "redis-ha.fullname" . }}-server-0.{{ template "redis-ha.fullname" . }} {{ .Values.redis.port }}/' $REDIS_CONF
-            else
-                echo "slaveof {{ template "redis-ha.fullname" . }}-server-0.{{ template "redis-ha.fullname" . }} {{ .Values.redis.port }}" >> $REDIS_CONF
-            fi
+            echo "slaveof {{ template "redis-ha.fullname" . }}-server-0.{{ template "redis-ha.fullname" . }} {{ .Values.redis.port }}" >> $REDIS_CONF
             sentinel_update "{{ template "redis-ha.fullname" . }}-server-0.{{ template "redis-ha.fullname" . }}"
             redis_update "{{ template "redis-ha.fullname" . }}-server-0.{{ template "redis-ha.fullname" . }}"
         fi
     }
-    function update_config(){
-        if [[ ! `redis-cli -h $MASTER ping` ]]; then
-           echo "Cannot contact master, replacing dead master with default master"
-           setup_defaults
+    function find_master(){
+        echo "Attempting to find master"
+        if [[ ! `redis-cli -h $MASTER{{ if .Values.auth }} -a $AUTH{{ end }} ping` ]]; then
+           echo "Can't ping master, attempting to force failover"
+           if redis-cli -h {{ template "redis-ha.fullname" . }} -p {{ .Values.sentinel.port }} sentinel failover {{ .Values.redis.masterGroupName }} | grep -q 'NOGOODSLAVE' ; then 
+               setup_defaults
+               return 0
+           fi
+           sleep 10
+           MASTER=`redis-cli -h {{ template "redis-ha.fullname" . }} -p {{ .Values.sentinel.port }} sentinel get-master-addr-by-name {{ .Values.redis.masterGroupName }} | grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}'`
+           if [[ "$MASTER" ]]; then
+               sentinel_update $MASTER
+               redis_update $MASTER
+           else
+              echo "Could not failover, exiting..."
+              exit 1
+           fi
         else
             echo "Found reachable master, updating config"
             sentinel_update $MASTER
             redis_update $MASTER
         fi
     }
-    function patch_conf(){
-        if [[ "$GROUP_NAME" != "{{ .Values.redis.masterGroupName }}" ]]; then
-            echo "Removing references to previous group name"
-            sed -i "s/ $GROUP_NAME / {{ .Values.redis.masterGroupName }} /" $SENTINEL_CONF
-        fi
-        {{- range $key, $value := .Values.redis.config }}
-        sed -i "s/^.*{{ $key }}.*/{{ $key }} {{ $value }}/" $REDIS_CONF
-        {{- end }}
-        {{- $root := . -}}
-        {{- range $key, $value := .Values.sentinel.config }}
-        sed -i "s/^.*sentinel {{ $key }}.*/sentinel {{ $key }} {{ $root.Values.redis.masterGroupName }} {{ $value }}/" $SENTINEL_CONF
-        {{- end }}
-    }
     mkdir -p /data/conf/
     echo "Initializing config.."
 
-    if [[ ! -f $REDIS_CONF && ! -f SENTINEL_CONF ]]; then
-        cp /readonly-config/redis.conf $REDIS_CONF
-        cp /readonly-config/sentinel.conf $SENTINEL_CONF
-        if [[ "$MASTER" ]]; then
-            update_config
-        else
-            setup_defaults
-        fi
-    elif [[ "$MASTER" == "" ]]; then
-        echo "Found configs but no redis master found! Configuring default master.."
-        patch_conf
-        setup_defaults
+    cp /readonly-config/redis.conf $REDIS_CONF
+    cp /readonly-config/sentinel.conf $SENTINEL_CONF
+
+    if [[ "$MASTER" ]]; then
+        find_master
     else
-        patch_conf
-        update_config
+        setup_defaults
     fi
-    echo "{{ .Values.redis.masterGroupName }}" > /data/conf/group_name
+    if [[ "$AUTH" ]]; then
+        echo "Setting auth values"
+        sed -i "s/replace-default-auth/$AUTH/" $REDIS_CONF $SENTINEL_CONF
+    fi
+
     echo "Ready..."
+
 {{- end }}

--- a/kubernetes/zenko/charts/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/kubernetes/zenko/charts/redis-ha/templates/redis-ha-statefulset.yaml
@@ -34,17 +34,47 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       {{- end }}
+      {{- if eq .Values.podAntiAffinity "hard" }}
       affinity:
-{{ tpl .Values.affinity . | indent 8 }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: {{ template "redis-ha.name" . }}
+                release: {{ .Release.Name }}
+                component: server
+            topologyKey: kubernetes.io/hostname
+      {{- else if eq .Values.podAntiAffinity "soft" }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: {{ template "redis-ha.name" . }}
+                  release: {{ .Release.Name }}
+                  component: server
+              topologyKey: kubernetes.io/hostname
+      {{- end }}
       securityContext:
 {{ toYaml .Values.securityContext | indent 8 }}
       initContainers:
       - name: config-init
-        image: {{ .Values.image }}:{{ .Values.tag }}
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
-          - "bash"
-          - "/readonly-config/init.bash"
+          - bash
+        args:
+          - /readonly-config/init.bash
         env:
+{{- if .Values.auth }}
+          - name: AUTH
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "redis-ha.fullname" . }}
+                key: auth
+{{- end }}
           - name: POD_IP
             valueFrom:
               fieldRef:
@@ -57,7 +87,8 @@ spec:
             mountPath: /data
       containers:
       - name: redis
-        image: {{ .Values.image }}:{{ .Values.tag }}
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
           - redis-server
         args:
@@ -81,7 +112,8 @@ spec:
           - mountPath: /data
             name: data
       - name: sentinel
-        image: {{ .Values.image }}:{{ .Values.tag }}
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
           - redis-sentinel
         args:

--- a/kubernetes/zenko/charts/redis-ha/templates/tests/test-redis-ha-service.yaml
+++ b/kubernetes/zenko/charts/redis-ha/templates/tests/test-redis-ha-service.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   containers:
   - name: "{{ .Release.Name }}-service-test"
-    image: {{ .Values.image }}:{{ .Values.tag }}
+    image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
     command:
       - sh
       - -c

--- a/kubernetes/zenko/charts/redis-ha/values.yaml
+++ b/kubernetes/zenko/charts/redis-ha/values.yaml
@@ -4,18 +4,20 @@
 
 enabled: true
 
-image: redis
-tag: 4.0.11-stretch
+image:
+  repository: redis
+  tag: 4.0.11-stretch
+  pullPolicy: IfNotPresent
 ## replicas number for each component
 replicas: 3
 
 ## Redis specific configuration options
 redis:
   port: 6379
-  masterGroupName: zenko
-  auth: false          # Not yet implemented - Configures redis with AUTH (requirepass & masterauth conf params)
-  # Any additional redis conf settings can be set as key value pairs as seen below
+  masterGroupName: mymaster
   config:
+    ## Additional redis conf options can be added below
+    ## For all available options see http://download.redis.io/redis-stable/redis.conf
     min-slaves-to-write: 1
     min-slaves-max-lag: 5   # Value in seconds
     maxmemory: "0"       # Max memory to use for each redis instance. Default is unlimited.
@@ -29,27 +31,30 @@ redis:
     rdbchecksum: "yes"
 
   resources:
-      requests:
-        memory: 200Mi
-        cpu: 100m
-      limits:
-        memory: 700Mi
+    requests:
+      memory: 200Mi
+      cpu: 100m
+    limits:
+      memory: 700Mi
 
 ## Sentinel specific configuration options
 sentinel:
   port: 26379
   quorum: 2
   config:
+    ## Additional sentinel conf options can be added below
+    ## For all available options see http://download.redis.io/redis-stable/sentinel.conf
     down-after-milliseconds: 10000
-    failover-timeout: 180000 # Value in milliseconds
+    ## Failover timeout value in milliseconds
+    failover-timeout: 180000
     parallel-syncs: 5
 
   resources:
-      requests:
-        memory: 200Mi
-        cpu: 100m
-      limits:
-        memory: 200Mi
+    requests:
+      memory: 200Mi
+      cpu: 100m
+    limits:
+      memory: 200Mi
 
 securityContext:
   runAsUser: 1000
@@ -59,27 +64,14 @@ securityContext:
 ## Node labels, affinity, and tolerations for pod assignment
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
-nodeSelector: {}
-podAnnotations: {}
-extraLabels: {}
-tolerations: []
-affinity: |
-  podAntiAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-    - labelSelector:
-        matchLabels:
-          app: {{ template "redis-ha.name" . }}
-          release: {{ .Release.Name | quote }}
-      topologyKey: kubernetes.io/hostname
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+podAntiAffinity: soft
 
 podDisruptionBudget:
   maxUnavailable: 1
 
-## Redis password - Not implemented
-## Defaults to a random 10-character alphanumeric string if not set and auth is true
-## ref: https://github.com/kubernetes/charts/blob/master/stable/redis-ha/templates/redis-auth-secret.yaml
-##
-## redisPassword:
+# redisPassword:
+auth: false
 
 persistentVolume:
   enabled: true

--- a/kubernetes/zenko/values.yaml
+++ b/kubernetes/zenko/values.yaml
@@ -161,10 +161,10 @@ zenko-quorum:
 
 redis-ha:
   enabled: true
-  redis_image: zenko/redis-ha:4.0.10-r1
-  rbac:
-    create: true
   replicas: *nodeCount
+  redis:
+    masterGroupName: zenko
+  podAntiAffinity: hard
 
 grafana:
   sidecar:


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
This fixes issues where redis servers can potentially get partitioned after failover and recovery or in certain cases after upgrades. These changes end up making the redis service more robust, better at failovers, and further simplifies implementation.

**Which issue does this PR fix?**

fixes # ZENKO-1145

**Special notes for your reviewers**:
- The relevant fixes themselves are within the configmap
https://github.com/scality/Zenko/pull/329/files#diff-0dd094d379f8ed1f968171377c597949
- There's some fluff being imported here as well (like the README changes) because of the way the upstream chart need to be setup.
- Changes made with input from the helm chart community.
- Lots of reviews and testing along with a user that installed the previous version of this and seemed to have encountered the specific issue this now fixes https://github.com/helm/charts/pull/7323
- All this code already exists in the scality/charts fork as well https://github.com/scality/charts/tree/redis-ha-refactor
- The custom values we had originally in the redis-ha/values.yaml have been moved to the zenko/values.yaml context

I believe these changes bring the redis-ha chart into a much more production ready state.