### PR TITLE
[backbeat]: bump image tag to 8.0.18

### DIFF
--- a/kubernetes/zenko/Chart.yaml
+++ b/kubernetes/zenko/Chart.yaml
@@ -1,6 +1,6 @@
 name: zenko
-version: 1.0.0
-appVersion: 1.0.0
+version: 1.0.0-hotfix.1
+appVersion: 1.0.0-hotfix.1
 kubeVersion: "^1.8.0-0"
 description: Zenko is the open source multi-cloud data controller
 home: https://www.zenko.io/

--- a/kubernetes/zenko/charts/backbeat/Chart.yaml
+++ b/kubernetes/zenko/charts/backbeat/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "8.0.16"
+appVersion: "8.0.18"
 description: A Helm chart for Zenko Backbeat
 name: backbeat
 version: 1.0.0

--- a/kubernetes/zenko/charts/backbeat/values.yaml
+++ b/kubernetes/zenko/charts/backbeat/values.yaml
@@ -10,7 +10,7 @@ global:
 
 image:
   repository: zenko/backbeat
-  tag: 8.0.16
+  tag: 8.0.18
   pullPolicy: IfNotPresent
 
 logging:

--- a/kubernetes/zenko/templates/_helpers.tpl
+++ b/kubernetes/zenko/templates/_helpers.tpl
@@ -28,3 +28,12 @@ Create the default url for the backbeat quorum service
 {{- $zookeeperConnectOverride := index .Values "configurationOverrides" "zookeeper.connect" -}}
 {{- default $zookeeperConnect $zookeeperConnectOverride -}}
 {{- end -}}
+
+{{/*
+Create the default mongodb replicaset hosts string
+*/}}
+{{- define "zenko.mongodb-hosts" -}}
+{{- $count := (int (.Values.nodeCount)) -}}
+{{- $release := .Release.Name -}}
+{{- range $v := until $count }}{{ $release }}-mongodb-replicaset-{{ $v }}.{{ $release }}-mongodb-replicaset:27017{{ if ne $v (sub $count 1) }},{{- end -}}{{- end -}}
+{{- end -}}

--- a/kubernetes/zenko/templates/retry-stalled-objects/cron.yaml
+++ b/kubernetes/zenko/templates/retry-stalled-objects/cron.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.maintenance.stalled.enabled -}}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-retry-stalled-objects
+  labels:
+    app: {{ template "zenko.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  schedule: "{{ .Values.maintenance.stalled.schedule }}"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 0
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: utils
+            image: {{ .Values.maintenance.stalled.image.repository }}:{{ .Values.maintenance.stalled.image.tag }}
+            imagePullPolicy: {{ .Values.maintenance.stalled.image.pullPolicy }}
+            command: ["/bin/bash"]
+            args:
+            - -c
+            - node stalled.js 
+            env:
+            - name: ENDPOINT
+              value: "{{ .Release.Name }}-cloudserver"
+            - name: ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-retry-stalled-secrets
+                  key: accesskey
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-retry-stalled-secrets
+                  key: secretkey
+            - name: MONGODB_REPLICASET
+              value: "{{ template "zenko.mongodb-hosts" . }}"
+            - name: DRY_RUN
+              value: "false"
+{{- end -}}

--- a/kubernetes/zenko/templates/retry-stalled-objects/secrets.yaml
+++ b/kubernetes/zenko/templates/retry-stalled-objects/secrets.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.maintenance.stalled.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "zenko.fullname" . }}-retry-stalled-secrets
+  labels:
+    app: {{ template "zenko.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  accesskey: {{ .Values.maintenance.stalled.accessKey | b64enc }}
+  secretkey: {{ .Values.maintenance.stalled.secretKey | b64enc }}
+{{- end -}}

--- a/kubernetes/zenko/values.yaml
+++ b/kubernetes/zenko/values.yaml
@@ -7,6 +7,21 @@
 # is equivalent to the number of nodes in a Kubernetes Cluster.
 nodeCount: &nodeCount 3
 
+maintenance:
+  stalled:
+  ## Enables a retry CronJob that will automatically retry CRR objects stuck
+  ## in pending state. For Orbit enabled installs, Zenko will need to be
+  ## registered and account credentials (secretKey and accessKey) will need to
+  ## be provisioned prior to enabling this maintenance feature.
+    enabled: false
+    schedule: "*/10 * * * *"
+    accessKey:
+    secretKey:
+    image:
+      repository: zenko/s3utils
+      tag: 0.2
+      pullPolicy: IfNotPresent
+
 ingress:
   enabled: false
   # Used to create an Ingress record.


### PR DESCRIPTION
<!--
Thank you for contributing to Zenko!

Please enter applicable information below.
-->

**What does this PR do, and why do we need it?**

Bumps backbeat image tag to `8.0.18`

**Which issue does this PR fix?**

None.

**Special notes for your reviewers**:

I'm assuming this should target `development/1.0`, therefore, the chart versions have been left intact. Is this ok? @ssalaues @rahulreddy.