### PR TITLE
feat(pfsd/s3data): add noCache and nosync options

### DIFF
--- a/kubernetes/cosmos/templates/pfsd-deployment.yaml
+++ b/kubernetes/cosmos/templates/pfsd-deployment.yaml
@@ -34,6 +34,10 @@ spec:
           env:
             - name: PFSD_READONLY
               value: {{ .Values.persistentVolume.readOnly | quote }}
+            - name: PFSD_NOSYNC
+              value: {{ .Values.pfsd.noSync | quote }}
+            - name: PFSD_NOCACHE
+              value: {{ .Values.pfsd.noCache | quote }}
             - name: PFSD_MOUNT_PATH
               value: /data
             - name: LISTEN_ADDR

--- a/kubernetes/cosmos/values.yaml
+++ b/kubernetes/cosmos/values.yaml
@@ -5,12 +5,23 @@ pfsd:
 
   image:
     repository: zenko/cloudserver
-    tag: 8.1.4
+    tag: 8.1.5
     pullPolicy: IfNotPresent
 
   service:
     type: ClusterIP
     port: 80
+
+  ## Enable file syncing. If set to 'true', files will not be synced to ensure
+  ## that they are written to disk. Also, it will not be guranteed that page
+  ## caches will be released by the Kernel when 'noCache' is 'true'
+  noSync: false
+
+  ## Enable Kernel page caching. If set to 'true', page caches will be released
+  ## after reading or writing files using posix_fadvise(POSIX_FADV_DONTNEED)
+  ## This prevents virtual memory size from increasing proportinally to the files
+  ## read or written.
+  noCache: true
 
   resources: {}
   nodeSelector: {}

--- a/kubernetes/zenko/charts/s3-data/templates/deployment.yaml
+++ b/kubernetes/zenko/charts/s3-data/templates/deployment.yaml
@@ -30,6 +30,10 @@ spec:
           env:
             - name: S3DATAPATH
               value: /data
+            - name: S3DATA_NOSYNC
+              value: {{ .Values.noSync | quote }}
+            - name: S3DATA_NOCACHE
+              value: {{ .Values.noCache | quote }}
             - name: LISTEN_ADDR
               value: 0.0.0.0
             - name: HEALTHCHECKS_ALLOWFROM

--- a/kubernetes/zenko/charts/s3-data/values.yaml
+++ b/kubernetes/zenko/charts/s3-data/values.yaml
@@ -4,13 +4,25 @@
 replicaCount: 1
 image:
   repository: zenko/cloudserver
-  tag: 8.1.2
+  tag: 8.1.5
   pullPolicy: IfNotPresent
 service:
   name: s3-data
   type: ClusterIP
   internalPort: 9991
   externalPort: 9991
+
+## Enable file syncing. If set to 'true', files will not be synced to ensure
+## that they are written to disk. Also, it will not be guranteed that page
+## caches will be released by the Kernel when 'noCache' is 'true'
+noSync: false
+
+## Enable Kernel page caching. If set to 'true', page caches will be released
+## after reading or writing files using posix_fadvise(POSIX_FADV_DONTNEED)
+## This prevents virtual memory size from increasing proportinally to the files
+## read or written.
+noCache: true
+
 persistentVolume:
   enabled: true
   accessModes:


### PR DESCRIPTION
<!--
Thank you for contributing to Zenko!

Please enter applicable information below.
-->

**What does this PR do, and why do we need it?**

Makes the `noCache` and `noSync` options configurable for `s3-data` and `pfsd`.

**Special notes for your reviewers**:

Image tag doesn't exist yet, waiting for https://github.com/scality/cloudserver/pull/1674