### PR TITLE
bump cloudserver image

### DIFF
--- a/kubernetes/zenko/Chart.yaml
+++ b/kubernetes/zenko/Chart.yaml
@@ -1,6 +1,6 @@
 name: zenko
-version: 1.1.0
-appVersion: 1.1.0
+version: 1.1.1
+appVersion: 1.1.1
 kubeVersion: "^1.8.0-0"
 description: Zenko is the open source multi-cloud data controller
 home: https://www.zenko.io/

--- a/kubernetes/zenko/charts/cloudserver/Chart.yaml
+++ b/kubernetes/zenko/charts/cloudserver/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "8.1.0"
+appVersion: "8.1.1"
 description: A Helm chart for Kubernetes
 name: cloudserver
-version: 1.1.0
+version: 1.1.1

--- a/kubernetes/zenko/charts/cloudserver/values.yaml
+++ b/kubernetes/zenko/charts/cloudserver/values.yaml
@@ -84,7 +84,7 @@ replicaFactor: 1
 
 image:
   repository: zenko/cloudserver
-  tag: 8.1.0
+  tag: 8.1.1
   pullPolicy: IfNotPresent
 
 proxy:


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
Bumps cloudserver image to 8.1.1
