### PR TITLE
feat: bump zenko to 1.1.0-alpha.0

### DIFF
--- a/eve/ci-values.yaml
+++ b/eve/ci-values.yaml
@@ -119,6 +119,8 @@ cloudserver:
     S3_END_TO_END: 'true'
 
 backbeat:
+  image:
+    pullPolicy: Always
   replication:
     replicaFactor: 2
   lifecycle:

--- a/kubernetes/cosmos/Chart.yaml
+++ b/kubernetes/cosmos/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Cosmos
 name: cosmos
-version: 0.3.0
+version: 1.1.0-alpha.0

--- a/kubernetes/zenko/Chart.yaml
+++ b/kubernetes/zenko/Chart.yaml
@@ -1,6 +1,6 @@
 name: zenko
-version: 1.1.0-development
-appVersion: 1.1.0-development
+version: 1.1.0-alpha.0
+appVersion: 1.1.0-alpha.0
 kubeVersion: ">=1.11.3"
 description: Zenko is the open source multi-cloud data controller
 home: https://www.zenko.io/

--- a/kubernetes/zenko/charts/backbeat/Chart.yaml
+++ b/kubernetes/zenko/charts/backbeat/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "8.1.0"
+appVersion: "8.1.4"
 description: A Helm chart for Zenko Backbeat
 name: backbeat
-version: 1.1.0
+version: 1.1.0-alpha.0

--- a/kubernetes/zenko/charts/backbeat/values.yaml
+++ b/kubernetes/zenko/charts/backbeat/values.yaml
@@ -10,7 +10,7 @@ global:
 
 image:
   repository: zenko/backbeat
-  tag: 8.1.1
+  tag: 8.1.4
   pullPolicy: IfNotPresent
 
 logging:

--- a/kubernetes/zenko/charts/cloudserver/Chart.yaml
+++ b/kubernetes/zenko/charts/cloudserver/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "8.1.2"
+appVersion: "8.1.7"
 description: A Helm chart for Kubernetes
 name: cloudserver
-version: 1.1.0
+version: 1.1.0-alpha.0

--- a/kubernetes/zenko/charts/cloudserver/values.yaml
+++ b/kubernetes/zenko/charts/cloudserver/values.yaml
@@ -97,7 +97,7 @@ replicaFactor: 1
 
 image:
   repository: zenko/cloudserver
-  tag: 8.1.4
+  tag: 8.1.7
   pullPolicy: IfNotPresent
 
 proxy:

--- a/kubernetes/zenko/charts/s3-data/Chart.yaml
+++ b/kubernetes/zenko/charts/s3-data/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "8.1.5"
+appVersion: "8.1.7"
 description: A Helm chart for Kubernetes
 name: s3-data
-version: 1.1.0
+version: 1.1.0-alpha.0


### PR DESCRIPTION
<!--
Thank you for contributing to Zenko!

Please enter applicable information below.
-->

**What does this PR do, and why do we need it?**

Bumps Cloudserver and Backbeat images for Zenko 1.1.0-alpha.0
