### PR TITLE
ft: Allow for more PV options

### DIFF
--- a/docs/Installation/topics/adding_NFS_storage.rst
+++ b/docs/Installation/topics/adding_NFS_storage.rst
@@ -71,7 +71,7 @@ and their default values.
    +------------------------------------+---------------------------------------+------------------------------+
    | ``rclone.image.pullPolicy``        | rclone image pull policy              | ``IfNotPresent``             |
    +------------------------------------+---------------------------------------+------------------------------+
-   | ``rclone.schedule``                | rclone CronJob schedule               | ``*/10 * * * *``             |
+   | ``rclone.schedule``                | rclone CronJob schedule               | ``0 */12 * * *``             |
    +------------------------------------+---------------------------------------+------------------------------+
    | ``rclone.successfulJobsHistory``   | rclone CronJob successful job history | ``1``                        |
    +------------------------------------+---------------------------------------+------------------------------+
@@ -91,13 +91,13 @@ and their default values.
    +------------------------------------+---------------------------------------+------------------------------+
    | ``rclone.affinity``                | rclone pod affinity                   | ``{}``                       |
    +------------------------------------+---------------------------------------+------------------------------+
-   | ``persistentVolume.enabled``       | If true, enable persistentVolume      | ``true``                     |
+   | ``persistentVolume.enabled``       | If true, enable persistentVolume      | ``false``                    |
+   +------------------------------------+---------------------------------------+------------------------------+
+   | ``persistentVolume.volumeConfig``  | Specify volume type and mount options | ``{}``                       |
    +------------------------------------+---------------------------------------+------------------------------+
    | ``persistentVolume.accessModes``   | Persistent volume access modes        | ``ReadWriteMany``            |
    +------------------------------------+---------------------------------------+------------------------------+
    | ``persistentVolume.existingClaim`` | Name of existing claim                | ``""``                       |
-   +------------------------------------+---------------------------------------+------------------------------+
-   | ``persistentVolume.storageClass``  | Persistent volume storage class       | ``cosmos``                   |
    +------------------------------------+---------------------------------------+------------------------------+
    | ``persistentVolume.size``          | Persistent volume size                | ``1Gi``                      |
    +------------------------------------+---------------------------------------+------------------------------+
@@ -167,8 +167,15 @@ from `Orbit <https://admin.zenko.io>`_.
            bucket: ${NFS_BUCKET}
  
        persistentVolume:
-         server: ${NFS_HOST}
-         path: ${NFS_EXPORT_PATH}
+         enabled: true
+         volumeConfig:
+           nfs:
+             server: ${NFS_HOST}
+             path: ${NFS_EXPORT_PATH}
+             readOnly: false
+           # Any valid nfs mount option can be listed here
+           mountOptions:
+             - nfsvers=3
        EOF
   
 6. Install Cosmos.
@@ -241,8 +248,16 @@ Installing the Chart with a Standalone Cloudserver Instance
           bucket: my-nfs-bucket # Bucket will be created if not present
 
       persistentVolume:
-        server: 10.100.1.42 # IP address of your NFS server
-        path: /data # NFS export
+        enabled: true
+        volumeConfig:
+          nfs:
+            server: 10.100.1.42 # IP address of your NFS server
+            path: /data # NFS export
+            readOnly: false
+          # Any valid nfs mount option can be listed here
+          mountOptions:
+            - nfsvers=3
+      persistentVolume:
       EOF
 
 5. Install Cosmos.

--- a/kubernetes/cosmos/README.md
+++ b/kubernetes/cosmos/README.md
@@ -63,7 +63,7 @@ The following table lists the configurable parameters of the Cosmos chart and th
 | `rclone.nodeSelector` | Node labels for rclone pod assignment | `{}` |
 | `rclone.tolerations` | Node taints to tolerate | `[]` |
 | `rclone.affinity` | rclone pod affinity | `{}` |
-| `persistentVolume.enabled` | If true, enable persistentVolume | `true` |
+| `persistentVolume.enabled` | If true, enable persistentVolume | `false` |
 | `persistentVolume.accessModes` | Persistent Volume access modes | `ReadWriteMany` |
 | `persistentVolume.existingClaim` | Existing claim name | `""` |
 | `persistentVolume.storageClass` | Persistent Volume storage class | `cosmos` |
