### PR TITLE
ci: fix namespace overlap ZENKO-1600

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -23,7 +23,7 @@ models:
       haltOnFailure: true
   - ShellCommand: &k8s_cleanup
       name: Cleanup
-      command: kubectl delete namespace '%(prop:workername)s'
+      command: kubectl delete namespace '%(prop:workername)s' --wait
       alwaysRun: true
       sigtermTime: 1200
       env:

--- a/eve/workers/zenko.yaml
+++ b/eve/workers/zenko.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: aggressor
-    image: zenko/zenko-releng:0.0.8
+    image: zenko/zenko-releng:0.0.10
     imagePullPolicy: Always
     resources:
       requests:


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
Fixes a CI issue where the namespace from a previous build is still being cleared out and the next build fails because it is trying to allocate the resource during the cleanup.

**Which issue does this PR fix?**

fixes ZENKO-1600

**Special notes for your reviewers**:
