### PR TITLE
Bugfix/zenko 1356 split brain

### DIFF
--- a/kubernetes/zenko/charts/redis-ha/Chart.yaml
+++ b/kubernetes/zenko/charts/redis-ha/Chart.yaml
@@ -5,12 +5,16 @@ keywords:
 - redis
 - keyvalue
 - database
-version: 3.0.3-Z
+version: 3.0.4
 appVersion: 4.0.11
 description: Highly available Kubernetes implementation of Redis
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/6/6b/Redis_Logo.svg/1200px-Redis_Logo.svg.png
+maintainers:
+- email: salimsalaues@gmail.com
+  name: ssalaues
 details:
   This Helm chart provides a highly available Redis implementation with a master/slave configuration
   and uses Sentinel sidecars for failover management
 sources:
-  - https://redis.io/download
+- https://redis.io/download
+- https://github.com/scality/Zenko/tree/development/1.0/kubernetes/zenko/charts/redis-ha

--- a/kubernetes/zenko/charts/redis-ha/README.md
+++ b/kubernetes/zenko/charts/redis-ha/README.md
@@ -18,7 +18,7 @@ This chart bootstraps a [Redis](https://redis.io) highly available master/slave 
 
 ## Prerequisites
 
-- Kubernetes 1.5+ with Beta APIs enabled
+- Kubernetes 1.8+ with Beta APIs enabled
 - PV provisioner support in the underlying infrastructure
 
 ## Upgrading the Chart
@@ -55,14 +55,22 @@ The following table lists the configurable parameters of the Redis chart and the
 | -------------------------------- | -----------------------------------------------------                                                                        | --------------------------------------------------------- |
 | `image`                          | Redis image                                                                                                                  | `redis`                                                   |
 | `tag`                            | Redis tag                                                                                                                    | `4.0.11-stretch`                                          |
-| `redis.resources`                | CPU/Memory for master/slave nodes resource requests/limits                                                                   | Memory: `200Mi`, CPU: `100m`                              |
-| `sentinel.resources`             | CPU/Memory for sentinel node resource requests/limits                                                                        | Memory: `200Mi`, CPU: `100m`                              |
-| `replicas`                       | Number of redis master/slave pods                                                                                            | 3                                                         |
-| `nodeSelector`                   | Node labels for pod assignment                                                                                               | {}                                                        |
-| `tolerations`                    | Toleration labels for pod assignment                                                                                         | []                                                        |
-| `podAntiAffinity.server`         | Antiaffinity for pod assignment of servers, `hard` or `soft`                                                                 | `soft`                                                    |
+| `replicas`                       | Number of redis master/slave pods                                                                                            | `3`                                                       |
+| `redis.port`                     | Port to access the redis service                                                                                             | `6379`                                                    |
+| `redis.masterGroupName`          | Redis convention for naming the cluster group                                                                                | `mymaster`                                                |
 | `redis.config`                   | Any valid redis config options in this section will be applied to each server (see below)                                    | see values.yaml                                           |
-| `sentinel.config`                | Any valid sentinel config options in this section will be applied to each sentinel (see below)                               | see values.yaml                                           |
+| `redis.customConfig`             | Allows for custom redis.conf files to be applied. If this is used then `redis.config` is ignored                             | ``                                                        |
+| `redis.resources`                | CPU/Memory for master/slave nodes resource requests/limits                                                                   | `{}`                                                      |
+| `sentinel.port`                  | Port to access the sentinel service                                                                                          | `26379`                                                   |
+| `sentinel.quorum`                | Minimum number of servers necessary to maintain quorum                                                                       | `2`                                                       |
+| `sentinel.config`                | Valid sentinel config options in this section will be applied as config options to each sentinel (see below)                 | see values.yaml                                           |
+| `sentinel.customConfig`          | Allows for custom sentinel.conf files to be applied. If this is used then `sentinel.config` is ignored                       | ``                                                        |
+| `sentinel.resources`             | CPU/Memory for sentinel node resource requests/limits                                                                        | `{}`                                                      |
+| `auth`                           | Enables or disables redis AUTH (Requires `redisPassword` to be set)                                                          | `false`                                                   |
+| `redisPassword`                  | A password that configures a `requirepass` and `masterauth` in the conf parameters (Requires `auth: enabled`)                | ``                                                        |
+| `nodeSelector`                   | Node labels for pod assignment                                                                                               | `{}`                                                      |
+| `tolerations`                    | Toleration labels for pod assignment                                                                                         | `[]`                                                      |
+| `podAntiAffinity.server`         | Antiaffinity for pod assignment of servers, `hard` or `soft`                                                                 | `Hard node and soft zone anti-affinity`                   |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
@@ -86,7 +94,7 @@ $ helm install -f values.yaml stable/redis-ha
 
 ## Custom Redis and Sentinel config options
 
-This chart allow for any valid redis or sentinel config option to be passed as a key value pair through the `values.yaml` file.
+This chart allows for most redis or sentinel config options to be passed as a key value pair through the `values.yaml` under `redis.config` and `sentinel.config`. See links below for all available options.
 
 [Example redis.conf](http://download.redis.io/redis-stable/redis.conf)
 [Example sentinel.conf](http://download.redis.io/redis-stable/sentinel.conf)
@@ -96,3 +104,12 @@ For example `repl-timeout 60` would be added to the `redis.config` section of th
 ```yml
     repl-timeout: "60"
 ```
+
+Sentinel options supported must be in the the `sentinel <option> <master-group-name> <value>` format. For example, `sentinel down-after-milliseconds 30000` would be added to the `sentinel.config` section of the `values.yaml` as:
+
+```yml
+    down-after-milliseconds: 30000
+```
+
+If more control is needed from either the redis or sentinel config then an entire config can be defined under `redis.customConfig` or `sentinel.customConfig`. Please note that these values will override any configuration options under their respective section. For example, if you define `sentinel.customConfig` then the `sentinel.config` is ignored.
+

--- a/kubernetes/zenko/charts/redis-ha/templates/NOTES.txt
+++ b/kubernetes/zenko/charts/redis-ha/templates/NOTES.txt
@@ -1,15 +1,15 @@
-Redis cluster can be accessed via port {{ .Values.redis.port }} on the following DNS name from within your cluster:
+Redis can be accessed via port {{ .Values.redis.port }} and Sentinel can be accessed via port {{ .Values.sentinel.port }} on the following DNS name from within your cluster:
 {{ template "redis-ha.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 
 To connect to your Redis server:
 
 {{- if .Values.auth }}
-1. Get the randomly generated redis password:
-   echo $(kubectl get secret {{ template "redis-ha.fullname" . }} -o "jsonpath={.data['auth']}" | base64 -D)
+1. To retrieve the redis password:
+   echo $(kubectl get secret {{ template "redis-ha.fullname" . }} -o "jsonpath={.data['auth']}" | base64 --decode)
 
 2. Connect to the Redis master pod that you can use as a client. By default the {{ template "redis-ha.fullname" . }}-server-0 pod is configured as the master:
 
-   kubectl exec -it {{ template "redis-ha.fullname" . }}-server-0 bash -n {{ .Release.Namespace }}
+   kubectl exec -it {{ template "redis-ha.fullname" . }}-server-0 sh -n {{ .Release.Namespace }}
 
 3. Connect using the Redis CLI (inside container):
 
@@ -17,7 +17,7 @@ To connect to your Redis server:
 {{- else }}
 1. Run a Redis pod that you can use as a client:
 
-   kubectl exec -it {{ template "redis-ha.fullname" . }}-server-0 bash -n {{ .Release.Namespace }}
+   kubectl exec -it {{ template "redis-ha.fullname" . }}-server-0 sh -n {{ .Release.Namespace }}
 
 2. Connect using the Redis CLI:
 

--- a/kubernetes/zenko/charts/redis-ha/templates/_helpers.tpl
+++ b/kubernetes/zenko/charts/redis-ha/templates/_helpers.tpl
@@ -13,10 +13,17 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "redis-ha.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-
+{{- end -}}
+{{- end -}}
 
 {{- /*
 Credit: @technosophos

--- a/kubernetes/zenko/charts/redis-ha/templates/redis-auth-secret.yaml
+++ b/kubernetes/zenko/charts/redis-ha/templates/redis-auth-secret.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.enabled -}}
 {{- if .Values.auth -}}
 apiVersion: v1
 kind: Secret
@@ -10,4 +9,3 @@ type: Opaque
 data:
   auth: {{ .Values.redisPassword | b64enc | quote }}
 {{- end -}}
-{{- end }}

--- a/kubernetes/zenko/charts/redis-ha/templates/redis-ha-announce-service.yaml
+++ b/kubernetes/zenko/charts/redis-ha/templates/redis-ha-announce-service.yaml
@@ -1,0 +1,33 @@
+{{- $fullName := include "redis-ha.fullname" . }}
+{{- $replicas := int .Values.replicas }}
+{{- $root := . }}
+{{- range $i := until $replicas }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}-announce-{{ $i }}
+  labels:
+{{ include "labels.standard" $root | indent 4 }}
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+  {{- if $root.Values.serviceAnnotations }}
+{{ toYaml $root.Values.serviceAnnotations | indent 4 }}
+  {{- end }}
+spec:
+  publishNotReadyAddresses: true
+  type: ClusterIP
+  ports:
+  - name: server
+    port: {{ $root.Values.redis.port }}
+    protocol: TCP
+    targetPort: redis
+  - name: sentinel
+    port: {{ $root.Values.sentinel.port }}
+    protocol: TCP
+    targetPort: sentinel
+  selector:
+    release: {{ $root.Release.Name }}
+    app: {{ include "redis-ha.name" $root }}
+    "statefulset.kubernetes.io/pod-name": {{ $fullName }}-server-{{ $i }}
+{{- end }}

--- a/kubernetes/zenko/charts/redis-ha/templates/redis-ha-configmap.yaml
+++ b/kubernetes/zenko/charts/redis-ha/templates/redis-ha-configmap.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,6 +9,9 @@ metadata:
     app: {{ template "redis-ha.fullname" . }}
 data:
   redis.conf: |
+{{- if .Values.redis.customConfig }}
+{{ .Values.redis.customConfig | indent 4 }}
+{{- else }}
     dir "/data"
     {{- range $key, $value := .Values.redis.config }}
     {{ $key }} {{ $value }}
@@ -18,8 +20,12 @@ data:
     requirepass replace-default-auth
     masterauth replace-default-auth
 {{- end }}
+{{- end }}
 
   sentinel.conf: |
+{{- if .Values.sentinel.customConfig }}
+{{ .Values.sentinel.customConfig | indent 4 }}
+{{- else }}
     dir "/data"
     {{- $root := . -}}
     {{- range $key, $value := .Values.sentinel.config }}
@@ -28,73 +34,104 @@ data:
 {{- if .Values.auth }}
     sentinel auth-pass {{ .Values.redis.masterGroupName }} replace-default-auth
 {{- end }}
+{{- end }}
 
-  init.bash: |
-    MASTER=`redis-cli -h {{ template "redis-ha.fullname" . }} -p {{ .Values.sentinel.port }} sentinel get-master-addr-by-name {{ .Values.redis.masterGroupName }} | grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}'`
+  init.sh: |
+    HOSTNAME="$(hostname)"
+    INDEX="${HOSTNAME##*-}"
+    MASTER="$(redis-cli -h {{ template "redis-ha.fullname" . }} -p {{ .Values.sentinel.port }} sentinel get-master-addr-by-name {{ .Values.redis.masterGroupName }} | grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')"
+    MASTER_GROUP="{{ .Values.redis.masterGroupName }}"
+    QUORUM="{{ .Values.sentinel.quorum }}"
     REDIS_CONF=/data/conf/redis.conf
+    REDIS_PORT={{ .Values.redis.port }}
     SENTINEL_CONF=/data/conf/sentinel.conf
-    
-    set -e
-    function sentinel_update(){
+    SENTINEL_PORT={{ .Values.sentinel.port }}
+    SERVICE={{ template "redis-ha.fullname" . }}
+    set -eu
+
+    sentinel_update() {
         echo "Updating sentinel config"
-        sed -i "1s/^/sentinel monitor {{ .Values.redis.masterGroupName }} $1 {{ .Values.redis.port }} {{ .Values.sentinel.quorum }} \n/" $SENTINEL_CONF
+        sed -i "1s/^/$(cat sentinel-id)\\n/" "$SENTINEL_CONF"
+        sed -i "2s/^/sentinel monitor $MASTER_GROUP $1 $REDIS_PORT $QUORUM \\n/" "$SENTINEL_CONF"
+        echo "sentinel announce-ip $ANNOUNCE_IP" >> $SENTINEL_CONF
+        echo "sentinel announce-port $SENTINEL_PORT" >> $SENTINEL_CONF
     }
-    function redis_update(){
+
+    redis_update() {
         echo "Updating redis config"
-        echo "slaveof $1 {{ .Values.redis.port }}" >> $REDIS_CONF
+        echo "slaveof $1 $REDIS_PORT" >> "$REDIS_CONF"
+        echo "slave-announce-ip $ANNOUNCE_IP" >> $REDIS_CONF
+        echo "slave-announce-port $REDIS_PORT" >> $REDIS_CONF
     }
-    function setup_defaults(){
+
+    copy_config() {
+        if [ -f "$SENTINEL_CONF" ]; then
+            grep "sentinel myid" "$SENTINEL_CONF" > sentinel-id || true
+        fi
+        cp /readonly-config/redis.conf "$REDIS_CONF"
+        cp /readonly-config/sentinel.conf "$SENTINEL_CONF"
+    }
+
+    setup_defaults() {
         echo "Setting up defaults"
-        if [[ "$HOSTNAME" == "{{ template "redis-ha.fullname" . }}-server-0" ]]; then
+        if [ "$INDEX" = "0" ]; then
             echo "Setting this pod as the default master"
-            sed -i "s/^.*slaveof.*//" $REDIS_CONF
-            sentinel_update "$POD_IP"
+            sed -i "s/^.*slaveof.*//" "$REDIS_CONF"
+            sentinel_update "$ANNOUNCE_IP"
         else
+            DEFAULT_MASTER="$(getent hosts "$SERVICE-announce-0" | awk '{ print $1 }')"
+            if [ -z "$DEFAULT_MASTER" ]; then
+                echo "Unable to resolve host"
+                exit 1
+            fi
             echo "Setting default slave config.."
-            echo "slaveof {{ template "redis-ha.fullname" . }}-server-0.{{ template "redis-ha.fullname" . }} {{ .Values.redis.port }}" >> $REDIS_CONF
-            sentinel_update "{{ template "redis-ha.fullname" . }}-server-0.{{ template "redis-ha.fullname" . }}"
-            redis_update "{{ template "redis-ha.fullname" . }}-server-0.{{ template "redis-ha.fullname" . }}"
+            redis_update "$DEFAULT_MASTER"
+            sentinel_update "$DEFAULT_MASTER"
         fi
     }
-    function find_master(){
+
+    find_master() {
         echo "Attempting to find master"
-        if [[ ! `redis-cli -h $MASTER{{ if .Values.auth }} -a $AUTH{{ end }} ping` ]]; then
+        if [ "$(redis-cli -h "$MASTER"{{ if .Values.auth }} -a "$AUTH"{{ end }} ping)" != "PONG" ]; then
            echo "Can't ping master, attempting to force failover"
-           if redis-cli -h {{ template "redis-ha.fullname" . }} -p {{ .Values.sentinel.port }} sentinel failover {{ .Values.redis.masterGroupName }} | grep -q 'NOGOODSLAVE' ; then 
+           if redis-cli -h "$SERVICE" -p "$SENTINEL_PORT" sentinel failover "$MASTER_GROUP" | grep -q 'NOGOODSLAVE' ; then 
                setup_defaults
                return 0
            fi
            sleep 10
-           MASTER=`redis-cli -h {{ template "redis-ha.fullname" . }} -p {{ .Values.sentinel.port }} sentinel get-master-addr-by-name {{ .Values.redis.masterGroupName }} | grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}'`
-           if [[ "$MASTER" ]]; then
-               sentinel_update $MASTER
-               redis_update $MASTER
+           MASTER="$(redis-cli -h $SERVICE -p $SENTINEL_PORT sentinel get-master-addr-by-name $MASTER_GROUP | grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')"
+           if [ "$MASTER" ]; then
+               sentinel_update "$MASTER"
+               redis_update "$MASTER"
            else
               echo "Could not failover, exiting..."
               exit 1
            fi
         else
             echo "Found reachable master, updating config"
-            sentinel_update $MASTER
-            redis_update $MASTER
+            sentinel_update "$MASTER"
+            redis_update "$MASTER"
         fi
     }
+
     mkdir -p /data/conf/
+
     echo "Initializing config.."
+    copy_config
 
-    cp /readonly-config/redis.conf $REDIS_CONF
-    cp /readonly-config/sentinel.conf $SENTINEL_CONF
-
-    if [[ "$MASTER" ]]; then
+    ANNOUNCE_IP=$(getent hosts "$SERVICE-announce-$INDEX" | awk '{ print $1 }')
+    if [ -z "$ANNOUNCE_IP" ]; then
+        "Could not resolve the announce ip for this pod"
+        exit 1
+    elif [ "$MASTER" ]; then
         find_master
     else
         setup_defaults
     fi
-    if [[ "$AUTH" ]]; then
+
+    if [ "${AUTH:-}" ]; then
         echo "Setting auth values"
-        sed -i "s/replace-default-auth/$AUTH/" $REDIS_CONF $SENTINEL_CONF
+        sed -i "s/replace-default-auth/$AUTH/" "$REDIS_CONF" "$SENTINEL_CONF"
     fi
 
     echo "Ready..."
-
-{{- end }}

--- a/kubernetes/zenko/charts/redis-ha/templates/redis-ha-configmap.yaml
+++ b/kubernetes/zenko/charts/redis-ha/templates/redis-ha-configmap.yaml
@@ -39,7 +39,7 @@ data:
   init.sh: |
     HOSTNAME="$(hostname)"
     INDEX="${HOSTNAME##*-}"
-    MASTER="$(redis-cli -h {{ template "redis-ha.fullname" . }} -p {{ .Values.sentinel.port }} sentinel get-master-addr-by-name {{ .Values.redis.masterGroupName }} | grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')"
+    MASTER="$(timeout -t 3 redis-cli -h {{ template "redis-ha.fullname" . }} -p {{ .Values.sentinel.port }} sentinel get-master-addr-by-name {{ .Values.redis.masterGroupName }} | grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')"
     MASTER_GROUP="{{ .Values.redis.masterGroupName }}"
     QUORUM="{{ .Values.sentinel.quorum }}"
     REDIS_CONF=/data/conf/redis.conf

--- a/kubernetes/zenko/charts/redis-ha/templates/redis-ha-healthchecks.yaml
+++ b/kubernetes/zenko/charts/redis-ha/templates/redis-ha-healthchecks.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "redis-ha.fullname" . }}-probes
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app: {{ template "redis-ha.fullname" . }}
+data:
+  check-quorum.sh: |
+    #!/bin/sh
+    set -eu
+    MASTER_GROUP="{{ .Values.redis.masterGroupName }}"
+    SENTINEL_PORT={{ .Values.sentinel.port }}
+    REDIS_PORT={{ .Values.redis.port }}
+    NUM_SLAVES=$(redis-cli -p "$SENTINEL_PORT" sentinel master {{ .Values.redis.masterGroupName }} | awk '/num-slaves/{getline; print}')
+    MIN_SLAVES={{ index .Values.redis.config "min-slaves-to-write" }}
+
+    if [ "$1" = "$SENTINEL_PORT" ]; then
+        if redis-cli -p "$SENTINEL_PORT" sentinel ckquorum "$MASTER_GROUP" | grep -q NOQUORUM ; then
+            echo "ERROR: NOQUORUM. Sentinel quorum check failed, not enough sentinels found"
+            exit 1
+        fi
+    elif [ "$1" = "$REDIS_PORT" ]; then
+        if [ "$MIN_SLAVES" -gt "$NUM_SLAVES" ]; then
+            echo "Could not find enough replicating slaves. Needed $MIN_SLAVES but found $NUM_SLAVES"
+            exit 1
+        fi
+    fi
+    sh /probes/readiness.sh "$1"
+
+  readiness.sh: |
+    #!/bin/sh
+    set -eu
+    CHECK_SERVER="$(redis-cli -p "$1"{{ if .Values.auth }} -a "$AUTH"{{ end }} ping)"
+
+    if [ "$CHECK_SERVER" != "PONG" ]; then
+        echo "Server check failed with: $CHECK_SERVER"
+        exit 1
+    fi

--- a/kubernetes/zenko/charts/redis-ha/templates/redis-ha-pdb.yaml
+++ b/kubernetes/zenko/charts/redis-ha/templates/redis-ha-pdb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.enabled -}}
+{{- if .Values.podDisruptionBudget -}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -11,4 +11,4 @@ spec:
       release: {{ .Release.Name }}
       app: {{ template "redis-ha.name" . }}
 {{ toYaml .Values.podDisruptionBudget | indent 2 }}
-{{- end }}
+{{- end -}}

--- a/kubernetes/zenko/charts/redis-ha/templates/redis-ha-service.yaml
+++ b/kubernetes/zenko/charts/redis-ha/templates/redis-ha-service.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -24,4 +23,3 @@ spec:
   selector:
     release: {{ .Release.Name }}
     app: {{ template "redis-ha.name" . }}
-{{- end }}

--- a/kubernetes/zenko/charts/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/kubernetes/zenko/charts/redis-ha/templates/redis-ha-statefulset.yaml
@@ -80,7 +80,7 @@ spec:
 {{- end }}
         livenessProbe:
           exec:
-            command: [ "sh", "/probes/check-quorum.sh", "{{ .Values.redis.port }}"]
+            command: [ "sh", "/probes/readiness.sh", "{{ .Values.redis.port }}"]
           initialDelaySeconds: 15
           periodSeconds: 5
         readinessProbe:
@@ -115,7 +115,7 @@ spec:
 {{- end }}
         livenessProbe:
           exec:
-            command: [ "sh", "/probes/check-quorum.sh", "{{ .Values.sentinel.port }}"]
+            command: [ "sh", "/probes/readiness.sh", "{{ .Values.sentinel.port }}"]
           initialDelaySeconds: 15
           periodSeconds: 5
         readinessProbe:

--- a/kubernetes/zenko/charts/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/kubernetes/zenko/charts/redis-ha/templates/redis-ha-statefulset.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.enabled -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -18,9 +17,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/redis-ha-configmap.yaml") . | sha256sum }}
+        checksum/init-config: {{ include (print $.Template.BasePath "/redis-ha-configmap.yaml") . | sha256sum }}
+        checksum/probe-config: {{ include (print $.Template.BasePath "/redis-ha-healthchecks.yaml") . | sha256sum }}
       {{- if .Values.podAnnotations }}
-{{ toYaml .Values.podAnnotations . | indent 8 }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
       {{- end }}
       labels:
         release: {{ .Release.Name }}
@@ -34,29 +34,10 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       {{- end }}
-      {{- if eq .Values.podAntiAffinity "hard" }}
+    {{- with .Values.affinity }}
       affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                app: {{ template "redis-ha.name" . }}
-                release: {{ .Release.Name }}
-                component: server
-            topologyKey: kubernetes.io/hostname
-      {{- else if eq .Values.podAntiAffinity "soft" }}
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: {{ template "redis-ha.name" . }}
-                  release: {{ .Release.Name }}
-                  component: server
-              topologyKey: kubernetes.io/hostname
-      {{- end }}
+{{ tpl . $ | indent 8 }}
+    {{- end }}
       securityContext:
 {{ toYaml .Values.securityContext | indent 8 }}
       initContainers:
@@ -64,53 +45,59 @@ spec:
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
-          - bash
+        - sh
         args:
-          - /readonly-config/init.bash
-        env:
+        - /readonly-config/init.sh
 {{- if .Values.auth }}
-          - name: AUTH
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "redis-ha.fullname" . }}
-                key: auth
+        env:
+        - name: AUTH
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "redis-ha.fullname" . }}
+              key: auth
 {{- end }}
-          - name: POD_IP
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP
         volumeMounts:
-          - name: config
-            mountPath: /readonly-config
-            readOnly: true
-          - name: data
-            mountPath: /data
+        - name: config
+          mountPath: /readonly-config
+          readOnly: true
+        - name: data
+          mountPath: /data
       containers:
       - name: redis
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
-          - redis-server
+        - redis-server
         args:
-          - /data/conf/redis.conf
+        - /data/conf/redis.conf
+{{- if .Values.auth }}
+        env:
+        - name: AUTH
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "redis-ha.fullname" . }}
+              key: auth
+{{- end }}
         livenessProbe:
           exec:
-            command: ["redis-cli", "ping"]
+            command: [ "sh", "/probes/check-quorum.sh", "{{ .Values.redis.port }}"]
           initialDelaySeconds: 15
           periodSeconds: 5
         readinessProbe:
           exec:
-            command: ["redis-cli", "ping"]
+            command: ["sh", "/probes/readiness.sh", "{{ .Values.redis.port }}"]
           initialDelaySeconds: 15
           periodSeconds: 5
         resources:
 {{ toYaml .Values.redis.resources | indent 10 }}
         ports:
-          - name: redis
-            containerPort: {{ .Values.redis.port }}
+        - name: redis
+          containerPort: {{ .Values.redis.port }}
         volumeMounts:
-          - mountPath: /data
-            name: data
+        - mountPath: /data
+          name: data
+        - mountPath: /probes
+          name: probes
       - name: sentinel
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -118,14 +105,22 @@ spec:
           - redis-sentinel
         args:
           - /data/conf/sentinel.conf
+{{- if .Values.auth }}
+        env:
+        - name: AUTH
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "redis-ha.fullname" . }}
+              key: auth
+{{- end }}
         livenessProbe:
           exec:
-            command: ["redis-cli", "-p", "{{ .Values.sentinel.port }}", "ping"]
+            command: [ "sh", "/probes/check-quorum.sh", "{{ .Values.sentinel.port }}"]
           initialDelaySeconds: 15
           periodSeconds: 5
         readinessProbe:
           exec:
-            command: ["redis-cli", "-p", "{{ .Values.sentinel.port }}", "ping"]
+            command: ["sh", "/probes/readiness.sh", "{{ .Values.sentinel.port }}"]
           initialDelaySeconds: 15
           periodSeconds: 5
         resources:
@@ -134,37 +129,41 @@ spec:
           - name: sentinel
             containerPort: {{ .Values.sentinel.port }}
         volumeMounts:
-          - mountPath: /data
-            name: data
+        - mountPath: /data
+          name: data
+        - mountPath: /probes
+          name: probes
       volumes:
-        - name: config
-          configMap:
-            name: {{ template "redis-ha.fullname" . }}-configmap
+      - name: config
+        configMap:
+          name: {{ template "redis-ha.fullname" . }}-configmap
+      - name: probes
+        configMap:
+          name: {{ template "redis-ha.fullname" . }}-probes
 {{- if .Values.persistentVolume.enabled }}
   volumeClaimTemplates:
-    - metadata:
-        name: data
-        annotations:
-        {{- range $key, $value := .Values.persistentVolume.annotations }}
-          {{ $key }}: {{ $value }}
-        {{- end }}
-      spec:
-        accessModes:
-        {{- range .Values.persistentVolume.accessModes }}
-          - {{ . | quote }}
-        {{- end }}
-        resources:
-          requests:
-            storage: {{ .Values.persistentVolume.size | quote }}
-      {{- if .Values.persistentVolume.storageClass }}
-      {{- if (eq "-" .Values.persistentVolume.storageClass) }}
-        storageClassName: ""
-      {{- else }}
-        storageClassName: "{{ .Values.persistentVolume.storageClass }}"
+  - metadata:
+      name: data
+      annotations:
+      {{- range $key, $value := .Values.persistentVolume.annotations }}
+        {{ $key }}: {{ $value }}
       {{- end }}
