### PR TITLE
feature: ZENKO-1383 Add metadata integrity checks

### DIFF
--- a/tests/zenko_tests/node_tests/backbeat/LifecycleUtility.js
+++ b/tests/zenko_tests/node_tests/backbeat/LifecycleUtility.js
@@ -43,6 +43,20 @@ class LifecycleUtility extends ReplicationUtility {
         }, cb);
     }
 
+    getObjectTagging(cb) {
+        this.s3.getObjectTagging({
+            Bucket: this.bucket,
+            Key: this.key,
+        }, cb);
+    }
+
+    headObject(cb) {
+        this.s3.headObject({
+            Bucket: this.bucket,
+            Key: this.key,
+        }, cb);
+    }
+
     clearBucket(cb) {
         this.deleteAllVersions(this.bucket, this.keyPrefix, cb);
     }


### PR DESCRIPTION
Add checks for metadata integrity (i.e. object tagging, user metadata) during a transition.