### PR TITLE
ZENKO-1557 initial ingestion

### DIFF
--- a/docs/Installation/topics/adding_NFS_storage.rst
+++ b/docs/Installation/topics/adding_NFS_storage.rst
@@ -71,6 +71,8 @@ and their default values.
    +------------------------------------+---------------------------------------+------------------------------+
    | ``rclone.image.pullPolicy``        | rclone image pull policy              | ``IfNotPresent``             |
    +------------------------------------+---------------------------------------+------------------------------+
+   | ``rclone.initialIngestion``        | launches a post-install ingestion job | ``true``                     |
+   +------------------------------------+---------------------------------------+------------------------------+
    | ``rclone.schedule``                | rclone CronJob schedule               | ``0 */12 * * *``             |
    +------------------------------------+---------------------------------------+------------------------------+
    | ``rclone.successfulJobsHistory``   | rclone CronJob successful job history | ``1``                        |
@@ -269,10 +271,11 @@ Installing the Chart with a Standalone Cloudserver Instance
 Manually Trigger Sync
 ---------------------
 
-This chart deploys a Kubernetes CronJob, which periodically launches
-rclone jobs to sync metadata. The job schedule can be configured with
-the ``rclone.schedule`` field in the ``values.yaml`` file. However, to
-to manually trigger the job run the following command:
+This chart deploys a Kubernetes Job at install to immediately begin a metadata
+sync. Additionally, a Kubernetes CronJob is deployed, which periodically
+launches rclone jobs to sync any additional metadata changes. The job schedule
+can be configured with the ``rclone.schedule`` field in the ``values.yaml``
+file. However, to manually trigger the job run the following command:
 
 .. code:: bash
 

--- a/kubernetes/cosmos/Chart.yaml
+++ b/kubernetes/cosmos/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Cosmos
 name: cosmos
-version: 0.1.0
+version: 0.2.0

--- a/kubernetes/cosmos/README.md
+++ b/kubernetes/cosmos/README.md
@@ -53,6 +53,7 @@ The following table lists the configurable parameters of the Cosmos chart and th
 | `rclone.image.repository` | rclone image repository | `zenko/rclone` |
 | `rclone.image.tag` | rclone image tag | `1.45` |
 | `rclone.image.pullPolicy` | rclone image pull policy | `IfNotPresent` |
+| `rclone.initialIngestion` | launches a post-install job to begin ingestion | `true` |
 | `rclone.suspend` | Enables/disables the cronjob | `false` |
 | `rclone.schedule` | rclone CronJob schedule | `*/10 * * * *` |
 | `rclone.successfulJobsHistory` | rclone CronJob successful job history | `1` |
@@ -221,10 +222,11 @@ $ helm install --name ${COSMOS_RELEASE_NAME} . -f remoteValues.yaml
 
 ## Rclone CronJob
 
-This chart deploys a Kubernetes CronJob which will periodically launch rclone jobs with the
-purpose of syncing metadata. The time at which this job runs can be configured through the
-`rclone.schedule` field in the `values.yaml` file. Additionally, you can manually create a
-jobs at will with the following command:
+This chart deploys a Kubernetes Job at install to immediately begin a metadata
+sync. Additionally, a Kubernetes CronJob is deployed, which periodically
+launches rclone jobs to sync any additional metadata changes. The job schedule
+can be configured with the ``rclone.schedule`` field in the ``values.yaml``
+file. However, to manually trigger the job run the following command:
 
 ```sh
 kubectl create job my-job-name --from=cronjob/my-release-cosmos-rclone

--- a/kubernetes/cosmos/templates/_helpers.tpl
+++ b/kubernetes/cosmos/templates/_helpers.tpl
@@ -90,6 +90,7 @@ Create storage class name
 {{- default (include "cosmos.fullname" . ) .Values.persistentVolume.storageClass -}}
 {{- end -}}
 
+{{/*
 The standard labels are frequently used in metadata.
 */ -}}
 {{- define "cosmos.labels" -}}

--- a/kubernetes/cosmos/templates/_helpers.tpl
+++ b/kubernetes/cosmos/templates/_helpers.tpl
@@ -89,3 +89,13 @@ Create storage class name
 {{- define "cosmos.storageclass.name" -}}
 {{- default (include "cosmos.fullname" . ) .Values.persistentVolume.storageClass -}}
 {{- end -}}
+
+The standard labels are frequently used in metadata.
+*/ -}}
+{{- define "cosmos.labels" -}}
+app: {{ template "cosmos.name" . }}
+chart: {{ template "cosmos.chart" . }}
+heritage: {{ .Release.Service | quote }}
+release: {{ .Release.Name | quote }}
+{{- end -}}
+

--- a/kubernetes/cosmos/templates/pfsd-deployment.yaml
+++ b/kubernetes/cosmos/templates/pfsd-deployment.yaml
@@ -3,11 +3,8 @@ kind: Deployment
 metadata:
   name: {{ template "cosmos.pfsd.fullname" . }}
   labels:
-    app: {{ template "cosmos.name" . }}
-    chart: {{ template "cosmos.chart" . }}
     component: pfsd
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+{{ include "cosmos.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.pfsd.replicaCount }}
   selector:
@@ -18,9 +15,8 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "cosmos.name" . }}
         component: pfsd
-        release: {{ .Release.Name }}
+{{ include "cosmos.labels" . | indent 8 }}
     spec:
       containers:
         - name: {{ .Chart.Name }}

--- a/kubernetes/cosmos/templates/pfsd-service.yaml
+++ b/kubernetes/cosmos/templates/pfsd-service.yaml
@@ -7,11 +7,8 @@ metadata:
   name: {{ template "cosmos.pfsd.fullname" . }}
   {{- end }}
   labels:
-    app: {{ template "cosmos.name" . }}
-    chart: {{ template "cosmos.chart" . }}
     component: pfsd
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+{{ include "cosmos.labels" . | indent 4 }}
 spec:
   type: {{ .Values.pfsd.service.type }}
   ports:

--- a/kubernetes/cosmos/templates/pv.yaml
+++ b/kubernetes/cosmos/templates/pv.yaml
@@ -4,10 +4,7 @@ kind: PersistentVolume
 metadata:
   name: {{ template "cosmos.fullname" . }}
   labels:
-    app: {{ template "cosmos.name" . }}
-    chart: {{ template "cosmos.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+{{ include "cosmos.labels" . | indent 4 }}
 spec:
   accessModes:
   - ReadWriteMany

--- a/kubernetes/cosmos/templates/pvc.yaml
+++ b/kubernetes/cosmos/templates/pvc.yaml
@@ -4,10 +4,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ template "cosmos.fullname" . }}
   labels:
-    app: {{ template "cosmos.name" . }}
-    chart: {{ template "cosmos.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+{{ include "cosmos.labels" . | indent 4 }}
 spec:
   accessModes:
 {{- range .Values.persistentVolume.accessModes }}

--- a/kubernetes/cosmos/templates/rclone-configmap.yaml
+++ b/kubernetes/cosmos/templates/rclone-configmap.yaml
@@ -3,11 +3,8 @@ kind: ConfigMap
 metadata:
   name: {{ template "cosmos.rclone.fullname" . }}
   labels:
-    app: {{ template "cosmos.name" . }}
-    chart: {{ template "cosmos.chart" . }}
     component: rclone
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+{{ include "cosmos.labels" . | indent 4 }}
 data:
   rclone.conf: |-
     [cloudserver]

--- a/kubernetes/cosmos/templates/rclone-cronjob.yaml
+++ b/kubernetes/cosmos/templates/rclone-cronjob.yaml
@@ -3,11 +3,8 @@ kind: CronJob
 metadata:
   name: {{ template "cosmos.rclone.fullname" . }}
   labels:
-    app: {{ template "cosmos.name" . }}
-    chart: {{ template "cosmos.chart" . }}
     component: rclone
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+{{ include "cosmos.labels" . | indent 4 }}
 spec:
   suspend: {{ .Values.rclone.suspend }}
   schedule: {{ .Values.rclone.schedule | quote }}
@@ -18,7 +15,13 @@ spec:
     backoffLimit: 1
     spec:
       template:
+        metadata:
+          labels:
+            component: rclone
+{{ include "cosmos.labels" . | indent 12 }}
         spec:
+{{- template "cosmos.rclone.job" . }}
+{{- define "cosmos.rclone.job" }}
           restartPolicy: OnFailure
           containers:
           - name: {{ .Chart.Name }}
@@ -56,4 +59,23 @@ spec:
               claimName: {{ default (include "cosmos.fullname" .) .Values.persistentVolume.existingClaim }}
 {{- else }}
             emptyDir: {}
+{{- end }}
+{{- end -}}
+{{- if .Values.rclone.initialIngestion }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "cosmos.rclone.fullname" . }}-initial-ingest
+  labels:
+    component: rclone
+{{ include "cosmos.labels" . | indent 4 }}
+spec:
+  template:
+    metadata:
+      labels:
+        component: rclone
+{{ include "cosmos.labels" . | indent 8 }}
+    spec:
+{{- template "cosmos.rclone.job" . }}
 {{- end }}

--- a/kubernetes/cosmos/templates/sc.yaml
+++ b/kubernetes/cosmos/templates/sc.yaml
@@ -4,10 +4,7 @@ kind: StorageClass
 metadata:
   name: {{ template "cosmos.fullname" . }}
   labels:
-    app: {{ template "cosmos.name" . }}
-    chart: {{ template "cosmos.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+{{ include "cosmos.labels" . | indent 4 }}
 provisioner: kubernetes.io/no-provisioner
 reclaimPolicy: Retain
 volumeBindingMode: WaitForFirstConsumer

--- a/kubernetes/cosmos/templates/secrets.yaml
+++ b/kubernetes/cosmos/templates/secrets.yaml
@@ -4,10 +4,7 @@ kind: Secret
 metadata:
   name: {{ template "cosmos.rclone.fullname" . }}
   labels:
-    app: {{ template "cosmos.name" . }}
-    chart: {{ template "cosmos.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+{{ include "cosmos.labels" . | indent 4 }}
 type: Opaque
 data:
   accessKey: {{ .Values.rclone.remote.accessKey | b64enc }}

--- a/kubernetes/cosmos/values.yaml
+++ b/kubernetes/cosmos/values.yaml
@@ -40,6 +40,7 @@ rclone:
     tag: 1.45
     pullPolicy: IfNotPresent
 
+  initialIngestion: true
   suspend: false
   schedule: "0 */12 * * *"
   successfulJobsHistory: 1


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
Starts ingestion job by default immediately after install but can be disabled at install as well. Avoids code duplication by turning the Job spec into a template that is reused.

**Which issue does this PR fix?**
ZENKO-1557

**Special notes for your reviewers**:
Additional commit updates the other yaml files to use a common labels template