@@ -125,8 +125,15 @@ rclone:
     bucket: ${NFS_BUCKET}
 
 persistentVolume:
-  server: ${NFS_HOST}
-  path: ${NFS_EXPORT_PATH}
+  enabled: true
+  volumeConfig:
+    nfs:
+      server: ${NFS_HOST}
+      path: ${NFS_EXPORT_PATH}
+      readOnly: false
+    # Any valid nfs mount option can be listed here
+    mountOptions:
+      - nfsvers=3
 EOF
 ```
 
@@ -195,8 +202,11 @@ rclone:
     bucket: my-nfs-bucket # Bucket will be created if not present
 
 persistentVolume:
-  server: 10.100.1.42 # IP of your NFS server
-  path: /data # NFS export
+  enabled: true
+  volueConfig:
+    nfs:
+      server: 10.100.1.42 # IP of your NFS server
+      path: /data # NFS export
 EOF
 ```
 

--- a/kubernetes/cosmos/templates/pfsd-deployment.yaml
+++ b/kubernetes/cosmos/templates/pfsd-deployment.yaml
@@ -33,7 +33,7 @@ spec:
               protocol: TCP
           env:
             - name: PFSD_READONLY
-              value: {{ .Values.persistentVolume.readOnly | quote }}
+              value: {{ .Values.pfsd.readOnly | quote }}
             - name: PFSD_MOUNT_PATH
               value: /data
             - name: LISTEN_ADDR
@@ -67,5 +67,9 @@ spec:
     {{- end }}
       volumes:
         - name: backend-storage
+{{- if .Values.persistentVolume.enabled }}
           persistentVolumeClaim:
             claimName: {{ template "cosmos.fullname" . }}
+{{- else }}
+          emptyDir: {}
+{{- end }}

--- a/kubernetes/cosmos/templates/pv.yaml
+++ b/kubernetes/cosmos/templates/pv.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.persistentVolume.enabled }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -12,9 +13,7 @@ spec:
   - ReadWriteMany
   capacity:
     storage: {{ .Values.persistentVolume.size }}
-  nfs:
-    path: {{ .Values.persistentVolume.path }}
-    server: {{ .Values.persistentVolume.server }}
-    readOnly: {{ .Values.persistentVolume.readOnly }}
+{{ toYaml .Values.persistentVolume.volumeConfig | indent 2 }}
   persistentVolumeReclaimPolicy: Retain
   storageClassName: {{ template "cosmos.fullname" . }}
+{{- end }}

--- a/kubernetes/cosmos/templates/pvc.yaml
+++ b/kubernetes/cosmos/templates/pvc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.persistentVolume.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -16,3 +17,4 @@ spec:
     requests:
       storage: {{ .Values.persistentVolume.size | quote }}
   storageClassName: {{ template "cosmos.fullname" . }}
+{{- end }}

--- a/kubernetes/cosmos/templates/rclone-cronjob.yaml
+++ b/kubernetes/cosmos/templates/rclone-cronjob.yaml
@@ -40,5 +40,9 @@ spec:
             configMap:
               name: {{ template "cosmos.rclone.fullname" . }}
           - name: backend-storage
+{{- if .Values.persistentVolume.enabled }}
             persistentVolumeClaim:
               claimName: {{ template "cosmos.fullname" . }}
+{{- else }}
+            emptyDir: {}
+{{- end }}

--- a/kubernetes/cosmos/values.yaml
+++ b/kubernetes/cosmos/values.yaml
@@ -2,6 +2,7 @@ pfsd:
   name: pfsd
 
   replicaCount: 1
+  readOnly: false
 
   image:
     repository: zenko/cloudserver
@@ -41,9 +42,16 @@ rclone:
   affinity: {}
 
 persistentVolume:
-  server: 10.100.1.42
-  path: /data
+  enabled: false
+  volumeConfig:
+    ## Example NFS config
+    # nfs:
+    #   server: 10.100.1.42
+    #   path: /data
+    #   readOnly: false
+    # mountOptions:
+    # - hard
+    # - nfsvers=4.1
   accessModes:
     - ReadWriteMany
   size: 1Gi
-  readOnly: false


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
Make the Cosmos chart PV more configurable. Allowing for not only more NFS Mount options but for different Kubernetes supported PVs.

**Which issue does this PR fix?**
ZENKO-1422

**Special notes for your reviewers**: