### PR TITLE
rf: backbeat template env var s3 to cloudserver

### DIFF
--- a/kubernetes/zenko/charts/backbeat/templates/gc/deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/gc/deployment.yaml
@@ -32,9 +32,9 @@ spec:
               value: service
             - name: EXTENSIONS_GC_AUTH_ACCOUNT
               value: service-gc
-            - name: S3_HOST
+            - name: CLOUDSERVER_HOST
               value: "{{- printf "%s-cloudserver" .Release.Name | trunc 63 | trimSuffix "-" -}}"
-            - name: S3_PORT
+            - name: CLOUDSERVER_PORT
               value: "80"
             - name: MONGODB_HOSTS
               value: "{{ template "backbeat.mongodb-hosts" . }}"

--- a/kubernetes/zenko/charts/backbeat/templates/ingestion/consumer_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/ingestion/consumer_deployment.yaml
@@ -43,9 +43,9 @@ spec:
               value: "{{ template "backbeat.redis-hosts" . }}"
             - name: REDIS_HA_NAME
               value: "{{ .Values.redis.sentinel.name }}"
-            - name: S3_HOST
+            - name: CLOUDSERVER_HOST
               value: "{{- printf "%s-cloudserver" .Release.Name | trunc 63 | trimSuffix "-" -}}"
-            - name: S3_PORT
+            - name: CLOUDSERVER_PORT
               value: "80"
           livenessProbe:
             httpGet:

--- a/kubernetes/zenko/charts/backbeat/templates/lifecycle/bucket_processor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/lifecycle/bucket_processor_deployment.yaml
@@ -32,9 +32,9 @@ spec:
               value: "{{- printf "%s-zenko-queue:9092" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: MONGODB_HOSTS
               value: "{{ template "backbeat.mongodb-hosts" . }}"
-            - name: S3_HOST
+            - name: CLOUDSERVER_HOST
               value: "{{- printf "%s-cloudserver" .Release.Name | trunc 63 | trimSuffix "-" -}}"
-            - name: S3_PORT
+            - name: CLOUDSERVER_PORT
               value: "80"
             - name: LOG_LEVEL
               value: {{ .Values.logging.level }}

--- a/kubernetes/zenko/charts/backbeat/templates/lifecycle/object_processor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/lifecycle/object_processor_deployment.yaml
@@ -32,9 +32,9 @@ spec:
               value: "{{- printf "%s-zenko-queue:9092" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: MONGODB_HOSTS
               value: "{{ template "backbeat.mongodb-hosts" . }}"
-            - name: S3_HOST
+            - name: CLOUDSERVER_HOST
               value: "{{- printf "%s-cloudserver" .Release.Name | trunc 63 | trimSuffix "-" -}}"
-            - name: S3_PORT
+            - name: CLOUDSERVER_PORT
               value: "80"
             - name: LOG_LEVEL
               value: {{ .Values.logging.level }}

--- a/kubernetes/zenko/charts/backbeat/values.yaml
+++ b/kubernetes/zenko/charts/backbeat/values.yaml
@@ -10,7 +10,7 @@ global:
 
 image:
   repository: zenko/backbeat
-  tag: 8.1.0
+  tag: 8.1.1
   pullPolicy: IfNotPresent
 
 logging:


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
Changes S3_HOST and S3_PORT env vars to use CLOUDSERVER_HOST and CLOUDSERVER_PORT respectively. 
Goes with: https://github.com/scality/backbeat/pull/620


