### PR TITLE
bf: fix developmental Chart version and requirements

### DIFF
--- a/kubernetes/zenko/Chart.yaml
+++ b/kubernetes/zenko/Chart.yaml
@@ -1,7 +1,7 @@
 name: zenko
-version: 1.1.1
-appVersion: 1.1.1
-kubeVersion: "^1.8.0-0"
+version: 1.1.0-development
+appVersion: 1.1.0-development
+kubeVersion: ">=1.11.3"
 description: Zenko is the open source multi-cloud data controller
 home: https://www.zenko.io/
 icon: https://rawgit.com/scality/Zenko/development/0.9/res/zenko.io-logo-color-cmyk.png
@@ -12,4 +12,4 @@ maintainers:
   - name: ssalaues
   - name: tmacro
 engine: gotpl
-tillerVersion: ">=2.8.0"
+tillerVersion: ">=2.9.1"


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
People installing the development version of Zenko have been confused as to exactly what version they are running (checked via `helm ls`). This helps clarify the exact version and requirements

**Which issue does this PR fix?**
ZENKO-1550

**Special notes for your reviewers**:
I've been approached by several people asking what version "1.1.1" means and what version exactly they are running when installing off development/1.1
