### PR TITLE
INTEGRATION [PR#371 > development/1.1] docs(README.md): fix broken link to minikube docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ all configured to talk to each other.
 
 Simple Zenko setup for quick testing with non-production data:
 
-- [Zenko Single-Node Kubernetes](./kubernetes/zenko/minikube.md)
+- [Zenko Single-Node Kubernetes](./docs/minikube.md)
 - [Zenko Docker Swarm Testing](./swarm-testing)
 
 ## Zenko in Production


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #371.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/1.1/improvement/minikube-link-patch`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/1.1/improvement/minikube-link-patch
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/1.1/improvement/minikube-link-patch
```

Please always comment pull request #371 instead of this one.