### PR TITLE
improvement: ZENKO-1291 keepalive configuration for ext backends

### DIFF
--- a/kubernetes/zenko/charts/cloudserver/templates/_env.tpl
+++ b/kubernetes/zenko/charts/cloudserver/templates/_env.tpl
@@ -20,6 +20,22 @@ env:
     value: "{{ .Release.Name }}-cloudserver,{{ .Values.endpoint }}"
   - name: HEALTHCHECKS_ALLOWFROM
     value: "{{ .Values.allowHealthchecksFrom }}"
+  - name: AWS_S3_HTTPAGENT_KEEPALIVE
+    value: "{{ .Values.externalBackends.aws_s3.keepAlive }}"
+  - name: AWS_S3_HTTPAGENT_KEEPALIVE_MS
+    value: "{{ .Values.externalBackends.aws_s3.keepAliveMsecs }}"
+  - name: AWS_S3_HTTPAGENT_KEEPALIVE_MAX_SOCKETS
+    value: "{{ .Values.externalBackends.aws_s3.maxSockets }}"
+  - name: AWS_S3_HTTPAGENT_KEEPALIVE_MAX_FREE_SOCKETS
+    value: "{{ .Values.externalBackends.aws_s3.maxFreeSockets }}"
+  - name: GCP_HTTPAGENT_KEEPALIVE
+    value: "{{ .Values.externalBackends.gcp.keepAlive }}"
+  - name: GCP_HTTPAGENT_KEEPALIVE_MS
+    value: "{{ .Values.externalBackends.gcp.keepAliveMsecs }}"
+  - name: GCP_HTTPAGENT_KEEPALIVE_MAX_SOCKETS
+    value: "{{ .Values.externalBackends.gcp.maxSockets }}"
+  - name: GCP_HTTPAGENT_KEEPALIVE_MAX_FREE_SOCKETS
+    value: "{{ .Values.externalBackends.gcp.maxFreeSockets }}"
   {{- if .Values.global.orbit.storageLimit.enabled }}
   - name: STORAGE_LIMIT_ENABLED
     value: "true"

--- a/kubernetes/zenko/charts/cloudserver/values.yaml
+++ b/kubernetes/zenko/charts/cloudserver/values.yaml
@@ -51,6 +51,19 @@ global:
     # - azurebackend
     # - gcpbackend
 
+# backends level keep-alive config
+externalBackends:
+  aws_s3:
+    keepAlive: false
+    keepAliveMsecs: 1000
+    maxFreeSockets: 256
+    maxSockets: null
+  gcp:
+    keepAlive: true
+    keepAliveMsecs: 1000
+    maxFreeSockets: 256
+    maxSockets: null
+
 endpoint: zenko.local
 
 users: {}


### PR DESCRIPTION
This allow configuring keep alive for external backends, currently
AWS_S3 and GCP are supported.