### PR TITLE
bugfix: ZENKO-1312 reduce replicaFactor of backbeat processor

### DIFF
--- a/kubernetes/zenko/values.yaml
+++ b/kubernetes/zenko/values.yaml
@@ -81,7 +81,10 @@ backbeat:
   replication:
     dataProcessor:
       replicaCount: *nodeCount
-      replicaFactor: 2
+      # If replicaFactor is increased, make sure to increase the
+      # number of partitions for "backbeat-replication" topic
+      # accordingly
+      replicaFactor: 1
     statusProcessor:
       replicaCount: *nodeCount
   lifecycle:


### PR DESCRIPTION
Set the default replicaFactor for backbeat processor pods to 1 instead
of 2, to match the default number of partitions for
backbeat-replication topic which is the number of nodes.
