### PR TITLE
improvement: ZENKO-1217 add tuneable to retry timeout

### DIFF
--- a/kubernetes/zenko/charts/backbeat/templates/replication/data_processor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/replication/data_processor_deployment.yaml
@@ -98,6 +98,8 @@ spec:
               value: "{{ template "backbeat.redis-hosts" . }}"
             - name: REDIS_HA_NAME
               value: "{{ .Values.redis.sentinel.name }}"
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_RETRY_TIMEOUT_S
+              value: "{{ .Values.replication.dataProcessor.retryTimeoutS }}"
           livenessProbe:
             httpGet:
               path: {{ .Values.health.path.liveness}}

--- a/kubernetes/zenko/charts/backbeat/values.yaml
+++ b/kubernetes/zenko/charts/backbeat/values.yaml
@@ -121,6 +121,7 @@ replication:
     nodeSelector: {}
     tolerations: []
     affinity: {}
+    retryTimeoutS: 300
 
   populator:
     replicaCount: 1

--- a/kubernetes/zenko/values.yaml
+++ b/kubernetes/zenko/values.yaml
@@ -49,6 +49,7 @@ backbeat:
     dataProcessor:
       replicaCount: *nodeCount
       replicaFactor: 2
+      retryTimeoutS: 300
     statusProcessor:
       replicaCount: *nodeCount
   lifecycle:


### PR DESCRIPTION
This tunable controls for how long (in seconds) a replication entry will
be retried before setting the object as failed