### PR TITLE
bf(ZENKO-1530): Fix flakey object monitor test

### DIFF
--- a/tests/zenko_tests/node_tests/backbeat/tests/api/objectMonitor.js
+++ b/tests/zenko_tests/node_tests/backbeat/tests/api/objectMonitor.js
@@ -17,7 +17,7 @@ const hex = crypto.createHash('md5')
     .digest('hex');
 const keyPrefix = `${srcBucket}/${hex}`;
 const key = `${keyPrefix}/object-to-replicate-${Date.now()}`;
-const REPLICATION_TIMEOUT = 300000;
+const REPLICATION_TIMEOUT = 600000;
 
 function getAndCheckResponse(path, expectedBody, cb) {
     let shouldContinue = false;


### PR DESCRIPTION
Bump the timeout waiting for replication. As E2E test now run on a single cluster Zenko can slow down when multiple builds are running and cause this to occasionally time out.