### PR TITLE
improvement: add pods with debug tools

### DIFF
--- a/kubernetes/zenko/templates/_helpers.tpl
+++ b/kubernetes/zenko/templates/_helpers.tpl
@@ -15,6 +15,42 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "zenko.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- /*
+Print the standard Helm labels.
+*/ -}}
+{{- define "zenko.labels.standard" -}}
+app: {{ template "zenko.name" . }}
+chart: {{ template "zenko.chart" . }}
+heritage: {{ .Release.Service | quote }}
+release: {{ .Release.Name | quote }}
+{{- end -}}
+
+{{/*
+Create a common name for retry resources
+*/}}
+{{- define "zenko.retry" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s-retry" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a common name for debug resources
+*/}}
+{{- define "zenko.debug" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s-debug" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Disables kafka from deploying it's own zookeeper
+*/}}
 {{- define ".Values.zookeeper.enabled" -}}
 {{- printf "false" -}}
 {{- end -}}

--- a/kubernetes/zenko/templates/maintenance/debug/kafkaclient.yaml
+++ b/kubernetes/zenko/templates/maintenance/debug/kafkaclient.yaml
@@ -1,14 +1,20 @@
-{{- if .Values.maintenance.debug -}}
+{{- if .Values.maintenance.debug.enabled -}}
 apiVersion: v1
 kind: Pod
 metadata:
-  name: {{ template "zenko.fullname" . }}-debug-kafka-client
+  name: {{ template "zenko.debug" . }}-kafka-client
+  labels:
+{{ include "zenko.labels.standard" . | indent 4 }}
 spec:
   containers:
-  - name: kafka
-    image: solsson/kafka:0.11.0.0
+  - name: kafkaclient
+    image: {{ .Values.maintenance.kafkaClientImage.repository }}:{{ .Values.maintenance.kafkaClientImage.tag }}
+    imagePullPolicy: {{ .Values.maintenance.kafkaClientImage.pullPolicy }}
     command:
       - sh
       - -c
       - "exec tail -f /dev/null"
+    env:
+    - name: ZOOKEEPER_URL
+      value: "{{ .Release.Name }}-zenko-quorum:2181"
 {{- end -}}

--- a/kubernetes/zenko/templates/maintenance/debug/kafkaclient.yaml
+++ b/kubernetes/zenko/templates/maintenance/debug/kafkaclient.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.maintenance.debug -}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ template "zenko.fullname" . }}-debug-kafka-client
+spec:
+  containers:
+  - name: kafka
+    image: solsson/kafka:0.11.0.0
+    command:
+      - sh
+      - -c
+      - "exec tail -f /dev/null"
+{{- end -}}

--- a/kubernetes/zenko/templates/maintenance/debug/kafkaclient.yaml
+++ b/kubernetes/zenko/templates/maintenance/debug/kafkaclient.yaml
@@ -1,20 +1,34 @@
 {{- if .Values.maintenance.debug.enabled -}}
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1beta2
+kind: Deployment
 metadata:
-  name: {{ template "zenko.debug" . }}-kafka-client
+  name: {{ include "zenko.debug" . }}-kafka-client
   labels:
-{{ include "zenko.labels.standard" . | indent 4 }}
+    app.kubernetes.io/name: {{ include "zenko.name" . }}
+    helm.sh/chart: {{ include "zenko.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  containers:
-  - name: kafkaclient
-    image: {{ .Values.maintenance.kafkaClientImage.repository }}:{{ .Values.maintenance.kafkaClientImage.tag }}
-    imagePullPolicy: {{ .Values.maintenance.kafkaClientImage.pullPolicy }}
-    command:
-      - sh
-      - -c
-      - "exec tail -f /dev/null"
-    env:
-    - name: ZOOKEEPER_URL
-      value: "{{ .Release.Name }}-zenko-quorum:2181"
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "zenko.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "zenko.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+      - name: kafkaclient
+        image: {{ .Values.maintenance.kafkaClient.image.repository }}:{{ .Values.maintenance.kafkaClient.image.tag }}
+        imagePullPolicy: {{ .Values.maintenance.kafkaClient.image.pullPolicy }}
+        command:
+          - sh
+          - -c
+          - "exec tail -f /dev/null"
+        env:
+        - name: ZOOKEEPER_URL
+          value: "{{ .Release.Name }}-zenko-quorum:2181"
 {{- end -}}

--- a/kubernetes/zenko/templates/maintenance/debug/s3utils.yaml
+++ b/kubernetes/zenko/templates/maintenance/debug/s3utils.yaml
@@ -1,32 +1,46 @@
 {{- if .Values.maintenance.debug.enabled -}}
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1beta2
+kind: Deployment
 metadata:
-  name: {{ template "zenko.debug" . }}-s3utils
+  name: {{ include "zenko.debug" . }}-s3utils
   labels:
-{{ include "zenko.labels.standard" . | indent 4 }}
+    app.kubernetes.io/name: {{ include "zenko.name" . }}
+    helm.sh/chart: {{ include "zenko.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  containers:
-  - name: utils
-    image: {{ .Values.maintenance.s3UtilsImage.repository }}:{{ .Values.maintenance.s3UtilsImage.tag }}
-    imagePullPolicy: {{ .Values.maintenance.s3UtilsImage.pullPolicy }}
-    command:
-      - sh
-      - -c
-      - "exec tail -f /dev/null"
-    env:
-    - name: ENDPOINT
-      value: "{{ .Release.Name }}-cloudserver"
-    - name: ACCESS_KEY
-      valueFrom:
-        secretKeyRef:
-          name: {{ template "zenko.debug" . }}
-          key: accesskey
-    - name: SECRET_KEY
-      valueFrom:
-        secretKeyRef:
-          name: {{ template "zenko.debug" . }}
-          key: secretkey
-    - name: MONGODB_REPLICASET
-      value: "{{ template "zenko.mongodb-hosts" . }}"
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "zenko.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "zenko.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+      - name: utils
+        image: {{ .Values.maintenance.s3Utils.image.repository }}:{{ .Values.maintenance.s3Utils.image.tag }}
+        imagePullPolicy: {{ .Values.maintenance.s3Utils.image.pullPolicy }}
+        command:
+          - sh
+          - -c
+          - "exec tail -f /dev/null"
+        env:
+        - name: ENDPOINT
+          value: "{{ .Release.Name }}-cloudserver"
+        - name: ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "zenko.debug" . }}
+              key: accesskey
+        - name: SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "zenko.debug" . }}
+              key: secretkey
+        - name: MONGODB_REPLICASET
+          value: "{{ template "zenko.mongodb-hosts" . }}"
 {{- end -}}

--- a/kubernetes/zenko/templates/maintenance/debug/s3utils.yaml
+++ b/kubernetes/zenko/templates/maintenance/debug/s3utils.yaml
@@ -1,15 +1,32 @@
-{{- if .Values.maintenance.debug -}}
+{{- if .Values.maintenance.debug.enabled -}}
 apiVersion: v1
 kind: Pod
 metadata:
-  name: {{ template "zenko.fullname" . }}-debug-s3utils
+  name: {{ template "zenko.debug" . }}-s3utils
+  labels:
+{{ include "zenko.labels.standard" . | indent 4 }}
 spec:
   containers:
   - name: utils
-    image: {{ .Values.maintenance.image.repository }}:{{ .Values.maintenance.image.tag }}
-    imagePullPolicy: {{ .Values.maintenance.image.pullPolicy }}
+    image: {{ .Values.maintenance.s3UtilsImage.repository }}:{{ .Values.maintenance.s3UtilsImage.tag }}
+    imagePullPolicy: {{ .Values.maintenance.s3UtilsImage.pullPolicy }}
     command:
       - sh
       - -c
       - "exec tail -f /dev/null"
+    env:
+    - name: ENDPOINT
+      value: "{{ .Release.Name }}-cloudserver"
+    - name: ACCESS_KEY
+      valueFrom:
+        secretKeyRef:
+          name: {{ template "zenko.debug" . }}
+          key: accesskey
+    - name: SECRET_KEY
+      valueFrom:
+        secretKeyRef:
+          name: {{ template "zenko.debug" . }}
+          key: secretkey
+    - name: MONGODB_REPLICASET
+      value: "{{ template "zenko.mongodb-hosts" . }}"
 {{- end -}}

--- a/kubernetes/zenko/templates/maintenance/debug/s3utils.yaml
+++ b/kubernetes/zenko/templates/maintenance/debug/s3utils.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.maintenance.debug -}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ template "zenko.fullname" . }}-debug-s3utils
+spec:
+  containers:
+  - name: utils
+    image: {{ .Values.maintenance.image.repository }}:{{ .Values.maintenance.image.tag }}
+    imagePullPolicy: {{ .Values.maintenance.image.pullPolicy }}
+    command:
+      - sh
+      - -c
+      - "exec tail -f /dev/null"
+{{- end -}}

--- a/kubernetes/zenko/templates/maintenance/debug/secrets.yaml
+++ b/kubernetes/zenko/templates/maintenance/debug/secrets.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.maintenance.debug.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "zenko.debug" . }}
+  labels:
+{{ include "zenko.labels.standard" . | indent 4 }}
+type: Opaque
+data:
+  accesskey: {{ .Values.maintenance.debug.accessKey | b64enc }}
+  secretkey: {{ .Values.maintenance.debug.secretKey | b64enc }}
+{{- end -}}

--- a/kubernetes/zenko/templates/maintenance/retry-failed-cron.yaml
+++ b/kubernetes/zenko/templates/maintenance/retry-failed-cron.yaml
@@ -39,6 +39,4 @@ spec:
                   key: secretkey
             - name: MONGODB_REPLICASET
               value: "{{ template "zenko.mongodb-hosts" . }}"
-            - name: DRY_RUN
-              value: "false"
 {{- end -}}

--- a/kubernetes/zenko/templates/maintenance/retry-failed-cron.yaml
+++ b/kubernetes/zenko/templates/maintenance/retry-failed-cron.yaml
@@ -2,12 +2,9 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ template "zenko.fullname" . }}-retry-failed
+  name: {{ template "zenko.retry" . }}-failed
   labels:
-    app: {{ template "zenko.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+{{ include "zenko.labels.standard" . | indent 4 }}
 spec:
   schedule: "{{ .Values.maintenance.retryFailed.schedule }}"
   concurrencyPolicy: Forbid
@@ -21,8 +18,8 @@ spec:
           restartPolicy: OnFailure
           containers:
           - name: failed
-            image: {{ .Values.maintenance.image.repository }}:{{ .Values.maintenance.image.tag }}
-            imagePullPolicy: {{ .Values.maintenance.image.pullPolicy }}
+            image: {{ .Values.maintenance.s3UtilsImage.repository }}:{{ .Values.maintenance.s3UtilsImage.tag }}
+            imagePullPolicy: {{ .Values.maintenance.s3UtilsImage.pullPolicy }}
             command: ["/bin/bash"]
             args:
             - -c
@@ -33,12 +30,12 @@ spec:
             - name: ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "zenko.fullname" . }}-retry-secrets
+                  name: {{ template "zenko.retry" . }}
                   key: accesskey
             - name: SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "zenko.fullname" . }}-retry-secrets
+                  name: {{ template "zenko.retry" . }}
                   key: secretkey
             - name: MONGODB_REPLICASET
               value: "{{ template "zenko.mongodb-hosts" . }}"

--- a/kubernetes/zenko/templates/maintenance/retry-pending-cron.yaml
+++ b/kubernetes/zenko/templates/maintenance/retry-pending-cron.yaml
@@ -39,6 +39,4 @@ spec:
                   key: secretkey
             - name: MONGODB_REPLICASET
               value: "{{ template "zenko.mongodb-hosts" . }}"
-            - name: DRY_RUN
-              value: "false"
 {{- end -}}

--- a/kubernetes/zenko/templates/maintenance/retry-pending-cron.yaml
+++ b/kubernetes/zenko/templates/maintenance/retry-pending-cron.yaml
@@ -2,12 +2,9 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ template "zenko.fullname" . }}-retry-pending
+  name: {{ template "zenko.retry" . }}-pending
   labels:
-    app: {{ template "zenko.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+{{ include "zenko.labels.standard" . | indent 4 }}
 spec:
   schedule: "{{ .Values.maintenance.retryPending.schedule }}"
   concurrencyPolicy: Forbid
@@ -21,8 +18,8 @@ spec:
           restartPolicy: OnFailure
           containers:
           - name: pending
-            image: {{ .Values.maintenance.image.repository }}:{{ .Values.maintenance.image.tag }}
-            imagePullPolicy: {{ .Values.maintenance.image.pullPolicy }}
+            image: {{ .Values.maintenance.s3UtilsImage.repository }}:{{ .Values.maintenance.s3UtilsImage.tag }}
+            imagePullPolicy: {{ .Values.maintenance.s3UtilsImage.pullPolicy }}
             command: ["/bin/bash"]
             args:
             - -c
@@ -33,12 +30,12 @@ spec:
             - name: ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "zenko.fullname" . }}-retry-secrets
+                  name: {{ template "zenko.retry" . }}
                   key: accesskey
             - name: SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "zenko.fullname" . }}-retry-secrets
+                  name: {{ template "zenko.retry" . }}
                   key: secretkey
             - name: MONGODB_REPLICASET
               value: "{{ template "zenko.mongodb-hosts" . }}"

--- a/kubernetes/zenko/templates/maintenance/secrets.yaml
+++ b/kubernetes/zenko/templates/maintenance/secrets.yaml
@@ -2,12 +2,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "zenko.fullname" . }}-retry-secrets
+  name: {{ template "zenko.retry" . }}
   labels:
-    app: {{ template "zenko.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+{{ include "zenko.labels.standard" . | indent 4 }}
 type: Opaque
 data:
   accesskey: {{ .Values.maintenance.accessKey | b64enc }}

--- a/kubernetes/zenko/values.yaml
+++ b/kubernetes/zenko/values.yaml
@@ -55,14 +55,16 @@ maintenance:
     enabled: false
     accessKey: ""
     secretKey: ""
-  s3UtilsImage:
-    repository: zenko/s3utils
-    tag: 0.3
-    pullPolicy: IfNotPresent
-  kafkaClientImage:
-    repository: solsson/kafka
-    tag: 0.11.0.0
-    pullPolicy: IfNotPresent
+  s3Utils:
+    image:
+      repository: zenko/s3utils
+      tag: 0.3
+      pullPolicy: IfNotPresent
+  kafkaClient:
+    image:
+      repository: solsson/kafka
+      tag: 0.11.0.0
+      pullPolicy: IfNotPresent
 
 cloudserver:
   replicaCount: *nodeCount

--- a/kubernetes/zenko/values.yaml
+++ b/kubernetes/zenko/values.yaml
@@ -40,18 +40,29 @@ maintenance:
   # (secretKey and accessKey) will need to be provisioned prior to enabling this
   # maintenance feature.
   enabled: false
-  accessKey:
-  secretKey:
+  accessKey: ""
+  secretKey: ""
   successfulJobsHistory: 1
   retryFailed:
     schedule: "*/10 * * * *"
   retryPending:
     schedule: "*/10 * * * *"
-  image:
+  debug:
+    # This provisions a pod with utilities to help debug Zenko from within the
+    # cluster. Credentials can be added here that will be applied to the pods
+    # environment variables and can be used for debugging but not necessary to
+    # instanciate the pod.
+    enabled: false
+    accessKey: ""
+    secretKey: ""
+  s3UtilsImage:
     repository: zenko/s3utils
     tag: 0.3
     pullPolicy: IfNotPresent
-  debug: false
+  kafkaClientImage:
+    repository: solsson/kafka
+    tag: 0.11.0.0
+    pullPolicy: IfNotPresent
 
 cloudserver:
   replicaCount: *nodeCount

--- a/kubernetes/zenko/values.yaml
+++ b/kubernetes/zenko/values.yaml
@@ -51,6 +51,7 @@ maintenance:
     repository: zenko/s3utils
     tag: 0.3
     pullPolicy: IfNotPresent
+  debug: false
 
 cloudserver:
   replicaCount: *nodeCount


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
Adds an optional kafkaclient and s3utils pods if `--set maintenance.debug=true` at install or upgrade.

**Which issue does this PR fix?**


**Special notes for your reviewers**:
