### PR TITLE
improvement: restart queue-config pod on failure

### DIFF
--- a/kubernetes/zenko/charts/zenko-queue/templates/job-config.yaml
+++ b/kubernetes/zenko/charts/zenko-queue/templates/job-config.yaml
@@ -16,7 +16,7 @@ spec:
         app: {{ template "kafka.fullname" . }}
         release: "{{ .Release.Name }}"
     spec:
-      restartPolicy: Never
+      restartPolicy: OnFailure
       volumes:
         - name: config-volume
           configMap:


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
Prevents the queue-config from spawning more than 1 pod by simply restarting the existing one on failure.

**Which issue does this PR fix?**

fixes ZENKO-1134

**Special notes for your reviewers**:
This could be considered a bugfix or improvement. Original fix for ZENKO-1134 had to be reverted because it was causing timeout issues at install time.