### PR TITLE
Add s3 listing fuzzer to eve

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -183,3 +183,30 @@ stages:
             <<: *global_env
       - ShellCommand: *dump_logs
       - Upload: *upload_artifacts
+
+  fuzz-listing:
+    worker: *kube_cluster
+    steps:
+      - Git: *git_pull
+      - ShellCommand: *private_registry_login
+      - ShellCommand:
+          name: Setup Zenko and run versioned bucket test
+          command: make -e test-listing
+          workdir: build/tests
+          maxTime: 43200
+          timeout: 43200
+          env:
+            S3_FUZZER: enabled
+            ZENKO_BUCKET: fuzzbucket-ver
+            <<: *global_env
+      - ShellCommand:
+          name: Run unversioned bucket test
+          command: make -e run-listing-fuzzer
+          workdir: build/tests
+          maxTime: 43200
+          env:
+            ZENKO_BUCKET: fuzzbucket-nonver
+            VERSIONED: disabled
+            <<: *global_env
+      - ShellCommand: *dump_logs
+      - Upload: *upload_artifacts

--- a/eve/workers/ci_env.sh
+++ b/eve/workers/ci_env.sh
@@ -7,7 +7,8 @@ if [ "$1" == "env" ]; then
 --env ZENKO_HELM_RELEASE=$ZENKO_HELM_RELEASE \
 --env HELM_NAMESPACE=$HELM_NAMESPACE \
 --env NUM_CPUS=1 \
---env INSTALL_TIMEOUT=$INSTALL_TIMEOUT "
+--env INSTALL_TIMEOUT=$INSTALL_TIMEOUT \
+--env S3_FUZZER=$S3_FUZZER "
 
 elif [ "$1" == "set" ]; then
   CLI_FLAG="set"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -34,6 +34,7 @@ COSBENCH_RUNNER_IMAGE_NAME := cosbench-runner
 E2E_POD := zenko-e2e
 COSBENCH_RUNNER_POD := cosbench-runner
 CEPH_WAITER_POD := ceph-waiter
+S3FUZZ_POD := s3fuzz-runner
 
 # Set a default tag,
 # but allow us to set all of them using TAG_OVERRIDE
@@ -177,6 +178,16 @@ ifndef NO_INSTALL
 endif
 .PHONY: install-latest-zenko
 
+wait-for-zenko: | build-tests
+	$(V)$(KUBECTL) run zenko-waiter \
+		--image $(E2E_IMAGE) \
+		--rm \
+		--attach=True \
+		--restart=Never \
+		--namespace=$(HELM_NAMESPACE) \
+		$(shell ../eve/workers/ci_env.sh env) \
+		--command -- python3 create_buckets.py || (echo "Zenko has failed to stabilize" ; kubectl get pods -L redis-role ; exit 1) >&2
+.PHONY: wait-for-zenko
 
 wait-for-ceph: | build-tests
 	$(V)echo "Waiting for ceph..."
@@ -212,6 +223,27 @@ run-tests: | build-tests
 		--env CLOUDSERVER_ENDPOINT="http://$(ZENKO_HELM_RELEASE)-cloudserver:80" \
 		$(shell ../eve/workers/ci_env.sh env) || (echo "Tests have failed" ; kubectl get pods -L redis-role ; exit 1) >&2
 .PHONY: run-tests
+
+run-listing-fuzzer:
+	$(V)$(KUBECTL) run $(S3FUZZ_POD) \
+		--rm \
+		--restart=Never \
+		--attach=True \
+		--image=zenko/s3fuzz:latest \
+		--namespace $(HELM_NAMESPACE) \
+		--env ZENKO_HOST="http://$(ZENKO_HELM_RELEASE)-cloudserver:80" \
+		--env COUNT=1 \
+		--env SEED=$(shell date '+%s') \
+		--env ZENKO_BUCKET=$(ZENKO_BUCKET) \
+		--env AWS_BUCKET=ci-zenko-s3-fuzzer \
+		--env VERSIONED=$(VERSIONED) \
+		--env ANTITIMEOUT=1 \
+		--env NO_SERVICES=1 \
+		$(shell ../eve/workers/ci_env.sh env)
+.PHONY: run-listing-fuzzer
+
+test-listing: | install-common get-latest-commit install-zenko wait-for-zenko run-listing-fuzzer
+.PHONY: test-listing
 
 test-flaky:
 	$(eval NODE_TEST_TAGS = is:flaky)

--- a/tests/zenko_tests/create_buckets.py
+++ b/tests/zenko_tests/create_buckets.py
@@ -98,6 +98,12 @@ buckets = [
     get_env('CEPH_CRR_SRC_BUCKET_NAME', 'ci-zenko-ceph-crr-src-bucket')
 ]
 
+if get_env('S3_FUZZER') is not None:
+    buckets += [
+        'fuzzbucket-ver',
+        'fuzzbucket-nonver'
+    ]
+
 s = Session(aws_access_key_id=ZENKO_ACCESS_KEY,
             aws_secret_access_key=ZENKO_SECRET_KEY)
 s3client = s.resource('s3',
@@ -125,6 +131,11 @@ if not created:
     sys.exit(1)
 else:
     _log.info('Created buckets')
+
+if get_env('S3_FUZZER') is not None:
+    _log.info('Enabling version for s3://fuzzbucket-ver')
+    bkt = s3client.Bucket('fuzzbucket-ver').Versioning().enable()
+
 
 # Wait for all containers to become ready
 wait_for_pods(False, TIMEOUT)


### PR DESCRIPTION
<!--
Thank you for contributing to Zenko!

Please enter applicable information below.
-->

**What does this PR do, and why do we need it?**
Adds the s3 listing fuzzer to our nightly test runs. Listing objects is a complex problem and has been the source of bugs in the past. By running a fuzzer nightly with random seeds we hope to catch many of theses before they crop up in production environments.

**Which issue does this PR fix?**

fixes ZENKO-1329
