### PR TITLE
chore: bumped kafka-manager version (#532)

### DIFF
--- a/images/kafka-manager/Dockerfile
+++ b/images/kafka-manager/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8u131-jdk AS build
 
-ENV KAFKA_MANAGER_VERSION=1.3.3.18
+ENV KAFKA_MANAGER_VERSION=1.3.3.22
 
 RUN wget "https://github.com/yahoo/kafka-manager/archive/${KAFKA_MANAGER_VERSION}.tar.gz" \
     && tar -xzf ${KAFKA_MANAGER_VERSION}.tar.gz \


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
updated patch level from 1.3.3.18 to 1.3.3.22

**Which issue does this PR fix?**

fixes #<ISSUE>

**Special notes for your reviewers**:
Contribution from PR #532 by @brandonwittwer 