### PR TITLE
feature: ZENKO-1383 extend lifecycle transition tests

### DIFF
--- a/eve/ci-values.yaml
+++ b/eve/ci-values.yaml
@@ -83,6 +83,9 @@ zenko-queue:
     - name: backbeat-replication-failed
       partitions: 1
       replicationFactor: 1
+    - name: backbeat-data-mover
+      partitions: 1
+      replicationFactor: 1
     - name: backbeat-sanitycheck
       partitions: 1
       replicationFactor: 1
@@ -125,7 +128,7 @@ backbeat:
     replicaFactor: 2
   lifecycle:
     conductor:
-      cronRule: "* * * * *"
+      cronRule: "*/5 * * * * *"
 
 grafana:
   persistentVolume:

--- a/tests/zenko_tests/docker-entrypoint.sh
+++ b/tests/zenko_tests/docker-entrypoint.sh
@@ -24,6 +24,6 @@ fi
 
 # Run the tests
 enter_and_run python_tests "./run.sh $PYTHON_ARGS"
-enter_and_run node_tests "npm_chain.sh test_crr test_api test_crr_pause_resume test_location_quota test_bucket_get_v2 test_ingestion_oob_s3c"
+enter_and_run node_tests "npm_chain.sh test_crr test_api test_crr_pause_resume test_lifecycle test_location_quota test_bucket_get_v2 test_ingestion_oob_s3c"
 
 exit "$EXIT_STATUS"