+    spec:
+      accessModes:
+      {{- range .Values.persistentVolume.accessModes }}
+        - {{ . | quote }}
       {{- end }}
+      resources:
+        requests:
+          storage: {{ .Values.persistentVolume.size | quote }}
+    {{- if .Values.persistentVolume.storageClass }}
+    {{- if (eq "-" .Values.persistentVolume.storageClass) }}
+      storageClassName: ""
+    {{- else }}
+      storageClassName: "{{ .Values.persistentVolume.storageClass }}"
+    {{- end }}
+    {{- end }}
 {{- else }}
-        - name: data
-          emptyDir: {}
-{{- end }}
+      - name: data
+        emptyDir: {}
 {{- end }}

--- a/kubernetes/zenko/charts/redis-ha/templates/tests/test-redis-ha-configmap.yaml
+++ b/kubernetes/zenko/charts/redis-ha/templates/tests/test-redis-ha-configmap.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ template "redis-ha.fullname" . }}-configmap-test
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+  - name: check-init
+    image: koalaman/shellcheck:v0.5.0
+    args:
+    - --shell=sh
+    - /readonly-config/init.sh
+    volumeMounts:
+    - name: config
+      mountPath: /readonly-config
+      readOnly: true
+  - name: check-probes
+    image: koalaman/shellcheck:v0.5.0
+    args:
+    - --shell=sh
+    - /probes/check-quorum.sh
+    volumeMounts:
+    - name: probes
+      mountPath: /probes
+      readOnly: true
+  volumes:
+  - name: config
+    configMap:
+      name: {{ template "redis-ha.fullname" . }}-configmap
+  - name: probes
+    configMap:
+      name: {{ template "redis-ha.fullname" . }}-probes
+  restartPolicy: Never

--- a/kubernetes/zenko/charts/redis-ha/values.yaml
+++ b/kubernetes/zenko/charts/redis-ha/values.yaml
@@ -1,12 +1,9 @@
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##
-
-enabled: true
-
 image:
   repository: redis
-  tag: 4.0.11-stretch
+  tag: 4.0.11-alpine
   pullPolicy: IfNotPresent
 ## replicas number for each component
 replicas: 3
@@ -24,35 +21,49 @@ redis:
     maxmemory-policy: "volatile-lru"  # Max memory policy to use for each redis instance. Default is volatile-lru.
     # Determines if scheduled RDB backups are created. Default is false.
     # Please note that local (on-disk) RDBs will still be created when re-syncing with a new slave. The only way to prevent this is to enable diskless replication.
-    save: "60 1"
+    save: "900 1"
     # When enabled, directly sends the RDB over the wire to slaves, without using the disk as intermediate storage. Default is false.
     repl-diskless-sync: "yes"
     rdbcompression: "yes"
     rdbchecksum: "yes"
 
-  resources:
-    requests:
-      memory: 200Mi
-      cpu: 100m
+  ## Custom redis.conf files used to override default settings. If this file is
+  ## specified then the redis.config above will be ignored.
+  # customConfig: |-
+      # Define configuration here
+
+  resources: {}
+  #  requests:
+  #    memory: 200Mi
+  #    cpu: 100m
+  #  limits:
+  #    memory: 700Mi
 
 ## Sentinel specific configuration options
 sentinel:
   port: 26379
   quorum: 2
   config:
