### PR TITLE
bugfix/ZENKO-1393 Clone of TP20-5. Fixes HTML output.

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -85,6 +85,10 @@ div.warning {
     border: 1px solid #e55529;
 }
 
+div.admonition.warning a:visited {
+    color: #3F5952;
+    text-decoration: none;
+}
 /* Changes the table header color to be gray */
 table.docutils th {
   background-color: #eaeaea;


### PR DESCRIPTION
This PR fixes the disappearing link text in HTML warning admonition boxes. 

This fixes ZENKO-1393, which is a clone of TP20-5