--- a/tests/zenko_tests/node_tests/backbeat/LifecycleUtility.js
+++ b/tests/zenko_tests/node_tests/backbeat/LifecycleUtility.js
@@ -3,9 +3,8 @@ const async = require('async');
 const ReplicationUtility = require('./ReplicationUtility');
 
 class LifecycleUtility extends ReplicationUtility {
-    constructor(client) {
-        super(client);
-        this.client = client;
+    constructor(s3, azure, gcpStorage) {
+        super(s3, azure, gcpStorage);
     }
 
     setBucket(bucket) {
@@ -23,32 +22,102 @@ class LifecycleUtility extends ReplicationUtility {
         return this;
     }
 
+    setSourceLocation(sourceLocation) {
+        this.sourceLocation = sourceLocation;
+        return this;
+    }
+
     setDestinationLocation(destinationLocation) {
         this.destinationLocation = destinationLocation;
         return this;
     }
 
-    putObject(data, cb) {
-        this.client.putObject({
+    setLocationType(locType) {
+        this.locationType = locType;
+        return this;
+    }
+
+    createBucket(cb) {
+        this.s3.createBucket({
             Bucket: this.bucket,
-            Key: this.key,
-            Body: data,
+            CreateBucketConfiguration: {
+                LocationConstraint: this.sourceLocation,
+            },
         }, cb);
+    }
+
+    createVersionedBucket(cb) {
+        return async.series([
+            next => this.createBucket(next),
+            next => this.s3.putBucketVersioning({
+                Bucket: this.bucket,
+                VersioningConfiguration: {
+                    Status: 'Enabled',
+                }
+            }, next),
+        ], err => cb(err));
+    }
+
+    putObject(data, cb) {
+        super.putObject(this.bucket, this.key, data, cb);
     }
 
     getObject(cb) {
-        this.client.getObject({
-            Bucket: this.bucket,
-            Key: this.key,
-        }, cb);
+        super.getObject(this.bucket, this.key, cb);
+    }
+
+    putMPU(howManyParts, cb) {
+        super.completeMPUAWS(this.bucket, this.key, howManyParts, cb);
+    }
+
+    getObjectDataFromLocation(cb) {
+        switch (this.locationType) {
+        case 'AWS':
+            super.getObject(this.bucket, this.key, (err, data) => {
+                if (err) {
+                    return cb(err);
+                }
+                return cb(null, data.Body);
+            });
+            break ;
+        case 'GCP':
+            super.download(this.bucket, this.key, (err, data) => {
+                if (err) {
+                    return cb(err);
+                }
+                // GCP returns [] for an empty object for some reason
+                if (Array.isArray(data) && data.length === 0) {
+                    return cb(null, new Buffer(0));
+                }
+                return cb(null, data);
+            });
+            break ;
+        case 'Azure':
+            super.getBlob(this.bucket, this.key, cb);
+            break ;
+        default:
+            cb(new Error(`bad destination location type ${this.locationType}`));
+        }
     }
 
     clearBucket(cb) {
-        this.deleteAllVersions(this.bucket, this.keyPrefix, cb);
+        switch (this.locationType) {
+        case 'AWS':
+            this.deleteAllVersions(this.bucket, this.keyPrefix, cb);
+            break ;
+        case 'GCP':
+            this.deleteAllFiles(this.bucket, this.keyPrefix, cb);
+            break ;
+        case 'Azure':
+            super.deleteAllBlobs(this.bucket, this.keyPrefix, cb);
+            break ;
+        default:
+            cb(new Error(`bad destination location type ${this.locationType}`));
+        }
     }
 
     putBucketLifecycleConfiguration(transitionDate, cb) {
-        this.client.putBucketLifecycleConfiguration({
+        this.s3.putBucketLifecycleConfiguration({
             Bucket: this.bucket,
             LifecycleConfiguration: {
                 Rules: [{
@@ -68,7 +137,7 @@ class LifecycleUtility extends ReplicationUtility {
     waitUntilTransitioned(cb) {
         let shouldContinue;
         return async.doWhilst(next =>
-            this.client.headObject({
+            this.s3.headObject({
                 Bucket: this.bucket,
                 Key: this.key,
             }, (err, data) => {

--- a/tests/zenko_tests/node_tests/backbeat/ReplicationUtility.js
+++ b/tests/zenko_tests/node_tests/backbeat/ReplicationUtility.js
@@ -216,7 +216,7 @@ class ReplicationUtility {
                 return next();
             }),
             next =>
-                async.mapLimit(partNumbers, 10, (partNumber, callback) => {
+                async.mapLimit(partNumbers, 2, (partNumber, callback) => {
                     const uploadPartParams = {
                         Bucket: bucketName,
                         Key: objectName,
@@ -307,7 +307,7 @@ class ReplicationUtility {
                 return next();
             }),
             next =>
-                async.mapLimit(partNumbers, 10, (partNumber, callback) => {
+                async.mapLimit(partNumbers, 2, (partNumber, callback) => {
                     const uploadPartCopyParams = {
                         Bucket: bucketName,
                         CopySource: copySource,

--- a/tests/zenko_tests/node_tests/backbeat/tests/lifecycle/transition.js
+++ b/tests/zenko_tests/node_tests/backbeat/tests/lifecycle/transition.js
@@ -3,69 +3,154 @@ const uuid = require('uuid/v4');
 const { series } = require('async');
 
 const { scalityS3Client, awsS3Client } = require('../../../s3SDK');
+const gcpStorage = require('../../gcpStorage');
+const sharedBlobSvc = require('../../azureSDK');
 const LifecycleUtility = require('../../LifecycleUtility');
 
 const LIFECYCLE_TIMEOUT = 300000;
-const srcBucket = `${uuid()}-bucket`;
-const keyPrefix = `${uuid()}-key-prefix`;
-const key = `${keyPrefix}/object`;
+const srcBucket = `transition-bucket-${uuid()}`;
+const keyPrefix = uuid();
 
 const cloudServer = new LifecycleUtility(scalityS3Client)
-    .setBucket(srcBucket)
-    .setKeyPrefix(keyPrefix)
-    .setKey(key)
-    .setDestinationLocation(process.env.AWS_BACKEND_DESTINATION_LOCATION);
+      .setBucket(srcBucket)
+      .setKeyPrefix(keyPrefix);
 
-const s3 = new LifecycleUtility(awsS3Client)
-    .setBucket(process.env.AWS_CRR_BUCKET_NAME)
-    .setKeyPrefix(keyPrefix)
-    .setKey(`${srcBucket}/${key}`);
+const cloud = new LifecycleUtility(awsS3Client, sharedBlobSvc, gcpStorage)
+      .setKeyPrefix(keyPrefix);
 
 function compareTransitionedData(cb) {
     return series([
         next => cloudServer.getObject(next),
         next => cloudServer.putBucketLifecycleConfiguration(new Date(), next),
         next => cloudServer.waitUntilTransitioned(next),
-        next => s3.getObject(next),
+        next => cloud.getObjectDataFromLocation(next),
+        next => cloudServer.getObject(next),
     ], (err, data) => {
         if (err) {
             return cb(err);
         }
-        cloudServer._compareObjectBody(data[0].Body, data[3].Body);
+        // check data stored on the target cloud
+        cloudServer._compareObjectBody(data[0].Body, data[3]);
+        // check that object is still readable from Zenko
+        cloudServer._compareObjectBody(data[0].Body, data[4].Body);
         return cb();
     });
 };
 
-describe('transition to AWS backend', function() {
-    this.timeout(LIFECYCLE_TIMEOUT);
+const locationParams = {
+    LocalStorage: {
+        name: 'us-east-1',
+        supportsVersioning: true,
+    },
+    AWS: {
+        name: process.env.AWS_BACKEND_DESTINATION_LOCATION,
+        bucket: process.env.AWS_CRR_BUCKET_NAME,
+        supportsVersioning: true,
+    },
+    GCP: {
+        name: process.env.GCP_BACKEND_DESTINATION_LOCATION,
+        bucket: process.env.GCP_CRR_BUCKET_NAME,
+        supportsVersioning: false,
+    },
+    Azure: {
+        name: process.env.AZURE_BACKEND_DESTINATION_LOCATION,
+        bucket: process.env.AZURE_CRR_BUCKET_NAME,
+        supportsVersioning: false,
+    },
+};
 
-    afterEach(done => series([
-        next => cloudServer.deleteVersionedBucket(srcBucket, next),
-        next => s3.clearBucket(next),
-    ], done));
+const testsToRun = [{
+    from: 'LocalStorage',
+    to: 'AWS',
+}, {
+    from: 'LocalStorage',
+    to: 'GCP',
+}, {
+    from: 'LocalStorage',
+    to: 'Azure',
+}, {
+    from: 'AWS',
+    to: 'GCP',
+}, {
+    from: 'GCP',
+    to: 'Azure',
+}];
 
-    describe('without versioning', () => {
-        beforeEach(done => cloudServer.createBucket(srcBucket, done));
+testsToRun.forEach(test => {
+    describe(`transition from ${test.from} to ${test.to}`, function() {
+        this.timeout(LIFECYCLE_TIMEOUT);
+        const fromLoc = locationParams[test.from];
+        const toLoc = locationParams[test.to];
 
-        it('should transition an object', done => series([
-            next => cloudServer.putObject(Buffer.alloc(1), next),
-            next => compareTransitionedData(next),
+        before(() => {
+            cloudServer.setSourceLocation(fromLoc.name);
+            cloudServer.setDestinationLocation(toLoc.name);
+            cloud.setLocationType(test.to);
+            cloud.setBucket(toLoc.bucket);
+        });
+
+        afterEach(done => series([
+            next => cloudServer.deleteVersionedBucket(srcBucket, next),
+            next => cloud.clearBucket(next),
         ], done));
-    });
 
-    describe('with versioning', () => {
-        beforeEach(done => cloudServer.createVersionedBucket(srcBucket, done));
+        describe('without versioning', () => {
+            beforeEach(done => cloudServer.createBucket(done));
 
-        it('should transition a single master version', done => series([
-            next => cloudServer.putObject(Buffer.alloc(1), next),
-            next => compareTransitionedData(next),
-        ], done));
+            it('should transition an object', done => {
+                const key = `${keyPrefix}-from-${test.from}-to-${test.to}-` +
+                      'nover-object';
+                cloudServer.setKey(key);
+                cloud.setKey(`${srcBucket}/${key}`);
+                series([
+                    next => cloudServer.putObject(Buffer.from(key), next),
+                    next => compareTransitionedData(next),
+                ], done);
+            });
 
-        it('should transition the master version', done => series([
-            next => cloudServer.putObject(Buffer.alloc(0), next),
-            next => cloudServer.putObject(Buffer.alloc(1), next),
-            next => cloudServer.putObject(Buffer.alloc(2), next),
-            next => compareTransitionedData(next),
-        ], done));
+            it('should transition an MPU object with 10 parts', done => {
+                const key = `${keyPrefix}-from-${test.from}-to-${test.to}-` +
+                      'nover-mpu';
+                cloudServer.setKey(key);
+                cloud.setKey(`${srcBucket}/${key}`);
+                series([
+                    next => cloudServer.putMPU(10, next),
+                    next => compareTransitionedData(next),
+                ], done);
+            });
+        });
+
+        if (fromLoc.supportsVersioning) {
+            describe('with versioning', () => {
+                beforeEach(done => cloudServer.createVersionedBucket(done));
+
+                it('should transition a single master version', done => {
+                    const key = `${keyPrefix}-from-${test.from}-to-` +
+                          `${test.to}-ver-single-master`;
+                    cloudServer.setKey(key);
+                    cloud.setKey(`${srcBucket}/${key}`);
+                    series([
+                        next => cloudServer.putObject(Buffer.from(key), next),
+                        next => compareTransitionedData(next),
+                    ], done);
+                });
+
+                it('should transition the master version', done => {
+                    const key = `${keyPrefix}-from-${test.from}-to-` +
+                          `${test.to}-ver-master`;
+                    cloudServer.setKey(key);
+                    cloud.setKey(`${srcBucket}/${key}`);
+                    series([
+                        next => cloudServer.putObject(
+                            Buffer.from(`${key}-1`), next),
+                        next => cloudServer.putObject(
+                            Buffer.from(`${key}-2`), next),
+                        next => cloudServer.putObject(
+                            Buffer.from(`${key}-3`), next),
+                        next => compareTransitionedData(next),
+                    ], done);
+                });
+            });
+        }
     });
 });


### PR DESCRIPTION
**What does this PR do, and why do we need it?**

feature: ZENKO-1383 extend lifecycle transition tests
    
- test transition from/to all major clouds AWS, GCP, Azure

- add an MPU transition for each test


**Which issue does this PR fix?**

ZENKO-1383

**Special notes for your reviewers**:

Thank you :heart: 