### PR TITLE
INTEGRATION [PR#396 > development/1.1] feature: ZENKO-1217 retry tunables per cloud

### DIFF
--- a/kubernetes/zenko/charts/backbeat/templates/replication/data_processor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/replication/data_processor_deployment.yaml
@@ -98,8 +98,45 @@ spec:
               value: "{{ template "backbeat.redis-hosts" . }}"
             - name: REDIS_HA_NAME
               value: "{{ .Values.redis.sentinel.name }}"
-            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_RETRY_TIMEOUT_S
-              value: "{{ .Values.replication.dataProcessor.retryTimeoutS }}"
+            # AWS_S3 retry config
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_AWS_S3_RETRY_TIMEOUT_S
+              value: "{{ .Values.replication.dataProcessor.aws_s3.retry.timeoutS }}"
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_AWS_S3_RETRY_MAX_RETRIES
+              value: "{{ .Values.replication.dataProcessor.aws_s3.retry.maxRetries }}"
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_AWS_S3_RETRY_BACKOFF_MIN
+              value: "{{ .Values.replication.dataProcessor.aws_s3.retry.maxRetries }}"
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_AWS_S3_RETRY_BACKOFF_MAX
+              value: "{{ .Values.replication.dataProcessor.aws_s3.retry.maxRetries }}"
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_AWS_S3_RETRY_BACKOFF_JITTER
+              value: "{{ .Values.replication.dataProcessor.aws_s3.retry.maxRetries }}"
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_AWS_S3_RETRY_BACKOFF_FACTOR
+              value: "{{ .Values.replication.dataProcessor.aws_s3.retry.maxRetries }}"
+              # AZURE retry config
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_AZURE_RETRY_TIMEOUT_S
+              value: "{{ .Values.replication.dataProcessor.azure.retry.timeoutS }}"
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_AZURE_RETRY_MAX_RETRIES
+              value: "{{ .Values.replication.dataProcessor.azure.retry.maxRetries }}"
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_AZURE_RETRY_BACKOFF_MIN
+              value: "{{ .Values.replication.dataProcessor.azure.retry.maxRetries }}"
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_AZURE_RETRY_BACKOFF_MAX
+              value: "{{ .Values.replication.dataProcessor.azure.retry.maxRetries }}"
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_AZURE_RETRY_BACKOFF_JITTER
+              value: "{{ .Values.replication.dataProcessor.azure.retry.maxRetries }}"
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_AZURE_RETRY_BACKOFF_FACTOR
+              value: "{{ .Values.replication.dataProcessor.azure.retry.maxRetries }}"
+              # GCP retry config
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_GCP_RETRY_TIMEOUT_S
+              value: "{{ .Values.replication.dataProcessor.gcp.retry.timeoutS }}"
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_GCP_RETRY_MAX_RETRIES
+              value: "{{ .Values.replication.dataProcessor.gcp.retry.maxRetries }}"
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_GCP_RETRY_BACKOFF_MIN
+              value: "{{ .Values.replication.dataProcessor.gcp.retry.maxRetries }}"
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_GCP_RETRY_BACKOFF_MAX
+              value: "{{ .Values.replication.dataProcessor.gcp.retry.maxRetries }}"
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_GCP_RETRY_BACKOFF_JITTER
+              value: "{{ .Values.replication.dataProcessor.gcp.retry.maxRetries }}"
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_GCP_RETRY_BACKOFF_FACTOR
+              value: "{{ .Values.replication.dataProcessor.gcp.retry.maxRetries }}"
           livenessProbe:
             httpGet:
               path: {{ .Values.health.path.liveness}}

--- a/kubernetes/zenko/charts/backbeat/values.yaml
+++ b/kubernetes/zenko/charts/backbeat/values.yaml
@@ -121,7 +121,31 @@ replication:
     nodeSelector: {}
     tolerations: []
     affinity: {}
-    retryTimeoutS: 300
+    retry:
+      aws_s3:
+        timeoutS: 900
+        maxRetries: 5
+        backoff:
+          min: 60000
+          max: 900000
+          jitter: 0.1
+          factor: 1.5
+      azure:
+        timeoutS: 900
+        maxRetries: 5
+        backoff:
+          min: 60000
+          max: 900000
+          jitter: 0.1
+          factor: 1.5
+      gcp:
+        timeoutS: 900
+        maxRetries: 5
+        backoff:
+          min: 60000
+          max: 900000
+          jitter: 0.1
+          factor: 1.5
 
   populator:
     replicaCount: 1

--- a/kubernetes/zenko/values.yaml
+++ b/kubernetes/zenko/values.yaml
@@ -49,7 +49,6 @@ backbeat:
     dataProcessor:
       replicaCount: *nodeCount
       replicaFactor: 2
-      retryTimeoutS: 300
     statusProcessor:
       replicaCount: *nodeCount
   lifecycle:

--- a/tests/zenko_tests/node_tests/backbeat/Using.md
+++ b/tests/zenko_tests/node_tests/backbeat/Using.md
@@ -150,11 +150,4 @@ export AWS_S3_FAIL_BACKEND_DESTINATION_LOCATION=<destination-fail-aws-bucket-nam
 source .env && source .secrets.env
 ```
 
-6. Update the backbeat configuration properties as such:
-
-```
-extensions.replication.queueProcessor.retryTimeoutS: 1
-extensions.replication.replicationStatusProcessor.retryTimeoutS: 1
-```
-
-7. Run the test suite: `npm run test_retry`.
+5. Run the test suite: `npm run test_retry`.


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #396.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/1.1/feature/ZENKO-1217-tuneable-backoff-clouds`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/1.1/feature/ZENKO-1217-tuneable-backoff-clouds
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/1.1/feature/ZENKO-1217-tuneable-backoff-clouds
```

Please always comment pull request #396 instead of this one.