-    ## Additional sentinel conf options can be added below
-    ## For all available options see http://download.redis.io/redis-stable/sentinel.conf
+    ## Additional sentinel conf options can be added below. Only options that
+    ## are expressed in the format simialar to 'sentinel xxx mymaster xxx' will
+    ## be properly templated.
+    ## For available options see http://download.redis.io/redis-stable/sentinel.conf
     down-after-milliseconds: 10000
     ## Failover timeout value in milliseconds
     failover-timeout: 180000
     parallel-syncs: 5
 
-  resources:
-    requests:
-      memory: 200Mi
-      cpu: 100m
-    limits:
-      memory: 200Mi
+  ## Custom sentinel.conf files used to override default settings. If this file is
+  ## specified then the sentinel.config above will be ignored.
+  # customConfig: |-
+      # Define configuration here
+
+  resources: {}
+  #  requests:
+  #    memory: 200Mi
+  #    cpu: 100m
+  #  limits:
+  #    memory: 200Mi
 
 securityContext:
   runAsUser: 1000
@@ -63,13 +74,30 @@ securityContext:
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
-podAntiAffinity: soft
+affinity: |
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            app: {{ template "redis-ha.name" . }}
+            release: {{ .Release.Name }}
+        topologyKey: kubernetes.io/hostname
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app:  {{ template "redis-ha.name" . }}
+              release: {{ .Release.Name }}
+          topologyKey: failure-domain.beta.kubernetes.io/zone
 
