### PR TITLE
Documentation/zenko 1599 remove glacier references

### DIFF
--- a/docs/docsource/Operation-Architecture/Services/lifecycle_management/lifecycle_expiration_policies.rst
+++ b/docs/docsource/Operation-Architecture/Services/lifecycle_management/lifecycle_expiration_policies.rst
@@ -1,40 +1,40 @@
 Lifecycle Expiration Policies
 =============================
 
-Cloud users can apply lifecycle expiration rules (specified in Amazon’s
-`AWS S3 API <https://docs.aws.amazon.com/AmazonS3/latest/API/Welcome.html>`__)
+Cloud users can apply lifecycle expiration or transition rules (specified in 
+Amazon’s `AWS S3 API <https://docs.aws.amazon.com/AmazonS3/latest/API/Welcome.html>`__)
 to buckets managed through Zenko. These rules are triggered after a defined
-time has passed since the object’s creation.
+time has passed since the object’s last modification. 
 
-Zenko supports expiration of versioned or non-versioned objects, when a
-defined number of days has passed since those objects’ creation. This enables
-automatic deletion of older versions of versioned objects to reclaim storage
-space. Zenko also supports triggering expiration of current versions on a date
-from which a rule applies. This is currently feasible using the S3 API, but not
-with Orbit. Using Zenko from the command line or from Orbit, you can expire the
-current version of an object with a separate rule. For versioned buckets,
+Zenko supports expiration or transition of versioned or non-versioned objects,
+when a defined number of days has passed since those objects’ creation. This 
+enables automatic deletion of older versions of versioned objects to reclaim
+storage space. Zenko also supports triggering expiration or transition of 
+the latest version on a date. This is currently feasible from the S3 API, but not
+using Orbit. Using Zenko from the command line or from Orbit, you can expire
+the current version of an object with a separate rule. For versioned buckets,
 lifecycle adds a delete marker automatically when a rule expiring a current
 version is triggered, such as when a user deletes an object without first
 specifying a version ID.
 
 Bucket lifecycle characteristics inhere to each bucket. Zenko’s lifecycle
 management feature enforces, but does not set these characteristics. When
-lifecycle expiration is enabled, the host cloud enforces buckets’ lifecycle
-rules. If CRR operation is enabled, Zenko replicates the expiration rules to
-all backup clouds.
+lifecycle management is enabled, the host cloud enforces buckets’ lifecycle
+rules. 
 
 To configure bucket lifecycle, follow the AWS S3 Lifecycle Configuration
 Element syntax described in
-`https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html <https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html>`__.
+`https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html
+<https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html>`__.
 
 .. note::
 
    Lifecycle management rules conform to the S3 lifecycle management
-   syntax for expiration policies described at
+   syntax for expiration and transition policies described at
    https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html.
-   *Lifecycle actions are currently constrained to expiration actions,
-   and not transition actions.* Files that exceed a preconfigured
-   temporal threshold (for example, 90 days) are “expired” and deleted
-   from the bucket on which they are stored. At present, files
-   exceeding a preset date *cannot be transitioned* to STANDARD\_IA or
-   GLACIER storage classes.
+   Files that exceed a preconfigured temporal threshold (for example, 90 days) 
+   can be transitioned (moved) or expired (deleted) from the bucket on which
+   they are stored. 
+
+   Zenko does not support lifecycle transitions to Amazon's STANDARD\_IA or
+   GLACIER storage classes, only to other storage locations. 

--- a/docs/docsource/Reference/bucket_lifecycle_operations/get_bucket_lifecycle.rst
+++ b/docs/docsource/Reference/bucket_lifecycle_operations/get_bucket_lifecycle.rst
@@ -188,7 +188,7 @@ elements.
    |                                   |                                   |
    |                                   | **Type:** String                  |
    |                                   |                                   |
-   |                                   | **Valid values:** true or false   |
+   |                                   | **Valid Values:** true or false   |
    |                                   |                                   |
    |                                   | **Ancestor:** Expiration          |
    +-----------------------------------+-----------------------------------+
@@ -264,20 +264,34 @@ elements.
    |                                   |                                   |
    |                                   | **Ancestor:** Rule                |
    |                                   |                                   |
-   |                                   | **Valid values:** Enabled or      |
+   |                                   | **Valid Values:** Enabled or      |
    |                                   | Disabled                          |
    +-----------------------------------+-----------------------------------+
    | StorageClass                      | Specifies the storage class to    |
    |                                   | which you want to transition the  |
    |                                   | object.                           |
+   |				       | 				   |
+   |				       | Zenko reinterprets this S3 call   |
+   |				       | not as a service quality   	   |
+   |				       | directive, but as a service 	   |
+   |                          	       | locator. In other words, where    |
+   |                          	       | Amazon S3 uses this directive to  |
+   |				       | define a location by quality of   |
+   |                          	       | service (e.g., STANDARD or   	   |
+   |				       | GLACIER), Zenko uses it to direct |
+   |				       | replication to a location.   	   |
+   |                          	       | The quality of service is 	   |
+   |				       | determined and the replication    |
+   |				       | destination is configured by the  |
+   |				       | user.                             |
    |                                   |                                   |
    |                                   | **Type:** String                  |
    |                                   |                                   |
    |                                   | **Ancestor:** Transition and      |
    |                                   | NoncurrentVersionTransition       |
    |                                   |                                   |
-   |                                   | **Valid values:** STANDARD,       |
-   |                                   | STANDARD_IA, or GLACIER           |
+   |                                   | **Valid Values:** Any defined 	   |
+   |				       | destination name      		   |
    +-----------------------------------+-----------------------------------+
    | Tag                               | Container listing the tag key and |
    |                                   | value used to filter objects to   |
@@ -322,14 +336,14 @@ elements.
 .. tabularcolumns:: X{0.28\textwidth}X{0.27\textwidth}X{0.20\textwidth}X{0.20\textwidth}
 .. table::
 
-   +-----------------+-----------------+-----------------+-----------------+
-   | Error Code      | Description     | HTTP Status     | SOAP Fault      |
-   |                 |                 | Code            | Code Prefix     |
-   +=================+=================+=================+=================+
-   | NoSuchLifecycle | The lifecycle   | 404 Not Found   | Client          |
-   | Configuration   | configuration   |                 |                 |
-   |                 | does not exist. |                 |                 |
-   +-----------------+-----------------+-----------------+-----------------+
+   +------------------+-----------------+-----------------+-----------------+
+   | Error Code       | Description     | HTTP Status     | SOAP Fault      |
+   |                  |                 | Code            | Code Prefix     |
+   +==================+=================+=================+=================+
+   | NoSuchLifecycle\ | The lifecycle   | 404 Not Found   | Client          |
+   | Configuration    | configuration   |                 |                 |
+   |                  | does not exist. |                 |                 |
+   +------------------+-----------------+-----------------+-----------------+
 
 **Examples**
 
@@ -350,9 +364,9 @@ configurations from a specified bucket.
 The following is a sample response that shows a prefix of “projectdocs/”
 filter and multiple lifecycle configurations for these objects.
 
--  Transition to STANDARD_IA after 30 days
+-  Transition to wasabi_cloud after 30 days
 
--  Transition to GLACIER after 365 days
+-  Transition to azure_cold_storage after 365 days
 
 -  Expire after 3,650 days
 
@@ -377,11 +391,11 @@ filter and multiple lifecycle configurations for these objects.
       <Status>Enabled</Status>
       <Transition>
         <Days>30</Days>
-        <StorageClass>STANDARD_IA</StorageClass>
+        <StorageClass>wasabi_cloud</StorageClass>
       </Transition>
       <Transition>
         <Days>365</Days>
-        <StorageClass>GLACIER</StorageClass>
+        <StorageClass>azure_cold_storage</StorageClass>
       </Transition>
       <Expiration>
         <Days>3650</Days>

--- a/docs/docsource/Reference/bucket_lifecycle_operations/put_bucket_lifecycle.rst
+++ b/docs/docsource/Reference/bucket_lifecycle_operations/put_bucket_lifecycle.rst
@@ -305,7 +305,7 @@ configuration:
    |                       |                       |                       |
    |                       | **Type:** String      |                       |
    |                       |                       |                       |
-   |                       | **Valid values:**     |                       |
+   |                       | **Valid Values:**     |                       |
    |                       | true or false         |                       |
    |                       |                       |                       |
    |                       | **Ancestor:**         |                       |
@@ -360,13 +360,11 @@ configuration:
    | Transition            | transition rule that  | action is present in  |
    |                       | describes when        | the Rule.             |
    |                       | noncurrent objects    |                       |
-   |                       | transition to the     |                       |
-   |                       | STANDARD_IA or        |                       |
-   |                       | GLACIER storage       |                       |
-   |                       | class.                |                       |
+   |                       | transition to another |			   |
+   |			   | storage class 	   |			   |
+   |			   | (location).           |                       |
    |                       |                       |                       |
-   |                       | You set this          |                       |
-   |                       | lifecycle             |                       |
+   |                       | Set this lifecycle    |                       |
    |                       | configuration action  |                       |
    |                       | on a bucket that has  |                       |
    |                       | versioning enabled    |                       |
@@ -424,25 +422,24 @@ configuration:
    |                       |                       |                       |
    |                       | **Ancestor:** Rule    |                       |
    |                       |                       |                       |
-   |                       | **Valid values:**     |                       |
+   |                       | **Valid Values:**     |                       |
    |                       | Enabled or Disabled.  |                       |
    +-----------------------+-----------------------+-----------------------+
    | StorageClass          | Specifies the storage | Yes                   |
-   |                       | class to which you    |                       |
-   |                       | want the object to    | This element is       |
-   |                       | transition.           | required only if you  |
-   |                       |                       | specify one or both   |
-   |                       | **Type:** String      | its ancestors.        |
+   |                       | class (Zenko  	   | 			   |
+   |			   | location) to which	   | This element is       |
+   |			   | you want the object   | required only if you  |
+   |                       | to transition.        | specify one or both   |
+   |                       |                       | its ancestors.        |
+   |                       | **Type:** String      | 	 		   |
    |                       |                       |                       |
    |                       | **Ancestor:**         |                       |
    |                       | Transition and        |                       |
    |                       | NoncurrentVersion\    |                       |
    |                       | Transition            |                       |
    |                       |                       |                       |
-   |                       | **Valid values:**     |                       |
-   |                       | STANDARD,             |                       |
-   |                       | STANDARD_IA, or       |                       |
-   |                       | GLACIER               |                       |
+   |                       | **Valid Values:**     |                       |
+   |                       | Any defined location  |			   |
    +-----------------------+-----------------------+-----------------------+
    | Tag                   | Container for         | No                    |
    |                       | specifying a tag key  |                       |
@@ -592,7 +589,7 @@ The following lifecycle configuration specifies two rules, each with one
 action.
 
 -  The Transition action specifies objects with the “documents/” prefix
-      to transition to the GLACIER storage class 30 days after creation.
+      to transition to the wasabi_cloud storage class 30 days after creation.
 
 -  The Expiration action specifies objects with the “logs/” prefix to be
       deleted 365 days after creation.
@@ -608,7 +605,7 @@ action.
       <Status>Enabled</Status>
       <Transition>
         <Days>30</Days>
-        <StorageClass>GLACIER</StorageClass>
+        <StorageClass>wasabi_cloud</StorageClass>
       </Transition>
     </Rule>
     <Rule>
@@ -645,7 +642,7 @@ preceding lifecycle configuration to the “examplebucket” bucket.
       <Status>Enabled</Status>
       <Transition>
         <Days>30</Days>
-        <StorageClass>GLACIER</StorageClass>
+        <StorageClass>wasabi_cloud</StorageClass>
       </Transition>
     </Rule>
       <Rule>
@@ -683,7 +680,7 @@ versioning-enabled or versioning is suspended:
 
 -  The NoncurrentVersionTransition action specifies non-current versions
       of objects with the “documents/” prefix to transition to the
-      GLACIER storage class 30 days after they become non-current.
+      wasabi_cloud storage class 30 days after they become non-current.
 
 .. code::
 
@@ -706,7 +703,7 @@ versioning-enabled or versioning is suspended:
       <Status>Enabled</Status>
       <NoncurrentVersionTransition>
         <NoncurrentDays>30</NoncurrentDays>
-        <StorageClass>GLACIER</StorageClass>
+        <StorageClass>wasabi_cloud</StorageClass>
       </NoncurrentVersionTransition>
     </Rule>
   </LifeCycleConfiguration>
@@ -742,7 +739,7 @@ preceding lifecycle configuration to the \`examplebucket\` bucket.
       <Status>Enabled</Status>
       <NoncurrentVersionTransition>
         <NoncurrentDays>0</NoncurrentDays>
-        <StorageClass>GLACIER</StorageClass>
+        <StorageClass>wasabi_cloud</StorageClass>
       </NoncurrentVersionTransition>
     </Rule>
   </LifeCycleConfiguration>

--- a/docs/docsource/Reference/bucket_operations/get_bucket_replication.rst
+++ b/docs/docsource/Reference/bucket_operations/get_bucket_replication.rst
@@ -19,7 +19,7 @@ Requests
            
 **Request Parameters**
 
-The PUT Bucket operation does not use Request Parameters.
+The GET Bucket operation does not use request parameters.
 
 **Request Headers**
 
@@ -89,7 +89,7 @@ This implementation of GET returns the following response elements.
    |                          |                                                |
    |                          | Ancestor: Rule                                 |
    |                          |                                                |
-   |                          | Valid values: Enabled, Disabled.               |
+   |                          | Valid values: Enabled, Disabled                |
    +--------------------------+------------------------------------------------+
    | Prefix                   | Object keyname prefix identifying one or more  |
    |                          | objects to which the rule applies. Maximum     |
@@ -121,27 +121,28 @@ This implementation of GET returns the following response elements.
    |                          | Ancestor: Destination                          |
    +--------------------------+------------------------------------------------+
    | StorageClass             | Optional destination storage class override    |
-   |                          | to use when replicating objects. If not        |
-   |                          | specified, Amazon S3 uses the storage class of |
-   |                          | the source object to create object replica.    |
+   |                          | to use when replicating objects. If this       |
+   |			      | element is not specified, Zenko uses the       |
+   |			      | source object's storage class to create an     |
+   |   			      | object replica.                                |
+   |                          |                                                |
+   |			      | Zenko reinterprets this S3 call not as a       |
+   |                          | service quality directive, but as a service    |
+   |                          | locator. In other words, where Amazon S3 uses  |
+   |                          | this directive to define a location by quality |
+   |                          | of service (e.g., STANDARD or GLACIER), Zenko  | 
+   |                          | uses it to direct replication to a location.   |
+   |                          | The quality of service is determined and the   | 
+   |			      |	replication destination is configured by the   |
+   |                          | user.                                          |
    |                          |                                                |
    |                          | Type: String                                   |
    |                          |                                                |
    |                          | Ancestor: Destination                          |
    |                          |                                                |
-   |                          | Default: Storage class of the source object.   |
+   |                          | Default: Storage class of the source object    |
    |                          |                                                |
-   |                          | Valid Values: STANDARD \| STANDARD_IA \|       |
-   |                          | REDUCED_REDUNDANCY                             |
-   |                          |                                                |
-   |                          | GLACIER cannot be specified as the storage     |
-   |                          | class, though objects can be transitioned to   |
-   |                          | the GLACIER storage class using lifecycle      |
-   |                          | configuration (refer to `Object Lifecycle      |
-   |                          | Management <http://docs.aws.amazon.com/        |
-   |                          | AmazonS3/latest/dev/object-lifecycle-mgmt.     |
-   |                          | html>`__ in the Amazon Simple Storage Service  |
-   |                          | Service (S3) documentation).                   |
+   |                          | Valid Values: Any defined Zenko location       |
    +--------------------------+------------------------------------------------+
 
 **Special Errors**
@@ -153,8 +154,8 @@ This implementation of GET returns the following response elements.
    | Name               | Description     | HTTP Status     | SOAP Fault      |
    |                    |                 | Code            | Code Prefix     |
    +====================+=================+=================+=================+
-   | NoSuchReplica-     | The replication | 404 Not Found   | Client          |
-   | tionConfiguration  | configuration   |                 |                 |
+   | NoSuchReplication\ | The replication | 404 Not Found   | Client          |
+   | Configuration      | configuration   |                 |                 |
    |                    | does not exist. |                 |                 |
    +--------------------+-----------------+-----------------+-----------------+
 
@@ -173,12 +174,12 @@ information set for the examplebucket bucket.
    Authorization: signatureValue
 
 The following sample response shows that replication is enabled on the
-bucket, and the empty prefix indicates that S3 will replicate all
+bucket, and the empty prefix indicates that Zenko will replicate all
 objects created in the examplebucket bucket. The Destination element
-shows the target bucket where S3 creates the object replicas and the
-storage class (STANDARD_IA) that S3 will use when creating replicas.
+shows the target bucket where Zenko creates the object replicas and the
+storage class (AzureCloud) that Zenko uses when creating replicas.
 
-S3 will assume the specified role to replicate objects on behalf of the
+Zenko assumes the specified role to replicate objects on behalf of the
 bucket owner.
 
 .. code::
@@ -198,7 +199,7 @@ bucket owner.
        <Prefix></Prefix>
        <Destination>
          <Bucket>arn:aws:s3:::exampletargetbucket</Bucket>
-         <StorageClass>STANDARD_IA</StorageClass>
+         <StorageClass>AzureCloud</StorageClass>
        </Destination>
      </Rule>
      <Role>arn:aws:iam::35667example:role/CrossRegionReplicationRoleForS3</Role>

--- a/docs/docsource/Reference/bucket_operations/put_bucket_replication.rst
+++ b/docs/docsource/Reference/bucket_operations/put_bucket_replication.rst
@@ -58,10 +58,10 @@ status, and details about the destination.
 The destination details include the bucket in which to store replicas
 and optional storage classes to use to store the replicas.
 
-S3 acts only on rules with the status Enabled. The configuration also
-identifies an IAM role for S3 to assume for copying objects. This role
-must have sufficient permissions to read objects from the source bucket
-and replicate these objects into the target bucket.
+Zenko only acts on rules with an Enabled status. Zenko does not support IAM 
+roles; instead, Zenko pre-creates service accounts, one for each service
+(Replication, Lifecycle, Ingestion, Garbage Collection, Metadata Search).
+Each service uses keys generated for its own account to execute an operation.
 
 .. code::
 
@@ -104,8 +104,7 @@ configuration:
    |                          | Ancestor: None                                 |          |
    +--------------------------+------------------------------------------------+----------+
    | Role                     | Amazon Resource Name (ARN) of an IAM role for  | Yes      |
-   |                          | Amazon S3 to assume when replicating the       |          |
-   |                          | objects.                                       |          |
+   |                          | Zenko to assume when replicating the objects.  |          |
    |                          |                                                |          |
    |                          | Type: String                                   |          |
    |                          |                                                |          |
@@ -153,7 +152,7 @@ configuration:
    |                          | Ancestor: Rule                                 |          |
    +--------------------------+------------------------------------------------+----------+
    | Bucket                   | Amazon resource name (ARN) of the bucket where | Yes      |
-   |                          | Amazon S3 is to store replicas of the object   |          |
+   |                          | Zenko is to store replicas of the object       |          |
    |                          | identified by the rule.                        |          |
    |                          |                                                |          |
    |                          | If there are multiple rules in the replication |          |
@@ -168,9 +167,19 @@ configuration:
    +--------------------------+------------------------------------------------+----------+
    | StorageClass             | Optional destination storage class override to | No       |
    |                          | use when replicating objects. If this element  |          | 
-   |                          | is not specified, Amazon S3 uses the storage   |          |
+   |                          | is not specified, Zenko uses the storage       |          |
    |                          | class of the source object to create object    |          |
    |                          | replica.                                       |          |
+   |			      |						       |	  |
+   |                          | Zenko reinterprets this S3 call not as a       |	  |
+   |                          | service quality directive, but as a service    |	  |
+   |                          | locator. In other words, where Amazon S3 uses  |	  |
+   |                          | this directive to define a location by quality |	  |
+   |                          | of service (e.g., STANDARD or GLACIER), Zenko  |	  |
+   |                          | uses it to direct replication to a location.   |	  |
+   |                          | The quality of service is determined and the   |	  |
+   |                          | replication destination is configured by the   |	  |
+   |                          | user.                                          |	  |
    |                          |                                                |          |
    |                          | Type: String                                   |          |
    |                          |                                                |          |
@@ -178,18 +187,7 @@ configuration:
    |                          |                                                |          |
    |                          | Default: Storage class of the source object.   |          |
    |                          |                                                |          |
-   |                          | Valid Values: STANDARD \| STANDARD_IA \|       |          |
-   |                          | REDUCED_REDUNDANCY                             |          |
-   |                          |                                                |          |
-   |                          | Constraints: GLACIER cannot be specified as    |          |
-   |                          | the storage class, though objects can be       |          |
-   |                          | transitioned to the GLACIER storage class      |          |
-   |                          | using lifecycle configuration (see             |          |
-   |                          | `Object Lifecycle Management                   |          |
-   |                          | <http://docs.aws.amazon.com/AmazonS3/latest/   |          |
-   |                          | dev/object-lifecycle-mgmt.html>`__             |          |
-   |                          | in the Amazon Simple Storage Service (S3)      |          |
-   |                          | documentation).                                |          |
+   |                          | Valid Values: Any defined destination name     |	  |
    +--------------------------+------------------------------------------------+----------+
 
 **Response Headers**


### PR DESCRIPTION
This PR removes references to the GLACIER service class, which we do not support. 

We need it because it's bad to make promises we can't keep. 

This fixes ZENKO-1599