### PR TITLE
improvement: add retry on failure cron

### DIFF
--- a/kubernetes/zenko/templates/maintenance/retry-failed-cron.yaml
+++ b/kubernetes/zenko/templates/maintenance/retry-failed-cron.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.maintenance.enabled -}}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ template "zenko.fullname" . }}-retry-failed
+  labels:
+    app: {{ template "zenko.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  schedule: "{{ .Values.maintenance.retryFailed.schedule }}"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: {{ .Values.maintenance.successfulJobsHistory }}
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: failed
+            image: {{ .Values.maintenance.image.repository }}:{{ .Values.maintenance.image.tag }}
+            imagePullPolicy: {{ .Values.maintenance.image.pullPolicy }}
+            command: ["/bin/bash"]
+            args:
+            - -c
+            - node autoRetryFailedCRR.js 
+            env:
+            - name: ENDPOINT
+              value: "{{ .Release.Name }}-cloudserver"
+            - name: ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "zenko.fullname" . }}-retry-secrets
+                  key: accesskey
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "zenko.fullname" . }}-retry-secrets
+                  key: secretkey
+            - name: MONGODB_REPLICASET
+              value: "{{ template "zenko.mongodb-hosts" . }}"
+            - name: DRY_RUN
+              value: "false"
+{{- end -}}

--- a/kubernetes/zenko/templates/maintenance/retry-pending-cron.yaml
+++ b/kubernetes/zenko/templates/maintenance/retry-pending-cron.yaml
@@ -1,17 +1,17 @@
-{{- if .Values.maintenance.stalled.enabled -}}
+{{- if .Values.maintenance.enabled -}}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ .Release.Name }}-retry-stalled-objects
+  name: {{ template "zenko.fullname" . }}-retry-pending
   labels:
     app: {{ template "zenko.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  schedule: "{{ .Values.maintenance.stalled.schedule }}"
+  schedule: "{{ .Values.maintenance.retryPending.schedule }}"
   concurrencyPolicy: Forbid
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: {{ .Values.maintenance.successfulJobsHistory }}
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
@@ -20,9 +20,9 @@ spec:
         spec:
           restartPolicy: OnFailure
           containers:
-          - name: utils
-            image: {{ .Values.maintenance.stalled.image.repository }}:{{ .Values.maintenance.stalled.image.tag }}
-            imagePullPolicy: {{ .Values.maintenance.stalled.image.pullPolicy }}
+          - name: pending
+            image: {{ .Values.maintenance.image.repository }}:{{ .Values.maintenance.image.tag }}
+            imagePullPolicy: {{ .Values.maintenance.image.pullPolicy }}
             command: ["/bin/bash"]
             args:
             - -c
@@ -33,12 +33,12 @@ spec:
             - name: ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-retry-stalled-secrets
+                  name: {{ template "zenko.fullname" . }}-retry-secrets
                   key: accesskey
             - name: SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-retry-stalled-secrets
+                  name: {{ template "zenko.fullname" . }}-retry-secrets
                   key: secretkey
             - name: MONGODB_REPLICASET
               value: "{{ template "zenko.mongodb-hosts" . }}"

--- a/kubernetes/zenko/templates/maintenance/secrets.yaml
+++ b/kubernetes/zenko/templates/maintenance/secrets.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.maintenance.stalled.enabled -}}
+{{- if .Values.maintenance.enabled -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "zenko.fullname" . }}-retry-stalled-secrets
+  name: {{ template "zenko.fullname" . }}-retry-secrets
   labels:
     app: {{ template "zenko.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
@@ -10,6 +10,6 @@ metadata:
     heritage: {{ .Release.Service }}
 type: Opaque
 data:
-  accesskey: {{ .Values.maintenance.stalled.accessKey | b64enc }}
-  secretkey: {{ .Values.maintenance.stalled.secretKey | b64enc }}
+  accesskey: {{ .Values.maintenance.accessKey | b64enc }}
+  secretkey: {{ .Values.maintenance.secretKey | b64enc }}
 {{- end -}}

--- a/kubernetes/zenko/values.yaml
+++ b/kubernetes/zenko/values.yaml
@@ -7,21 +7,6 @@
 # is equivalent to the number of nodes in a Kubernetes Cluster.
 nodeCount: &nodeCount 3
 
-maintenance:
-  stalled:
-  ## Enables a retry CronJob that will automatically retry CRR objects stuck
-  ## in pending state. For Orbit enabled installs, Zenko will need to be
-  ## registered and account credentials (secretKey and accessKey) will need to
-  ## be provisioned prior to enabling this maintenance feature.
-    enabled: false
-    schedule: "*/10 * * * *"
-    accessKey:
-    secretKey:
-    image:
-      repository: zenko/s3utils
-      tag: 0.2
-      pullPolicy: IfNotPresent
-
 ingress:
   enabled: false
   # Used to create an Ingress record.
@@ -47,6 +32,25 @@ global:
     # https://zenko.io to manage your deployment
   locationConstraints: {}
   replicationEndpoints: []
+
+maintenance:
+  # Enables a retry CronJobs that will attempt to retry CRR objects stuck in
+  # pending or failed state based off the specified schedule. For Orbit enabled
+  # installs, Zenko will need to be registered and account credentials
+  # (secretKey and accessKey) will need to be provisioned prior to enabling this
+  # maintenance feature.
+  enabled: false
+  accessKey:
+  secretKey:
+  successfulJobsHistory: 1
+  retryFailed:
+    schedule: "*/10 * * * *"
+  retryPending:
+    schedule: "*/10 * * * *"
+  image:
+    repository: zenko/s3utils
+    tag: 0.3
+    pullPolicy: IfNotPresent
 
 cloudserver:
   replicaCount: *nodeCount


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
Adds a separate cron for retrying failed CRR objects added to s3utils https://github.com/scality/s3utils/pull/11

**Which issue does this PR fix?**
ZENKO-1258

**Special notes for your reviewers**:
