### PR TITLE
chore(kafka-manager): add curl to Dockerfile

### DIFF
--- a/images/kafka-manager/Dockerfile
+++ b/images/kafka-manager/Dockerfile
@@ -12,7 +12,7 @@ RUN wget "https://github.com/yahoo/kafka-manager/archive/${KAFKA_MANAGER_VERSION
 
 FROM openjdk:8u131-jre-alpine
 
-RUN apk update && apk add bash
+RUN apk update && apk add bash curl
 COPY --from=build /opt/kafka-manager /opt/kafka-manager
 WORKDIR /opt/kafka-manager
 


### PR DESCRIPTION
<!--
Thank you for contributing to Zenko!

Please enter applicable information below.
-->

**What does this PR do, and why do we need it?**

Adds curl to the new Kafka-manager Dockerfile. It is needed by the boostrap job to configure the cluster automagically.