### PR TITLE
documentation: ZENKO-1459 Typo in Operation-Architecture/Metadata_Sea…

### DIFF
--- a/docs/Operation-Architecture/Metadata_Search/Using_search_bucket.rst
+++ b/docs/Operation-Architecture/Metadata_Search/Using_search_bucket.rst
@@ -39,7 +39,7 @@ In the following examples, Zenko is accessible on endpoint
 
    ::
 
-       $ node bin/search_bucket -a <AccessKey1> -k <verySecretKey1> -b zenkobucket -q "x-amz-meta-color=blue" -h zenko.loca -p 80
+       $ node bin/search_bucket -a <AccessKey1> -k <verySecretKey1> -b zenkobucket -q "x-amz-meta-color=blue" -h zenko.local -p 80
 
 -  The search for objects tagged with “\ ``type=color``\ ”:
 


### PR DESCRIPTION
…rch/Using_search_bucket.html

This PR fixes a typo. You need it because typos are bad. 

fixes ZENKO-1459