-podDisruptionBudget:
-  maxUnavailable: 1
+podDisruptionBudget: {}
+  # maxUnavailable: 1
+  # minAvailable: 1
 
-# redisPassword:
+## Configures redis with AUTH (requirepass & masterauth conf params)
 auth: false
+# redisPassword:
 
 persistentVolume:
   enabled: true

--- a/kubernetes/zenko/values.yaml
+++ b/kubernetes/zenko/values.yaml
@@ -203,6 +203,14 @@ redis-ha:
   replicas: *nodeCount
   redis:
     masterGroupName: zenko
+    config:
+      save: "60 1"
+      stop-writes-on-bgsave-error: "yes"
+      slave-serve-stale-data: "yes"
+  sentinel:
+    config:
+      down-after-milliseconds: 5000
+      failover-timeout: 60000
 
 grafana:
   sidecar:

--- a/kubernetes/zenko/values.yaml
+++ b/kubernetes/zenko/values.yaml
@@ -200,11 +200,9 @@ zenko-quorum:
       enabled: true
 
 redis-ha:
-  enabled: true
   replicas: *nodeCount
   redis:
     masterGroupName: zenko
-  podAntiAffinity: hard
 
 grafana:
   sidecar:


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
The redis chart has a bug where the pods can easily turn into a "split-brain" after a network partition causing 2 masters. These changes should prevent the possibility of this happening by making the setup and recovery of the quorum more Kubernetes compatible.

Changes:
- Improved init script that better prevents split-brain and improves general failure recovery
- Retained Sentinel IDs
- Stable IPs via service names
- Better probes

**Which issue does this PR fix?**
ZENKO-1356

**Special notes for your reviewers**:

- I fixed this upstream first, tested thoroughly, updated based off feedback, and is now merged:
https://github.com/helm/charts/pull/10032

- Successfully upgrades from the latest Zenko 1.0.2-hotfix.1 release