### PR TITLE
INTEGRATION [PR#358 > development/1.1] improvement: restart queue-config pod on failure

### DIFF
--- a/kubernetes/zenko/charts/zenko-queue/templates/job-config.yaml
+++ b/kubernetes/zenko/charts/zenko-queue/templates/job-config.yaml
@@ -16,7 +16,7 @@ spec:
         app: {{ template "kafka.fullname" . }}
         release: "{{ .Release.Name }}"
     spec:
-      restartPolicy: Never
+      restartPolicy: OnFailure
       volumes:
         - name: config-volume
           configMap:


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #358.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/1.1/improvement/ZENKO-1134-queue-config`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/1.1/improvement/ZENKO-1134-queue-config
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/1.1/improvement/ZENKO-1134-queue-config
```

Please always comment pull request #358 instead of this one.