### PR TITLE
feature: ZENKO-1217 retry tunables per cloud

### DIFF
--- a/kubernetes/zenko/charts/backbeat/templates/replication/data_processor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/replication/data_processor_deployment.yaml
@@ -98,8 +98,45 @@ spec:
               value: "{{ template "backbeat.redis-hosts" . }}"
             - name: REDIS_HA_NAME
               value: "{{ .Values.redis.sentinel.name }}"
-            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_RETRY_TIMEOUT_S
-              value: "{{ .Values.replication.dataProcessor.retryTimeoutS }}"
+            # AWS_S3 retry config
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_AWS_S3_RETRY_TIMEOUT_S
+              value: "{{ .Values.replication.dataProcessor.retry.aws_s3.timeoutS }}"
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_AWS_S3_RETRY_MAX_RETRIES
+              value: "{{ .Values.replication.dataProcessor.retry.aws_s3.maxRetries }}"
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_AWS_S3_RETRY_BACKOFF_MIN
+              value: "{{ .Values.replication.dataProcessor.retry.aws_s3.backoff.min }}"
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_AWS_S3_RETRY_BACKOFF_MAX
+              value: "{{ .Values.replication.dataProcessor.retry.aws_s3.backoff.max }}"
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_AWS_S3_RETRY_BACKOFF_JITTER
+              value: "{{ .Values.replication.dataProcessor.retry.aws_s3.backoff.jitter }}"
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_AWS_S3_RETRY_BACKOFF_FACTOR
+              value: "{{ .Values.replication.dataProcessor.retry.aws_s3.backoff.factor }}"
+              # AZURE retry config
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_AZURE_RETRY_TIMEOUT_S
+              value: "{{ .Values.replication.dataProcessor.retry.azure.timeoutS }}"
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_AZURE_RETRY_MAX_RETRIES
+              value: "{{ .Values.replication.dataProcessor.retry.azure.maxRetries }}"
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_AZURE_RETRY_BACKOFF_MIN
+              value: "{{ .Values.replication.dataProcessor.retry.azure.backoff.min }}"
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_AZURE_RETRY_BACKOFF_MAX
+              value: "{{ .Values.replication.dataProcessor.retry.azure.backoff.max }}"
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_AZURE_RETRY_BACKOFF_JITTER
+              value: "{{ .Values.replication.dataProcessor.retry.azure.backoff.jitter }}"
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_AZURE_RETRY_BACKOFF_FACTOR
+              value: "{{ .Values.replication.dataProcessor.retry.azure.backoff.factor }}"
+              # GCP retry config
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_GCP_RETRY_TIMEOUT_S
+              value: "{{ .Values.replication.dataProcessor.retry.gcp.timeoutS }}"
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_GCP_RETRY_MAX_RETRIES
+              value: "{{ .Values.replication.dataProcessor.retry.gcp.maxRetries }}"
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_GCP_RETRY_BACKOFF_MIN
+              value: "{{ .Values.replication.dataProcessor.retry.gcp.backoff.min }}"
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_GCP_RETRY_BACKOFF_MAX
+              value: "{{ .Values.replication.dataProcessor.retry.gcp.backoff.max }}"
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_GCP_RETRY_BACKOFF_JITTER
+              value: "{{ .Values.replication.dataProcessor.retry.gcp.backoff.jitter }}"
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_GCP_RETRY_BACKOFF_FACTOR
+              value: "{{ .Values.replication.dataProcessor.retry.gcp.backoff.factor }}"
           livenessProbe:
             httpGet:
               path: {{ .Values.health.path.liveness}}

--- a/kubernetes/zenko/charts/backbeat/values.yaml
+++ b/kubernetes/zenko/charts/backbeat/values.yaml
@@ -121,7 +121,31 @@ replication:
     nodeSelector: {}
     tolerations: []
     affinity: {}
-    retryTimeoutS: 300
+    retry:
+      aws_s3:
+        timeoutS: 900
+        maxRetries: 5
+        backoff:
+          min: 60000
+          max: 900000
+          jitter: 0.1
+          factor: 1.5
+      azure:
+        timeoutS: 900
+        maxRetries: 5
+        backoff:
+          min: 60000
+          max: 900000
+          jitter: 0.1
+          factor: 1.5
+      gcp:
+        timeoutS: 900
+        maxRetries: 5
+        backoff:
+          min: 60000
+          max: 900000
+          jitter: 0.1
+          factor: 1.5
 
   populator:
     replicaCount: 1

--- a/kubernetes/zenko/values.yaml
+++ b/kubernetes/zenko/values.yaml
@@ -49,7 +49,6 @@ backbeat:
     dataProcessor:
       replicaCount: *nodeCount
       replicaFactor: 2
-      retryTimeoutS: 300
     statusProcessor:
       replicaCount: *nodeCount
   lifecycle:

--- a/tests/zenko_tests/node_tests/backbeat/Using.md
+++ b/tests/zenko_tests/node_tests/backbeat/Using.md
@@ -150,11 +150,4 @@ export AWS_S3_FAIL_BACKEND_DESTINATION_LOCATION=<destination-fail-aws-bucket-nam
 source .env && source .secrets.env
 ```
 
-6. Update the backbeat configuration properties as such:
-
-```
-extensions.replication.queueProcessor.retryTimeoutS: 1
-extensions.replication.replicationStatusProcessor.retryTimeoutS: 1
-```
-
-7. Run the test suite: `npm run test_retry`.
+5. Run the test suite: `npm run test_retry`.


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
This allows configuring retries for processing an object for replication
per cloud. The defaults are applied in the backbeat values chart which
can be overriden in zenko/values.yaml

**Which issue does this PR fix?**

fixes ZENKO-1212
