### PR TITLE
bf(ZENKO-1581): Switch channel to #sf-devsop

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -240,7 +240,7 @@ stages:
       - Git: *git_pull
       - SetProperty:
           property: report_build_name
-          value: 'Nightly Build'
+          value: 'Nightly-Build'
       - SetPropertyFromCommand: *notify-build-start
       - TriggerStages:
           name: Trigger latest builds
@@ -299,7 +299,7 @@ stages:
     - ShellCommand: *k8s_setup
     - SetProperty:
         property: report_build_name
-        value: 'Nightly Cosbench'
+        value: 'Nightly-Cosbench'
     - SetPropertyFromCommand: *notify-build-start
     - ShellCommand:
         name: Setup and run benchmarks
@@ -326,7 +326,7 @@ stages:
     - ShellCommand: *k8s_setup
     - SetProperty:
         property: report_build_name
-        value: 'Nightly Listing Fuzzer'
+        value: 'Nightly-Listing-Fuzzer'
     - SetPropertyFromCommand: *notify-build-start
     - ShellCommand:
         name: Setup Zenko and run versioned bucket test

--- a/tests/report.py
+++ b/tests/report.py
@@ -33,8 +33,8 @@ API_FRAGMENT = '/api/v%d/%s'
 EVE_URL = EVE_BASE_URL%BUILD_REPO
 
 SLACK_API_BASE = 'https://slack.com/api/%s'
-SLACK_CHAN = 'CFYM0GWJ0' # Dev channel
-# SLACK_CHAN = 'CFCCE4X7F' # sf-devops
+# SLACK_CHAN = 'CFYM0GWJ0' # Dev channel
+SLACK_CHAN = 'CFCCE4X7F' # sf-devops
 
 def get_args():
     parser = argparse.ArgumentParser(
@@ -103,7 +103,8 @@ class EveClient:
         try:
             res = session.open(req)
         except urllib2.HTTPError as excp:
-            return {}
+            print str(excp)
+            return {'error':True}
         if is_json:
             return json.loads(res.read())
         return res.read()
@@ -326,7 +327,10 @@ if __name__ == '__main__':
     eve = EveClient(EVE_TOKEN)
     if args.trigger:
         print 'Triggering monitor build...'
-        eve.trigger_build()
+        if eve.trigger_build() is not None:
+            print 'Monitor build started successfully.'
+        else:
+            print 'Monitor build failed to start!'
     elif args.report:
         print 'Waiting for build %s to finish...'%BUILD_NUMBER
         status = eve.check_status(buildnum=BUILD_NUMBER)


### PR DESCRIPTION
- Switch the channel used for posting messages to `#sf-devops`
- Work around RELENG-2863 by removing spaces from nightly build titles
- Improve logging