### PR TITLE
chore: bump backbeat to 8.0.19

### DIFF
--- a/kubernetes/zenko/charts/backbeat/Chart.yaml
+++ b/kubernetes/zenko/charts/backbeat/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "8.0.18"
+appVersion: "8.0.19"
 description: A Helm chart for Zenko Backbeat
 name: backbeat
-version: 1.0.0
+version: 1.0.2

--- a/kubernetes/zenko/charts/backbeat/values.yaml
+++ b/kubernetes/zenko/charts/backbeat/values.yaml
@@ -10,7 +10,7 @@ global:
 
 image:
   repository: zenko/backbeat
-  tag: 8.0.18
+  tag: 8.0.19
   pullPolicy: IfNotPresent
 
 logging:


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
bump backbeat chart for the ZENKO-1175 oplog fix 
 