### PR TITLE
bugfix(s3-data): add noCache and noSync options

### DIFF
--- a/kubernetes/zenko/charts/s3-data/Chart.yaml
+++ b/kubernetes/zenko/charts/s3-data/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "8.0.21"
+appVersion: "8.0.22"
 description: A Helm chart for Kubernetes
 name: s3-data
 version: 1.0.2

--- a/kubernetes/zenko/charts/s3-data/templates/deployment.yaml
+++ b/kubernetes/zenko/charts/s3-data/templates/deployment.yaml
@@ -30,6 +30,10 @@ spec:
           env:
             - name: S3DATAPATH
               value: /data
+            - name: S3DATA_NOSYNC
+              value: {{ .Values.noSync | quote }}
+            - name: S3DATA_NOCACHE
+              value: {{ .Values.noCache | quote }}
             - name: LISTEN_ADDR
               value: 0.0.0.0
             - name: HEALTHCHECKS_ALLOWFROM

--- a/kubernetes/zenko/charts/s3-data/values.yaml
+++ b/kubernetes/zenko/charts/s3-data/values.yaml
@@ -4,13 +4,25 @@
 replicaCount: 1
 image:
   repository: zenko/cloudserver
-  tag: 8.0.21
+  tag: 8.0.22
   pullPolicy: IfNotPresent
 service:
   name: s3-data
   type: ClusterIP
   internalPort: 9991
   externalPort: 9991
+
+## Enable file syncing. If set to 'true', files will not be synced to ensure
+## that they are written to disk. Also, it will not be guranteed that page
+## caches will be released by the Kernel when 'noCache' is 'true'
+noSync: false
+
+## Enable Kernel page caching. If set to 'true', page caches will be released
+## after reading or writing files using posix_fadvise(POSIX_FADV_DONTNEED)
+## This prevents virtual memory size from increasing proportinally to the files
+## read or written.
+noCache: true
+
 persistentVolume:
   enabled: true
   accessModes:


### PR DESCRIPTION
<!--
Thank you for contributing to Zenko!

Please enter applicable information below.
-->

**What does this PR do, and why do we need it?**

This adds the `noCache` and `noSync` options to the `s3-data` chart.
The integration branch does the same for `pfsd`.