### PR TITLE
documentation: ZENKO-1485 Typo in Installation Guide.

### DIFF
--- a/docs/Installation/topics/Installing_Zenko.rst
+++ b/docs/Installation/topics/Installing_Zenko.rst
@@ -36,7 +36,7 @@ For a default sizing, paste the following into kube-node.yml:
 For custom sizing, increase these base numbers.
 
 For non-MetalK8s deployments, follow your vendor or community’s instructions for
-configuring persistent voloumes at 500 Gi/node.
+configuring persistent volumes at 500 Gi/node.
 
 
 .. note::

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -1,7 +1,7 @@
 version: "0.2"
 
 branches:
-  feature/*, improvement/*, bugfix/*, w/*, q/*, hotfix/*:
+  documentation/*, feature/*, improvement/*, bugfix/*, w/*, q/*, hotfix/*:
     stage: pre-merge
 
 models:


### PR DESCRIPTION
This PR fixes a typo in the installation guide.

fixes ZENKO-1485