### PR TITLE
ft: Allow for more PV options

### DIFF
--- a/kubernetes/cosmos/templates/pv.yaml
+++ b/kubernetes/cosmos/templates/pv.yaml
@@ -12,9 +12,6 @@ spec:
   - ReadWriteMany
   capacity:
     storage: {{ .Values.persistentVolume.size }}
-  nfs:
-    path: {{ .Values.persistentVolume.path }}
-    server: {{ .Values.persistentVolume.server }}
-    readOnly: {{ .Values.persistentVolume.readOnly }}
+{{ toYaml .Values.persistentVolume.volumeConfig | indent 2 }}
   persistentVolumeReclaimPolicy: Retain
   storageClassName: {{ template "cosmos.fullname" . }}

--- a/kubernetes/cosmos/values.yaml
+++ b/kubernetes/cosmos/values.yaml
@@ -41,9 +41,14 @@ rclone:
   affinity: {}
 
 persistentVolume:
-  server: 10.100.1.42
-  path: /data
+  volumeConfig:
+    nfs:
+      server: 10.100.1.42
+      path: /data
+      readOnly: false
+    mountOptions: []
+    # - hard
+    # - nfsvers=4.1
   accessModes:
     - ReadWriteMany
   size: 1Gi
-  readOnly: false


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
Make the Cosmos chart PV more configurable. Allowing for not only more NFS Mount options but for different Kubernetes supported PVs.

**Which issue does this PR fix?**

ZENKO-1422

**Special notes for your reviewers**: