### PR TITLE
improvement: ZENKO-1562 add HTML date

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,9 +30,9 @@ copyright = '2019, Scality, Inc'
 author = 'Scality Technical Publications'
 
 # The short X.Y version
-version = '1.0'
+version = '1.1'
 # The full version, including alpha/beta/rc tags
-release = '1.0'
+release = '1.1'
 
 
 # -- General configuration ---------------------------------------------------
@@ -137,6 +137,8 @@ html_favicon = '_static/favicon.ico'
 # default: ``['localtoc.html', 'relations.html', 'sourcelink.html',
 # 'searchbox.html']``.
 #
+
+html_last_updated_fmt = '%B %d, %Y'
 
 html_sidebars = {
      '**': ['globaltoc.html', 'searchbox.html'],


### PR DESCRIPTION
This PR partially fixes TP20-31, by introducing a field at the HTML output page footer that states "Last updated on: {{ date filled in on build }} 

fixes #ZENKO-1562

Do not clear TP20-31. This is a partial resolution. 