### PR TITLE
documentation/ZENKO-1416 Update_copyright_to_2019

### DIFF
--- a/docs/Reference/conf.py
+++ b/docs/Reference/conf.py
@@ -20,8 +20,8 @@
 # -- Project information -----------------------------------------------------
 
 project = 'Zenko Reference Guide'
-copyright = '2018, Tech Pubs'
-author = 'Tech Pubs'
+copyright = '2019, Scality, Inc'
+author = 'Scality Technical Publications'
 
 # The short X.Y version
 version = ''

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'Zenko'
-copyright = '2018, Scality, Inc'
+copyright = '2019, Scality, Inc'
 author = 'Scality Technical Publications'
 
 # The short X.Y version


### PR DESCRIPTION
This PR updates the copyright bugs in the documentation to 2019. 

We need it to protect our copyrights, copylefts, and copyinbetweens. 

This PR fixes #ZENKO-1416
