### PR TITLE
improvement: update to pre-rc8

### DIFF
--- a/kubernetes/zenko/charts/backbeat/Chart.yaml
+++ b/kubernetes/zenko/charts/backbeat/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "8.0.12"
+appVersion: "8.0.13"
 description: A Helm chart for Zenko Backbeat
 name: backbeat
-version: 1.0.0-RC7
+version: 1.0.0-PRE-RC8

--- a/kubernetes/zenko/charts/backbeat/values.yaml
+++ b/kubernetes/zenko/charts/backbeat/values.yaml
@@ -10,7 +10,7 @@ global:
 
 image:
   repository: zenko/backbeat
-  tag: 8.0.12
+  tag: 8.0.13
   pullPolicy: IfNotPresent
 
 logging:

--- a/kubernetes/zenko/charts/cloudserver/Chart.yaml
+++ b/kubernetes/zenko/charts/cloudserver/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "8.0.14"
+appVersion: "8.0.15"
 description: A Helm chart for Kubernetes
 name: cloudserver
-version: 1.0.0-RC7
+version: 1.0.0-PRE-RC8

--- a/kubernetes/zenko/charts/cloudserver/values.yaml
+++ b/kubernetes/zenko/charts/cloudserver/values.yaml
@@ -84,7 +84,7 @@ replicaFactor: 1
 
 image:
   repository: zenko/cloudserver
-  tag: 8.0.14
+  tag: 8.0.15
   pullPolicy: IfNotPresent
 
 proxy:

--- a/kubernetes/zenko/charts/s3-data/Chart.yaml
+++ b/kubernetes/zenko/charts/s3-data/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "8.0.14"
+appVersion: "8.0.15"
 description: A Helm chart for Kubernetes
 name: s3-data
-version: 1.0.0-RC7
+version: 1.0.0-PRE-RC8

--- a/kubernetes/zenko/charts/s3-data/values.yaml
+++ b/kubernetes/zenko/charts/s3-data/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: zenko/cloudserver
-  tag: 8.0.14
+  tag: 8.0.15
   pullPolicy: IfNotPresent
 service:
   name: s3-data


### PR DESCRIPTION
<!--
Thank you for contributing to Zenko!

Please enter applicable information below.
-->

**What does this PR do, and why do we need it?**

Bumps cloudserver and backbeat images to the latest versions, 8.0.15 and 8.0.13 respectively. 
