### PR TITLE
chore: bumped kafka-manager version

### DIFF
--- a/images/kafka-manager/Dockerfile
+++ b/images/kafka-manager/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8u131-jdk AS build
 
-ENV KAFKA_MANAGER_VERSION=1.3.3.18
+ENV KAFKA_MANAGER_VERSION=1.3.3.22
 
 RUN wget "https://github.com/yahoo/kafka-manager/archive/${KAFKA_MANAGER_VERSION}.tar.gz" \
     && tar -xzf ${KAFKA_MANAGER_VERSION}.tar.gz \


### PR DESCRIPTION
updated patch level from 1.3.3.18 to 1.3.3.22

<!--
Thank you for contributing to Zenko!

Please enter applicable information below.
-->

**What does this PR do, and why do we need it?**
kafka-manager patch 1.3.3.22 adds kafka 2.x support

**Which issue does this PR fix?**

fixes #<ISSUE>

**Special notes for your reviewers**:
