### PR TITLE
bugfix: restart rclone job on failure

### DIFF
--- a/kubernetes/cosmos/templates/rclone-cronjob.yaml
+++ b/kubernetes/cosmos/templates/rclone-cronjob.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       template:
         spec:
-          restartPolicy: Never
+          restartPolicy: OnFailure
           containers:
           - name: {{ .Chart.Name }}
             image: "{{ .Values.rclone.image.repository }}:{{ .Values.rclone.image.tag }}"


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
Fixes a bug where endless amount of pods are created on failure, until the pod succeeds. Still leaving failed containers as artifacts.

**Which issue does this PR fix?**

ZENKO-1410

**Special notes for your reviewers**:
