### PR TITLE
bf(ZENKO-1477): Fix Nightly Builds

### DIFF
--- a/eve/ci-values.yaml
+++ b/eve/ci-values.yaml
@@ -109,6 +109,7 @@ cloudserver:
   env:
     MPU_TESTING: 'yes'
     PUSH_STATS: 'false'
+    CI_CEPH: 'true'
     CI: 'true'
     S3_END_TO_END: 'true'
 

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -230,11 +230,14 @@ stages:
       - ShellCommand: *k8s_setup
       - ShellCommand:
           name: Setup latest Zenko and run end to end tests
-          command: make -e test-latest
+          command: make -e VERBOSE=1 test-latest
           workdir: build/tests
           env:
             BACKBEAT_BRANCH: development/8.0
             CLOUDSERVER_BRANCH: development/8.0
+            PYTHON_ARGS: "-k 'not ceph'"
+            HELM_NAMESPACE: '%(prop:workername)s'
+            TILLER_NAMESPACE: '%(prop:workername)s'
             <<: *global_env
       - ShellCommand: *dump_logs
       - Upload: *upload_artifacts
@@ -253,6 +256,8 @@ stages:
         env:
           BACKBEAT_BRANCH: development/8.1
           CLOUDSERVER_BRANCH: development/8.1
+          HELM_NAMESPACE: '%(prop:workername)s'
+          TILLER_NAMESPACE: '%(prop:workername)s'
           <<: *global_env
     - ShellCommand: *dump_logs
     - Upload: *upload_artifacts

--- a/eve/workers/ci_env.sh
+++ b/eve/workers/ci_env.sh
@@ -66,4 +66,9 @@ FLAGS="\
 --$CLI_FLAG ${CI_PREFIX}CLOUDSERVER_ENDPOINT=http://$ZENKO_HELM_RELEASE-cloudserver:80 \
 --$CLI_FLAG ${CI_PREFIX}CLOUDSERVER_HOST=$ZENKO_HELM_RELEASE-cloudserver"
 
+# Optional variable that only need to be passed if set
+if [ -n "$PYTHON_ARGS" ]; then
+    FLAGS="$FLAGS --$CLI_FLAG ${CI_PREFIX}PYTHON_ARGS=\"$PYTHON_ARGS\""
+fi
+
 echo "$FLAGS"

--- a/tests/zenko_tests/python_tests/run.sh
+++ b/tests/zenko_tests/python_tests/run.sh
@@ -18,5 +18,6 @@ else
         PYTEST_XDIST_ARGS="-n ${NUM_CPUS}"
 fi
 
+
 # Disable cache to run in a read-only container
 exec pytest -s -p no:cacheprovider -raR "${PYTEST_XDIST_ARGS}" "$@"


### PR DESCRIPTION
Add the CEPH_CI env var to ci-values.yaml
Propagate HELM_NAMESPACE and TILLER_NAMESPACE to test runner.
Skip Ceph tests on Zenko 1.0.x