### PR TITLE
bf(ZENKO-1630): Fix invalid CI crontab

### DIFF
--- a/eve/ci-values.yaml
+++ b/eve/ci-values.yaml
@@ -125,7 +125,7 @@ backbeat:
     replicaFactor: 2
   lifecycle:
     conductor:
-      cronRule: "0 */1 * * * *"
+      cronRule: "* * * * *"
 
 grafana:
   persistentVolume:


### PR DESCRIPTION
**Which issue does this PR fix?**

fixes ZENKO-1630
Invalid crontab in ci-values.yaml
