### PR TITLE
chore: bump kafka-manager version

### DIFF
--- a/images/kafka-manager/Dockerfile
+++ b/images/kafka-manager/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8u131-jdk AS build
 
-ENV KAFKA_MANAGER_VERSION=1.3.3.22
+ENV KAFKA_MANAGER_VERSION=1.3.3.23
 
 RUN wget "https://github.com/yahoo/kafka-manager/archive/${KAFKA_MANAGER_VERSION}.tar.gz" \
     && tar -xzf ${KAFKA_MANAGER_VERSION}.tar.gz \


### PR DESCRIPTION
Signed-off-by: Fabrizio Fortino <fabrizio.fortino@gmail.com>

**What does this PR do, and why do we need it?**
bump kafka-manager image to version 1.3.3.23

**Which issue does this PR fix?**
Adds support for kafka 2.1.1, fixes several issues

fixes #<ISSUE>

**Special notes for your reviewers**:
