### PR TITLE
feat: add zenko-queue-manager chart

### DIFF
--- a/images/kafka-manager/Dockerfile
+++ b/images/kafka-manager/Dockerfile
@@ -1,0 +1,20 @@
+FROM hseeberger/scala-sbt
+
+ENV KM_VERSION=1.3.3.18
+
+WORKDIR /tmp
+
+RUN wget https://github.com/yahoo/kafka-manager/archive/${KM_VERSION}.tar.gz && \
+    tar xvf ${KM_VERSION}.tar.gz && \
+    cd kafka-manager-${KM_VERSION} && \
+    sbt clean dist
+
+WORKDIR /opt
+
+RUN unzip -d . /tmp/kafka-manager-${KM_VERSION}/target/universal/kafka-manager-${KM_VERSION}.zip && \
+    rm -fr /tmp/${KM_VERSION}.tar.gz /tmp/kafka-manager-${KM_VERSION}
+
+WORKDIR /opt/kafka-manager-${KM_VERSION}
+
+EXPOSE 9000
+ENTRYPOINT ["./bin/kafka-manager","-Dconfig.file=conf/application.conf"]

--- a/kubernetes/zenko/Chart.yaml
+++ b/kubernetes/zenko/Chart.yaml
@@ -1,6 +1,6 @@
 name: zenko
-version: 1.0.0-hotfix.1
-appVersion: 1.0.0-hotfix.1
+version: 1.0.1
+appVersion: 1.0.1
 kubeVersion: "^1.8.0-0"
 description: Zenko is the open source multi-cloud data controller
 home: https://www.zenko.io/

--- a/kubernetes/zenko/charts/zenko-queue-manager/.helmignore
+++ b/kubernetes/zenko/charts/zenko-queue-manager/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/kubernetes/zenko/charts/zenko-queue-manager/Chart.yaml
+++ b/kubernetes/zenko/charts/zenko-queue-manager/Chart.yaml
@@ -1,0 +1,17 @@
+name: zenko-queue-manager
+version: 1.0.0
+appVersion: 1.0.0
+kubeVersion: "^1.8.0-0"
+description: A tool for managing Apache Kafka.
+home: https://github.com/yahoo/kafka-manager
+icon: https://kafka.apache.org/images/logo.png
+sources:
+  - https://github.com/yahoo/kafka-manager
+keywords:
+- kafka
+- zookeeper
+- kafka-manager
+maintainers:
+- name: giacomoguiulfo
+  email: giacomoguiulfo@gmail.com
+engine: gotpl

--- a/kubernetes/zenko/charts/zenko-queue-manager/README.md
+++ b/kubernetes/zenko/charts/zenko-queue-manager/README.md
@@ -1,0 +1,83 @@
+# Kafka Manager Helm Chart
+
+[Kafka Manager](https://github.com/yahoo/kafka-manager) is a tool for managing [Apache Kafka](http://kafka.apache.org/).
+
+## TL;DR;
+
+```bash
+$ helm install stable/kafka-manager
+```
+
+## Prerequisites
+
+- Kubernetes 1.8+ with Beta APIs enabled
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release stable/kafka-manager
+```
+
+The command deploys Kafka Manager on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the Kafka Manager chart and their default values.
+
+Parameter | Description | Default
+--------- | ----------- | -------
+`serviceAccount.create` | If true, create a service account for this chart | `true`
+`serviceAccount.name` | Name of the service account to create | `{{ kafka-manager.fullname }}`
+`image.repository` | Container image repository | `zenko/kafka-manager`
+`image.tag` | Container image tag | `1.0.0`
+`image.pullPolicy` | Container image pull policy | `IfNotPresent`
+`zkHosts` | Zookeeper hosts required by the kafka-manager | `localhost:2181`
+`clusters` | Configuration of the clusters to manage | `{}`
+`applicationSecret` | Kafka-manager application secret | `""`
+`basicAuth.enabled` | If ture, enable basic authentication | `false`
+`basicAuth.username` | Username for basic auth | `admin`
+`basicAuth.password` | Paswword for basic auth | `""`
+`javaOptions` | Java runtime options | `""`
+`service.type` | Kafka-manager service type | `ClusterIP`
+`service.port` | Kafka-manager service port | `9000`
+`ingress.enabled` | If true, create an ingress resource | `false`
+`ingress.annotations` | Optional ingress annotations | `{}`
+`ingress.path` | Ingress path | `/`
+`ingress.hosts` | Ingress hostnames | `kafka-manager.local`
+`ingress.tls` | Ingress TLS configuration | `[]`
+`resources` | Pod resource requests and limits | `{}`
+`nodeSelector` | Node labels for pod assignment | `{}`
+`tolerations` | Tolerations for pod assignment | `[]`
+`affinity` | Affinity for pod assignment | `{}`
+`zookeeper.enabled` | If true, deploy Zookeeper | `false`
+`zookeeper.env` | Enviromental variables for Zookeeper | `ZK_HEAP_SIZE: "1G"`
+`zookeeper.persistence` | If true, enable persistence for Zookeeper | `false`
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm install stable/kafka-manager --name my-release \
+    --set ingress.enabled=true
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install stable/kafka-manager --name my-release -f values.yaml
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)

--- a/kubernetes/zenko/charts/zenko-queue-manager/requirements.lock
+++ b/kubernetes/zenko/charts/zenko-queue-manager/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: zookeeper
+  repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+  version: 1.2.0
+digest: sha256:48de211cbffc0b7df9995edc4fd5d693e8bbc94e684aa83c11e6f94803f0e8b9
+generated: 2018-10-24T11:47:00.371605298-07:00

--- a/kubernetes/zenko/charts/zenko-queue-manager/requirements.yaml
+++ b/kubernetes/zenko/charts/zenko-queue-manager/requirements.yaml
@@ -1,0 +1,5 @@
+dependencies:
+- name: zookeeper
+  version: 1.2.0
+  repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+  condition: zookeeper.enabled

--- a/kubernetes/zenko/charts/zenko-queue-manager/templates/NOTES.txt
+++ b/kubernetes/zenko/charts/zenko-queue-manager/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http://{{ . }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "kafka-manager.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "kafka-manager.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kafka-manager.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "kafka-manager.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:{{ .Values.service.port }}
+{{- end }}

--- a/kubernetes/zenko/charts/zenko-queue-manager/templates/_helpers.tpl
+++ b/kubernetes/zenko/charts/zenko-queue-manager/templates/_helpers.tpl
@@ -1,0 +1,64 @@
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kafka-manager.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "kafka-manager.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified bootstrap job name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "kafka-manager.bootstrap.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s-bootstrap" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified zookeeper name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "kafka-manager.zookeeper.fullname" -}}
+{{- $name := default "zookeeper" .Values.zookeeper.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kafka-manager.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use.
+*/}}
+{{- define "kafka-manager.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "kafka-manager.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the kafka-manager zookeeper hosts url.
+*/}}
+{{- define "kafka-manager.zkHosts" -}}
+{{- if .Values.zookeeper.enabled -}}
+    {{- printf "%s:2181" (include "kafka-manager.zookeeper.fullname" .) }}
+{{- else -}}
+    {{- default "localhost:2181" (tpl .Values.zkHosts .) -}}
+{{- end -}}
+{{- end -}}

--- a/kubernetes/zenko/charts/zenko-queue-manager/templates/configmap.yaml
+++ b/kubernetes/zenko/charts/zenko-queue-manager/templates/configmap.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.clusters -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "kafka-manager.bootstrap.fullname" . }}
+  labels:
+    app: {{ template "kafka-manager.fullname" . }}
+    chart: {{ template "kafka-manager.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+data:
+  addClusters.sh: |
+    #!/bin/bash
+    set -ex
+    echo "Running at {{ date "20060102150405" .Release.Time }}"
+    {{- range $cluster := .Values.clusters }}
+    {{ printf "curl http://%s:9000/clusters -X POST " (include "kafka-manager.fullname" $) -}}
+    {{- printf "-d name=%s " (default "default" $cluster.name) -}}
+    {{- printf "-d zkHosts=%s " (default (include "kafka-manager.zkHosts" $) $cluster.zkHosts ) -}}
+    {{- printf "-d kafkaVersion=%s " (default "1.0.0" $cluster.kafkaVersion) -}}
+    {{- printf "-d jmxUser=%s " (default "" $cluster.jmxUser) -}}
+    {{- printf "-d jmxPass=%s " (default "" $cluster.jmxPass) -}}
+    {{- printf "-d tuning.brokerViewUpdatePeriodSeconds=%s " (default "30" $cluster.tuning.brokerViewUpdatePeriodSeconds) -}}
+    {{- printf "-d tuning.clusterManagerThreadPoolSize=%s " (default "2" $cluster.tuning.clusterManagerThreadPoolSize) -}}
+    {{- printf "-d tuning.clusterManagerThreadPoolQueueSize=%s " (default "100" $cluster.tuning.clusterManagerThreadPoolQueueSize) -}}
+    {{- printf "-d tuning.kafkaCommandThreadPoolSize=%s " (default "2" $cluster.tuning.kafkaCommandThreadPoolSize) -}}
+    {{- printf "-d tuning.kafkaCommandThreadPoolQueueSize=%s " (default "100" $cluster.tuning.kafkaCommandThreadPoolQueueSize) -}}
+    {{- printf "-d tuning.logkafkaCommandThreadPoolSize=%s " (default "2" $cluster.tuning.logkafkaCommandThreadPoolSize) -}}
+    {{- printf "-d tuning.logkafkaCommandThreadPoolQueueSize=%s " (default "100" $cluster.tuning.logkafkaCommandThreadPoolQueueSize) -}}
+    {{- printf "-d tuning.logkafkaUpdatePeriodSeconds=%s " (default "30" $cluster.tuning.logkafkaUpdatePeriodSeconds) -}}
+    {{- printf "-d tuning.partitionOffsetCacheTimeoutSecs=%s " (default "5" $cluster.tuning.partitionOffsetCacheTimeoutSecs) -}}
+    {{- printf "-d tuning.brokerViewThreadPoolSize=%s " (default "4" $cluster.tuning.brokerViewThreadPoolSize) -}}
+    {{- printf "-d tuning.brokerViewThreadPoolQueueSize=%s " (default "1000" $cluster.tuning.brokerViewThreadPoolQueueSize) -}}
+    {{- printf "-d tuning.offsetCacheThreadPoolSize=%s " (default "4" $cluster.tuning.offsetCacheThreadPoolSize) -}}
+    {{- printf "-d tuning.offsetCacheThreadPoolQueueSize=%s " (default "1000" $cluster.tuning.offsetCacheThreadPoolQueueSize) -}}
+    {{- printf "-d tuning.kafkaAdminClientThreadPoolSize=%s " (default "4" $cluster.tuning.kafkaAdminClientThreadPoolSize) -}}
+    {{- printf "-d tuning.kafkaAdminClientThreadPoolQueueSize=%s " (default "1000" $cluster.tuning.kafkaAdminClientThreadPoolQueueSize) -}}
+    {{- printf "-d tuning.kafkaManagedOffsetMetadataCheckMillis=%s " (default "30000" $cluster.tuning.kafkaManagedOffsetMetadataCheckMillis) -}}
+    {{- printf "-d tuning.kafkaManagedOffsetGroupCacheSize=%s " (default "1000000" $cluster.tuning.kafkaManagedOffsetGroupCacheSize) -}}
+    {{- printf "-d tuning.kafkaManagedOffsetGroupExpireDays=%s " (default "7" $cluster.tuning.kafkaManagedOffsetGroupExpireDays) -}}
+    {{- printf "-d securityProtocol=%s " (default "PLAINTEXT" $cluster.securityProtocol) -}}
+    {{- printf "|| exit 1;" -}}
+    {{- end -}}
+{{- end -}}

--- a/kubernetes/zenko/charts/zenko-queue-manager/templates/deployment.yaml
+++ b/kubernetes/zenko/charts/zenko-queue-manager/templates/deployment.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "kafka-manager.fullname" . }}
+  labels:
+    app: {{ template "kafka-manager.name" . }}
+    chart: {{ template "kafka-manager.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "kafka-manager.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "kafka-manager.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccountName: {{ template "kafka-manager.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: kafka-manager
+              containerPort: 9000
+              protocol: TCP
+          env:
+            - name: ZK_HOSTS
+              value: {{ include "kafka-manager.zkHosts" . | quote }}
+            - name: JAVA_OPTS
+              value: {{ .Values.javaOptions }}
+            - name: APPLICATION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "kafka-manager.fullname" . }}
+                  key: applicationSecret
+            - name: KAFKA_MANAGER_AUTH_ENABLED
+              value: {{ .Values.basicAuth.enabled | quote }}
+            - name: KAFKA_MANAGER_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "kafka-manager.fullname" . }}
+                  key: basicAuthUsername
+            - name: KAFKA_MANAGER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "kafka-manager.fullname" . }}
+                  key: basicAuthPassword
+          livenessProbe:
+            httpGet:
+              path: /api/status/clusters
+              port: kafka-manager
+            initialDelaySeconds: 60
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: kafka-manager
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/kubernetes/zenko/charts/zenko-queue-manager/templates/ingress.yaml
+++ b/kubernetes/zenko/charts/zenko-queue-manager/templates/ingress.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "kafka-manager.fullname" . -}}
+{{- $servicePort := .Values.service.port -}}
+{{- $ingressPath := .Values.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ template "kafka-manager.name" . }}
+    chart: {{ template "kafka-manager.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: kafka-manager
+  {{- end }}
+{{- end }}

--- a/kubernetes/zenko/charts/zenko-queue-manager/templates/job.yaml
+++ b/kubernetes/zenko/charts/zenko-queue-manager/templates/job.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.clusters -}}
+{{- $scriptHash := include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | trunc 8 -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ template "kafka-manager.bootstrap.fullname" . }}-{{ $scriptHash }}"
+  labels:
+    app: {{ template "kafka-manager.name" . }}
+    chart: {{ template "kafka-manager.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  template:
+    metadata:
+      labels:
+        app: {{ template "kafka-manager.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccountName: {{ template "kafka-manager.serviceAccountName" . }}
+      restartPolicy: OnFailure
+      volumes:
+        - name: script-volume
+          configMap:
+            name: {{ template "kafka-manager.bootstrap.fullname" . }}
+            defaultMode: 0744
+      containers:
+      - name: {{ .Chart.Name }}-bootstrap
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: ["/usr/local/script/addClusters.sh"]
+        volumeMounts:
+          - name: script-volume
+            mountPath: "/usr/local/script"
+  backoffLimit: 20
+{{- end -}}

--- a/kubernetes/zenko/charts/zenko-queue-manager/templates/secrets.yaml
+++ b/kubernetes/zenko/charts/zenko-queue-manager/templates/secrets.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "kafka-manager.fullname" . }}
+  labels:
+    app: {{ template "kafka-manager.name" . }}
+    chart: {{ template "kafka-manager.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+type: Opaque
+data:
+  {{ if .Values.applicationSecret }}
+  applicationSecret:  {{ .Values.applicationSecret | b64enc | quote }}
+  {{ else }}
+  applicationSecret: {{ randAlphaNum 10 | b64enc | quote }}
+  {{ end }}
+  basicAuthUsername:  {{ .Values.basicAuth.username | b64enc | quote }}
+  {{ if .Values.basicAuth.password }}
+  basicAuthPassword:  {{ .Values.basicAuth.password | b64enc | quote }}
+  {{ else }}
+  basicAuthPassword: {{ randAlphaNum 10 | b64enc | quote }}
+  {{ end }}

--- a/kubernetes/zenko/charts/zenko-queue-manager/templates/service.yaml
+++ b/kubernetes/zenko/charts/zenko-queue-manager/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "kafka-manager.fullname" . }}
+  labels:
+    app: {{ template "kafka-manager.name" . }}
+    chart: {{ template "kafka-manager.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: kafka-manager
+      port: {{ .Values.service.port }}
+      targetPort: kafka-manager
+      protocol: TCP
+  selector:
+    app: {{ template "kafka-manager.name" . }}
+    release: {{ .Release.Name }}

--- a/kubernetes/zenko/charts/zenko-queue-manager/templates/serviceaccount.yaml
+++ b/kubernetes/zenko/charts/zenko-queue-manager/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "kafka-manager.name" . }}
+    chart: {{ template "kafka-manager.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "kafka-manager.serviceAccountName" . }}
+{{- end }}

--- a/kubernetes/zenko/charts/zenko-queue-manager/values.yaml
+++ b/kubernetes/zenko/charts/zenko-queue-manager/values.yaml
@@ -1,0 +1,150 @@
+# ------------------------------------------------------------------------------
+# Kafka Manager:
+# ------------------------------------------------------------------------------
+
+## Service account configuration
+## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+##
+serviceAccount:
+  create: true
+  ## Define serviceAccount name. Defaults to fully qualified name
+  ##
+  name: ""
+
+## Specs for the Kafka-manager image
+##
+image:
+  repository: zenko/kafka-manager
+  tag: 1.0.0
+  pullPolicy: IfNotPresent
+
+## Kafka-manager zookeeper hosts. Default to localhost:2181 or
+## the bundled zookeeper chart service url if enabled (see below).
+## This value can be a template
+##
+zkHosts: ""
+
+## Clusters to be added through the kafka-manager api
+##
+clusters: []
+  ## Name of your cluster
+  # - name: "default"
+
+    ## Cluster zookeeper hosts. It will default to the
+    ## Kafka-manager zookeeper hosts if not specified
+    ##
+    # zkHosts: ""
+
+    ## The following parameters can be configured for your cluster.
+    ## See '_helpers.tpl' for the default values
+    ##
+    # kafkaVersion: ""
+    # jmxUser: ""
+    # jmxPass: ""
+    # securityProtocol: ""
+
+    ## Additional cluster tunning. It is mandatory that this value exists,
+    ## even if it's empty '{}'.
+    ##
+    # tuning: {}
+      # brokerViewUpdatePeriodSeconds:
+      # clusterManagerThreadPoolSize:
+      # clusterManagerThreadPoolQueueSize:
+      # kafkaCommandThreadPoolSize:
+      # kafkaCommandThreadPoolQueueSize:
+      # logkafkaCommandThreadPoolSize:
+      # logkafkaCommandThreadPoolQueueSize:
+      # logkafkaUpdatePeriodSeconds:
+      # partitionOffsetCacheTimeoutSecs:
+      # brokerViewThreadPoolSize:
+      # brokerViewThreadPoolQueueSize:
+      # offsetCacheThreadPoolSize:
+      # offsetCacheThreadPoolQueueSize:
+      # kafkaAdminClientThreadPoolSize:
+      # kafkaAdminClientThreadPoolQueueSize:
+      # kafkaManagedOffsetMetadataCheckMillis:
+      # kafkaManagedOffsetGroupCacheSize:
+      # kafkaManagedOffsetGroupExpireDays:
+
+## Application secret. Defaults to a random 10-character alphanumeric string
+##
+applicationSecret: ""
+
+## Basic Auth configuration
+##
+basicAuth:
+  enabled: false
+  username: "admin"
+  ## Defaults to a random 10-character alphanumeric string if not set
+  ##
+  password: ""
+
+## Java runtime options. Passed through the JAVA_OPTS environmental variable
+##
+javaOptions: ""
+
+## Service configuration
+## Ref: http://kubernetes.io/docs/user-guide/services/
+##
+service:
+  type: ClusterIP
+  port: 9000
+
+## Ingress configuration
+## Ref: https://kubernetes.io/docs/concepts/services-networking/ingress/
+##
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  path: /
+  hosts:
+    - kafka-manager.local
+  tls: []
+    # - secretName: kafka-manager-tls
+    #   hosts:
+    #     - kafka-manager.local
+
+## Pod resource requests and limits
+## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources: {}
+#  limits:
+#    cpu: 100m
+#    memory: 128Mi
+#  requests:
+#    cpu: 100m
+#    memory: 128Mi
+
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+
+## Tolerations for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: []
+
+## Affinity for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+##
+affinity: {}
+
+# ------------------------------------------------------------------------------
+# Zookeeper:
+# ------------------------------------------------------------------------------
+
+zookeeper:
+  enabled: false
+
+  ## Environmental variables to set in Zookeeper
+  ##
+  env:
+    ## The JVM heap size to allocate to Zookeeper
+    ZK_HEAP_SIZE: "1G"
+
+  ## Configure Zookeeper persistence
+  persistence:
+    enabled: false

--- a/kubernetes/zenko/values.yaml
+++ b/kubernetes/zenko/values.yaml
@@ -202,3 +202,9 @@ grafana:
       # Likewise, every config map with the following label will be used as a source for
       # a dashboard.
       label: grafana-dashboard
+
+zenko-queue-manager:
+  zkHosts: "{{ .Release.Name }}-zenko-quorum-headless:2181"
+  clusters:
+    - name: "zenko-queue-cluster"
+      tuning: {}

--- a/tests/zenko_tests/create_buckets.py
+++ b/tests/zenko_tests/create_buckets.py
@@ -8,7 +8,8 @@ import logging
 import re
 
 IGNORED_PODS = [
-    r'.+queue-config'
+    r'.+queue-config',
+    r'.+bootstrap',
 ]
 
 IGNORED_PODS = [re.compile(x) for x in IGNORED_PODS]


### PR DESCRIPTION
<!--
Thank you for contributing to Zenko!

Please enter applicable information below.
-->

**What does this PR do, and why do we need it?**

This PR adds the Zenko-Queue-Manager chart ([Kafka-Manager](https://github.com/yahoo/kafka-manager)) to the Zenko stack. It is enabled by default and the zenko-queue cluster is configured automagically.

**Special notes for your reviewers**:

If possible, try this chart out and see if it works fine 😀

This more or less how it looks on with the Zenko-Queue cluster configured:
<img width="1425" alt="screenshot 2018-10-24 at 12 22 41 pm" src="https://user-images.githubusercontent.com/22091600/47455766-93800e80-d787-11e8-9c70-57886f8d5924.png">

