### PR TITLE
INTEGRATION [PR#347 > development/1.1] bf: ZENKO-1168 add initial delay before liveness probes

### DIFF
--- a/kubernetes/zenko/charts/backbeat/templates/api/deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/api/deployment.yaml
@@ -52,6 +52,7 @@ spec:
             httpGet:
               path: /_/healthcheck
               port: api
+            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
           # TODO readinessProbe:
           resources:
 {{ toYaml .Values.api.resources | indent 12 }}

--- a/kubernetes/zenko/charts/backbeat/templates/gc/deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/gc/deployment.yaml
@@ -41,6 +41,7 @@ spec:
             httpGet:
               path: {{ .Values.health.path.liveness}}
               port: {{ .Values.health.port }}
+            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
           resources:
 {{ toYaml .Values.garbageCollector.consumer.resources | indent 12 }}
     {{- with .Values.garbageCollector.consumer.nodeSelector }}

--- a/kubernetes/zenko/charts/backbeat/templates/ingestion/consumer_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/ingestion/consumer_deployment.yaml
@@ -44,6 +44,7 @@ spec:
             httpGet:
               path: {{ .Values.health.path.liveness }}
               port: {{ .Values.health.port }}
+            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
           resources:
 {{ toYaml .Values.ingestion.consumer.resources | indent 12 }}
     {{- with .Values.ingestion.consumer.nodeSelector }}

--- a/kubernetes/zenko/charts/backbeat/templates/ingestion/producer_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/ingestion/producer_deployment.yaml
@@ -43,6 +43,7 @@ spec:
             httpGet:
               path: {{ .Values.health.path.liveness }}
               port: {{ .Values.health.port }}
+            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
           resources:
 {{ toYaml .Values.ingestion.producer.resources | indent 12 }}
     {{- with .Values.ingestion.producer.nodeSelector }}

--- a/kubernetes/zenko/charts/backbeat/templates/lifecycle/bucket_processor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/lifecycle/bucket_processor_deployment.yaml
@@ -63,6 +63,7 @@ spec:
             httpGet:
               path: {{ .Values.health.path.liveness}}
               port: {{ .Values.health.port }}
+            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
           resources:
 {{ toYaml .Values.lifecycle.bucketProcessor.resources | indent 12 }}
     {{- with .Values.lifecycle.bucketProcessor.nodeSelector }}

--- a/kubernetes/zenko/charts/backbeat/templates/lifecycle/conductor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/lifecycle/conductor_deployment.yaml
@@ -53,6 +53,7 @@ spec:
             httpGet:
               path: {{ .Values.health.path.liveness}}
               port: {{ .Values.health.port }}
+            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
           resources:
 {{ toYaml .Values.lifecycle.conductor.resources | indent 12 }}
     {{- with .Values.lifecycle.conductor.nodeSelector }}

--- a/kubernetes/zenko/charts/backbeat/templates/lifecycle/object_processor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/lifecycle/object_processor_deployment.yaml
@@ -63,6 +63,7 @@ spec:
             httpGet:
               path: {{ .Values.health.path.liveness}}
               port: {{ .Values.health.port }}
+            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
           resources:
 {{ toYaml .Values.lifecycle.objectProcessor.resources | indent 12 }}
     {{- with .Values.lifecycle.objectProcessor.nodeSelector }}

--- a/kubernetes/zenko/charts/backbeat/templates/replication/data_processor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/replication/data_processor_deployment.yaml
@@ -102,6 +102,7 @@ spec:
             httpGet:
               path: {{ .Values.health.path.liveness}}
               port: {{ .Values.health.port }}
+            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
           {{- if not .Values.global.orbit.enabled }}
           volumeMounts:
             - name: auth-config

--- a/kubernetes/zenko/charts/backbeat/templates/replication/populator_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/replication/populator_deployment.yaml
@@ -61,6 +61,7 @@ spec:
             httpGet:
               path: {{ .Values.health.path.liveness}}
               port: {{ .Values.health.port }}
+            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
           resources:
 {{ toYaml .Values.replication.populator.resources | indent 12 }}
     {{- with .Values.replication.populator.nodeSelector }}

--- a/kubernetes/zenko/charts/backbeat/templates/replication/status_processor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/replication/status_processor_deployment.yaml
@@ -63,6 +63,7 @@ spec:
             httpGet:
               path: {{ .Values.health.path.liveness}}
               port: {{ .Values.health.port }}
+            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
           resources:
 {{ toYaml .Values.replication.statusProcessor.resources | indent 12 }}
     {{- with .Values.replication.statusProcessor.nodeSelector }}

--- a/kubernetes/zenko/charts/backbeat/values.yaml
+++ b/kubernetes/zenko/charts/backbeat/values.yaml
@@ -30,6 +30,7 @@ health:
   port: 4042
   path:
     liveness: /_/health/readiness
+  initialDelaySeconds: 120
 
 api:
   replicaCount: 1

--- a/kubernetes/zenko/charts/cloudserver/templates/deployment.yaml
+++ b/kubernetes/zenko/charts/cloudserver/templates/deployment.yaml
@@ -71,8 +71,9 @@ spec:
           args: ['npm', 'run', 'start_s3server']
           livenessProbe:
             httpGet:
-              path: /_/healthcheck
-              port: http
+              path: {{ .Values.health.path.liveness}}
+              port: {{ .Values.health.port }}
+            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
           volumeMounts:
             {{- if .Values.proxy.caCert }}
             - name: proxy-cert

--- a/kubernetes/zenko/charts/cloudserver/templates/manager-deployment.yaml
+++ b/kubernetes/zenko/charts/cloudserver/templates/manager-deployment.yaml
@@ -41,8 +41,9 @@ spec:
           args: ['npm', 'run', 'start_s3server']
           livenessProbe:
             httpGet:
-              path: /_/healthcheck
-              port: http
+              path: {{ .Values.health.path.liveness}}
+              port: {{ .Values.health.port }}
+            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
           volumeMounts:
             {{- if .Values.proxy.caCert }}
             - name: proxy-cert

--- a/kubernetes/zenko/charts/cloudserver/values.yaml
+++ b/kubernetes/zenko/charts/cloudserver/values.yaml
@@ -64,6 +64,12 @@ logging:
 
 allowHealthchecksFrom: '0.0.0.0/0'
 
+health:
+  port: http
+  path:
+    liveness: /_/healthcheck
+  initialDelaySeconds: 120
+
 env: {}
 
 mongodb:


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #347.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/1.1/bugfix/ZENKO-1168-initialDelayForLivenessProbes`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/1.1/bugfix/ZENKO-1168-initialDelayForLivenessProbes
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/1.1/bugfix/ZENKO-1168-initialDelayForLivenessProbes
```

Please always comment pull request #347 instead of this one.