### PR TITLE
ZENKO-1405 setup doc env

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.tox
+docs/_build

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -8,6 +8,7 @@ FROM docker.io/ubuntu:18.04
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
     apt-get install --no-install-recommends -y \
+        curl \
         enchant \
         emacs \
         git \
@@ -21,6 +22,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         texlive-latex-extra \
         texlive-latex-recommended \
         tox \
+        texlive-xetex \
         vim \
         xindy \
         && \

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -9,6 +9,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
     apt-get install --no-install-recommends -y \
         enchant \
+        emacs \
         git \
         inkscape \
         latexmk \
@@ -20,6 +21,8 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         texlive-latex-extra \
         texlive-latex-recommended \
         tox \
+        vim \
+        xindy \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -8,11 +8,25 @@ SPHINXPROJ    = Zenko
 SOURCEDIR     = .
 BUILDDIR      = _build
 
+
+ROOTDIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+DOCKER=docker
+BUILDERNAME=zenko-docs
+BUILDERIMAGE="$(ROOTDIR)/.."
+BUILDERDOCKERFILE=./Dockerfile
+BUILDERHOME=/usr/src/zenko
+
+.PHONY: build shell help Makefile
+
+build:
+	@$(DOCKER) build -t $(BUILDERNAME):latest -f $(BUILDERDOCKERFILE) $(BUILDERIMAGE)
+
+shell: build
+	@$(DOCKER) run -it --rm -v "$(ROOTDIR)/..:$(BUILDERHOME)" --entrypoint=bash $(BUILDERNAME)
+
 # Put it first so that "make" without argument is like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
-
-.PHONY: help Makefile
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -183,6 +183,7 @@ texinfo_documents = [
      'manual'),
 ]
 
+latex_engine = 'xelatex'
 
 # -- Options for Epub output -------------------------------------------------
 

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -2,6 +2,15 @@
 
 pushd %~dp0
 
+REM docker build setup
+
+set DOCKER=docker
+set BUILDERNAME=zenko-docs
+set BUILDERIMAGE=..\
+set BUILDERDOCKERFILE=.\Dockerfile
+set BUILDERHOME=/usr/src/zenko
+
+
 REM Command file for Sphinx documentation
 
 if "%SPHINXBUILD%" == "" (
@@ -13,24 +22,17 @@ set SPHINXPROJ=Zenko
 
 if "%1" == "" goto help
 
-%SPHINXBUILD% >NUL 2>NUL
-if errorlevel 9009 (
-	echo.
-	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
-	echo.installed, then set the SPHINXBUILD environment variable to point
-	echo.to the full path of the 'sphinx-build' executable. Alternatively you
-	echo.may add the Sphinx directory to PATH.
-	echo.
-	echo.If you don't have Sphinx installed, grab it from
-	echo.http://sphinx-doc.org/
-	exit /b 1
-)
+REM create a docker container work environment
+:shell
+	%DOCKER% build -t %BUILDERNAME%:latest -f %BUILDERDOCKERFILE% %BUILDERIMAGE%
+	%DOCKER% run -it --rm -v "%~dp0\..:%BUILDERHOME%" -v "C:\:/c" --entrypoint=bash %BUILDERNAME%
+
+:help
+	%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
 
 %SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
 goto end
 
-:help
-%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
 
 :end
 popd

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -127,7 +127,18 @@ stages:
     - ShellCommand:
         name: 'Build doc'
         haltOnFailure: true
-        command: tox --workdir /tmp/tox -e docs -- html # latexpdf
+        command: |-
+          tox --workdir /tmp/tox -e docs -- html BUILDDIR="%(prop:builddir)s/build/artifacts"
+          # Building the latex twice to catch up the reference
+          tox --workdir /tmp/tox -e docs -- latexpdf BUILDDIR="%(prop:builddir)s/build/artifacts"
+          tox --workdir /tmp/tox -e docs -- latexpdf BUILDDIR="%(prop:builddir)s/build/artifacts"
+
+    - Upload:
+        name: Upload documentation
+        source: 'artifacts'
+        urls:
+          - "html/index.html"
+          - "latex/*.pdf"
 
   test-zenko:
     worker: &kube_cluster


### PR DESCRIPTION
This PR brings a couple of features related to the documentation:

* Setting up an local shell using the docker image, to ease the setup of the documentation on a laptop.
* The CI is now supporting the build of the PDF.
* Uploading the results in artifacts, PDF and html results build inside the ci can now be retrieved.
