### PR TITLE
bf: fix crd install on upgrades

### DIFF
--- a/kubernetes/zenko/templates/cosmos-operator/crd.yaml
+++ b/kubernetes/zenko/templates/cosmos-operator/crd.yaml
@@ -3,8 +3,11 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: cosmoses.zenko.io
-  annotations:
-    "helm.sh/hook": crd-install
+  labels:
+    app: {{ template "cosmos-operator.name" . }}
+    chart: {{ template "zenko.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 spec:
   group: zenko.io
   names:


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
Zenko upgrades doesn't install the Cosmos CRD. This is a result of the `crd-install` helm hook which isn't absolutely required in our use-case since we do not template any Custom Resources along with the initial install/upgrades

**Which issue does this PR fix?**
ZENKO-1548

**Special notes for your reviewers**:
Known helm issue:
https://github.com/helm/helm/issues/4697