### PR TITLE
ZENKO 1187 sizing defaults

### DIFF
--- a/kubernetes/single-node-values.yaml
+++ b/kubernetes/single-node-values.yaml
@@ -11,6 +11,10 @@ cloudserver:
   mongodb:
     replicas: *nodeCount
 
+s3-data:
+  persistentVolume:
+    size: 10Gi
+
 backbeat:
   replication:
     dataProcessor:
@@ -69,6 +73,8 @@ zenko-queue:
     - name: backbeat-sanitycheck
       partitions: *nodeCount
       replicationFactor: 1
+  persistence:
+    size: 5Gi
 
 zenko-quorum:
   replicaCount: *nodeCount
@@ -78,6 +84,8 @@ zenko-quorum:
 mongodb-replicaset:
   replicaSet: rs0
   replicas: *nodeCount
+  persistentVolume:
+    size: 10Gi
 
 redis-ha:
   replicas: *nodeCount

--- a/kubernetes/zenko/charts/s3-data/values.yaml
+++ b/kubernetes/zenko/charts/s3-data/values.yaml
@@ -17,7 +17,7 @@ persistentVolume:
     - ReadWriteOnce
   annotations: {}
   existingClaim: ""
-  size: 10Gi
+  size: 90Gi
   # storageClass: "-"
 allowHealthchecksFrom: '0.0.0.0/0'
 

--- a/kubernetes/zenko/storage.yaml
+++ b/kubernetes/zenko/storage.yaml
@@ -26,7 +26,7 @@ mongodb-replicaset:
     ##
     accessModes:
       - ReadWriteOnce
-    size: 10Gi
+    size: 50Gi
     annotations: {}
 
 prometheus:
@@ -76,7 +76,7 @@ s3-data:
       - ReadWriteOnce
     annotations: {}
     existingClaim: ""
-    size: 10Gi
+    size: 90Gi
     storageClass: null
  
 zenko-queue:
@@ -90,7 +90,7 @@ zenko-queue:
     ## The size of the PersistentVolume to allocate to each Kafka Pod in the
     ## StatefulSet. For production servers this should be much larger.
     ##
-    size: "1Gi"
+    size: 20Gi
     ## The location within the Kafka container where the PV will mount its
     ## storage and Kafka will store its logs.
     ##

--- a/kubernetes/zenko/storage.yaml
+++ b/kubernetes/zenko/storage.yaml
@@ -1,10 +1,16 @@
-## These values can be used to override the storage and persistence options
-## of all the stateful charts used in Zenko. While all the options listed
-## are default values, this file can be changed and applied at chart
-## installation time by specifying `-f storage.yaml`. 
+## These values can be used to override the storage and persistence options of
+## all the stateful charts used in Zenko. While all the options listed are the
+## default values, this file can be changed and applied only at chart
+## installation time by specifying `-f storage.yaml`. Values cannot be changed
+## post installation.
 
 mongodb-replicaset:
-  ## Note: number of PVs required is `nodeCount`
+  ## Notes:
+  ##   - number of PVs required is `nodeCount`
+  ##   - Sizing is generally based off max object counts
+  ##     e.g. (Number of objects * 0.01) MB is typically used for sizing
+  ##     objects with the default amount of metadata
+  ##
   persistentVolume:
     enabled: true
     ## mongodb-replicaset data Persistent Volume Storage Class
@@ -25,7 +31,12 @@ mongodb-replicaset:
 
 prometheus:
   server:
-    ## Note: number of PVs required is 2 by default
+    ## Notes:
+    ##   - number of PVs required is 2 by default
+    ##   - This is used for storing application level metrics
+    ##   - Retention policies will attempt to keep 15 days worth of metrics
+    ##     if the volume isn't full
+    ##
     persistentVolume:
       enabled: true
       accessModes:
@@ -40,7 +51,10 @@ prometheus:
       subPath: ""
 
 redis-ha:
-  ## Note: number of PVs required is `nodeCount`
+  ## Notes:
+  ##   - number of PVs required is `nodeCount`
+  ##   - in-memory key-value store vital to the replication services
+  ##
   persistentVolume:
     enabled: true
     storageClass: null
@@ -50,7 +64,12 @@ redis-ha:
     annotations: {}
 
 s3-data:
-  ## Note: number of PVs required is 1
+  ## Notes: 
+  ##   - number of PVs required is 1
+  ##   - this storage is used for the Zenko transient source (data that can be
+  ##     stored locally prior to replication to an external resource)
+  ##   - storing files locally on Zenko is mostly limited by the s3-data volume
+  ##
   persistentVolume:
     enabled: true
     accessModes:
@@ -61,21 +80,28 @@ s3-data:
     storageClass: null
  
 zenko-queue:
-  ## Note: number of PVs required is `nodeCount`
+  ## Notes:
+  ##   - number of PVs required is `nodeCount`
+  ##   - Rention is 7 days by default which will generally use at least 300MB
+  ##     per pod for lighter work loads
+  ##
   persistence:
     enabled: true
-    ## The size of the PersistentVolume to allocate to each Kafka Pod in the StatefulSet. For
-    ## production servers this number should likely be much larger.
+    ## The size of the PersistentVolume to allocate to each Kafka Pod in the
+    ## StatefulSet. For production servers this should be much larger.
     ##
     size: "1Gi"
-    ## The location within the Kafka container where the PV will mount its storage and Kafka will
-    ## store its logs.
+    ## The location within the Kafka container where the PV will mount its
+    ## storage and Kafka will store its logs.
     ##
     mountPath: "/opt/kafka/data"
     storageClass: null
 
 zenko-quorum:
-  ## Note: number of PVs required is `nodeCount`
+  ## Notes:
+  ##   - number of PVs required is `nodeCount`
+  ##   - disk performance is vital here and SSD drives are highly recommended
+  ##
   persistence:
     enabled: true
     storageClass: null

--- a/kubernetes/zenko/values.yaml
+++ b/kubernetes/zenko/values.yaml
@@ -105,6 +105,8 @@ mongodb-replicaset:
     runAsUser: 1000
     fsGroup: 1000
     runAsNonRoot: true
+  persistentVolume:
+    size: 50Gi
 
 zenko-queue:
 ## Extensive list of configurables can be found here:
@@ -150,6 +152,8 @@ zenko-queue:
     - name: backbeat-sanitycheck
       partitions: 1
       replicationFactor: 3
+  persistence:
+    size: 20Gi
 
 zenko-quorum:
 ## Extensive list of configurables can be found here:


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
Updates sizing defaults for 1.0 to more reasonable values that total to a 200GB per node minimum.
**Which issue does this PR fix?**

fixes ZENKO-1187

**Special notes for your reviewers**:
This breaks any upgrades to Zenko from previous versions. (Upgrades would require modifying the values.yaml to previous settings). It's best to do this prior to any production install as it will give us more peace of mind even on 'default' installs where a user may not diligently update the storage values to production ready settings.