### PR TITLE
documentation: ZENKO-1636_get_rid_of_Enterprise

### DIFF
--- a/docs/docsource/Operation-Architecture/Zenko_CLI/index.rst
+++ b/docs/docsource/Operation-Architecture/Zenko_CLI/index.rst
@@ -24,7 +24,7 @@ S3 API
 ------
 
 Zenko supports a limited set of S3 API commands. For a comprehensive
-listing of supported S3 commands, see the *Scality Zenko Enterprise Reference
+listing of supported S3 commands, see the *Scality Zenko Reference
 Manual (v. 1.0)*.
 
 Setup

--- a/docs/docsource/Reference/bucket_cors_operations/bucket_cors_specification.rst
+++ b/docs/docsource/Reference/bucket_cors_operations/bucket_cors_specification.rst
@@ -3,12 +3,12 @@
 Bucket CORS Specification
 =========================
 
-Zenko Enterprise implements the `AWS S3 Bucket CORS APIs <http://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html>`__.
+Zenko implements the `AWS S3 Bucket CORS APIs <http://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html>`__.
 
 Preflight CORS Requests
 -----------------------
 
-A preflight request with the HTTP OPTIONS method can be made against Zenko Enterprise to
+A preflight request with the HTTP OPTIONS method can be made against Zenko to
 determine whether CORS requests are permitted on a bucket before sending
 the actual request. (For detailed information on the preflight request
 and response, refer to `OPTIONS

--- a/docs/docsource/Reference/bucket_cors_operations/index.rst
+++ b/docs/docsource/Reference/bucket_cors_operations/index.rst
@@ -1,7 +1,7 @@
 Bucket CORS Operations
 ======================
 
-Bucket CORS operations enable Zenko Enterprise to permit cross-origin requests sent
+Bucket CORS operations enable Zenko to permit cross-origin requests sent
 through the browser on a per-bucket basis. To enable cross-origin
 requests, configure a S3 bucket by adding a CORS subresource containing
 rules for the type of requests to permit.

--- a/docs/docsource/Reference/bucket_operations/get_bucket_list_objects.rst
+++ b/docs/docsource/Reference/bucket_operations/get_bucket_list_objects.rst
@@ -83,7 +83,6 @@ parameters to return a subset of objects in a bucket:
    |                       |                       | start with when       |
    |                       |                       | listing objects in a  |
    |                       |                       | bucket. Zenko         |
-   |                       |                       | Enterprise            |
    |                       |                       | returns object keys   |
    |                       |                       | in UTF-8 binary       |
    |                       |                       | order, starting with  |
@@ -192,9 +191,8 @@ XML elements in the response:
    | DisplayName           | string                | Object owner's name   |
    +-----------------------+-----------------------+-----------------------+
    | Encoding-Type         | string                | Encoding type used by |
-   |                       |                       | Zenko Enterprise to   |
-   |                       |                       | encode object key     |
-   |                       |                       | names in the XML      |
+   |                       |                       | Zenko to encode object|
+   |                       |                       | key names in the XML  |
    |                       |                       | response.             |
    |                       |                       |                       |
    |                       |                       | If encoding-type      |
@@ -402,7 +400,7 @@ The following GET request specifies the delimiter parameter with value
    Authorization: {{authorizationString}}
 
 The key greatshot.raw does not contain the delimiter character, and
-Zenko Enterprise returns it in the Contents element in the response. However, all other
+Zenko returns it in the Contents element in the response. However, all other
 keys contain the delimiter character. Zenko groups these keys and return a
 single CommonPrefixes element with the common prefix value
 ``photographs/``, which is a substring from the beginning of these keys
@@ -442,7 +440,7 @@ The following GET request specifies the delimiter parameter with value
    Date: Wed, 01 Mar  2006 12:00:00 GMT
    Authorization: {{authorizationString}}
 
-In response, Zenko Enterprise returns only the keys that start with the specified prefix.
+In response, Zenko returns only the keys that start with the specified prefix.
 Further, it uses the delimiter character to group keys that contain the
 same substring until the first occurrence of the delimiter character
 after the specified prefix. For each such key group Zenko returns one

--- a/docs/docsource/Reference/bucket_operations/get_bucket_location.rst
+++ b/docs/docsource/Reference/bucket_operations/get_bucket_location.rst
@@ -11,7 +11,7 @@ LocationConstraint request parameter in a PUT Bucket request. Refer to :ref:`PUT
 
   The possible options for a LocationConstraint are configured in the
   env_s3 setting of the S3 Configuration. For more information, refer to
-  “Modifying the Group Variables (all) File” in Zenko Enterprise Installation.
+  “Modifying the Group Variables (all) File” in Zenko Installation.
 
 Requests
 --------

--- a/docs/docsource/Reference/bucket_operations/get_bucket_object_versions.rst
+++ b/docs/docsource/Reference/bucket_operations/get_bucket_object_versions.rst
@@ -191,9 +191,8 @@ XML elements in the response:
    |                       |                       | leteMarker.Owner      |
    +-----------------------+-----------------------+-----------------------+
    | Encoding-Type         | string                | Encoding type used by |
-   |                       |                       | Zenko Enterprise to   |
-   |                       |                       | encode object key     |
-   |                       |                       | names in the XML      |
+   |                       |                       | Zenko to encode object|
+   |                       |                       | key names in the XML  |
    |                       |                       | response.             |
    |                       |                       |                       |
    |                       |                       | If encoding-type      |

--- a/docs/docsource/Reference/bucket_operations/list_multipart_uploads.rst
+++ b/docs/docsource/Reference/bucket_operations/list_multipart_uploads.rst
@@ -196,7 +196,7 @@ Responses
 **Response Headers**
 
 The List Multipart Uploads uses only the common response headers
-supported by Zenko Enterprise (refer to :ref:`Common Response Headers`).
+supported by Zenko (refer to :ref:`Common Response Headers`).
 
 **Response Elements**
 

--- a/docs/docsource/Reference/bucket_operations/put_bucket.rst
+++ b/docs/docsource/Reference/bucket_operations/put_bucket.rst
@@ -50,7 +50,7 @@ permissions.
 
 *Specifying a Canned ACL*
 
-Zenko Enterprise supports a set of canned ACLs, each with a predefined set of grantees
+Zenko supports a set of canned ACLs, each with a predefined set of grantees
 and permissions.
 
 .. tabularcolumns:: X{0.15\textwidth}X{0.15\textwidth}X{0.65\textwidth}

--- a/docs/docsource/Reference/bucket_operations/put_bucket_acl.rst
+++ b/docs/docsource/Reference/bucket_operations/put_bucket_acl.rst
@@ -65,7 +65,7 @@ grantee permissions.
 
 *Specifying a Canned ACL*
 
-Zenko Enterprise supports a set of canned ACLs, each of which has a predefined set of
+Zenko supports a set of canned ACLs, each of which has a predefined set of
 grantees and permissions.
 
 To grant access permissions by specifying canned ACLs, use the following
@@ -98,8 +98,8 @@ header and specify the canned ACL name as its value.
 *Explicitly Specifying Grantee Access Permissions*
 
 A set of x-amz-grant-permission headers is available for explicitly
-granting individualized bucket access permissions to specific Zenko Enterprise accounts
-or groups. Each of these headers maps to specific permissions the Zenko Enterprise
+granting individualized bucket access permissions to specific Zenko accounts
+or groups. Each of these headers maps to specific permissions the Zenko
 supports in an ACL.
 
 .. note::
@@ -160,7 +160,7 @@ type can be one any one of the following:
 
 For example, the following x-amz-grant-write header grants create,
 overwrite, and delete objects permission to a LogDelivery group
-predefined by Zenko Enterprise and two accounts identified by their email addresses.
+predefined by Zenko and two accounts identified by their email addresses.
 
 .. code::
 
@@ -169,7 +169,7 @@ predefined by Zenko Enterprise and two accounts identified by their email addres
 .. note::
 
   Though cited here for purposes of example, the LogDelivery group
-  permission is not currently being used by Zenko Enterprise.
+  permission is not currently being used by Zenko.
 
 Request Elements
 ~~~~~~~~~~~~~~~~
@@ -335,9 +335,9 @@ following grants.
 The request sample uses ACL-specific request headers to grant the
 following permissions:
 
--  Write permission to the Zenko Enterprise LogDelivery group and an account identified
+-  Write permission to the Zenko LogDelivery group and an account identified
    by the email xyz@scality.com
--  Read permission to the Zenko Enterprise AllUsers group
+-  Read permission to the Zenko AllUsers group
 
 *Request Sample*
 

--- a/docs/docsource/Reference/bucket_website_operations/bucket_website_specification.rst
+++ b/docs/docsource/Reference/bucket_website_operations/bucket_website_specification.rst
@@ -3,7 +3,7 @@
 Bucket Website Specification
 ============================
 
-Scality Zenko Enterprise implements the `AWS S3 Bucket Website
+Scality Zenko implements the `AWS S3 Bucket Website
 APIs <http://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html>`__
 per the AWS specifications. This makes the objects accessible through a
 bucket website.
@@ -28,10 +28,10 @@ Using Bucket Websites
 
 To experience bucket website behavior, a user must make a request to a bucket website endpoint rather than the usual REST endpoints. Refer to `Website Endpoints <https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteEndpoints.html>`_ for the difference in response from a bucket endpoint versus the usual REST endpoint.
 
-To set up Zenko Enterprise with website endpoints, in Federation env_s3 should have a
+To set up Zenko with website endpoints, in Federation env_s3 should have a
 website_endpoints section that contains a list of all desired website
 endpoints (e.g., s3-website.scality.example.com). Thus, if a user has a
-bucket foo, a bucket website request to Zenko Enterprise would be made to
+bucket foo, a bucket website request to Zenko would be made to
 foo.s3-website.scality.example.com.
 
 .. note::
@@ -40,5 +40,5 @@ foo.s3-website.scality.example.com.
   that the ACL of such an object must be public-read. This ACL can be set
   when the object is originally put or through a :ref:`PUT Object
   ACL` call. The AWS instructions for setting up bucket websites suggest using a bucket
-  policy to set all objects to public, but Zenko Enterprise does not yet implement bucket
+  policy to set all objects to public, but Zenko does not yet implement bucket
   policies so this option is not available.

--- a/docs/docsource/Reference/introduction/bucket_encryption.rst
+++ b/docs/docsource/Reference/introduction/bucket_encryption.rst
@@ -11,13 +11,13 @@ on GET). In contrast, AWS SSE is quite intrusive, as it requires special
 headers on all Object create calls, including Object Put, Object Copy,
 Object Post, and Multi Part Upload requests.
 
-Zenko Enterprise bucket encryption is similar to SSE-C in how it integrates with the Key
+Zenko bucket encryption is similar to SSE-C in how it integrates with the Key
 Management Service (KMS). Scality requires that customers provide the
 KMS, which is responsible for generating encryption keys on PUT calls
 and for retrieving the same encryption key on GET calls. In this manner,
-Zenko Enterprise does not store encryption keys.
+Zenko does not store encryption keys.
 
-Also, Zenko Enterprise uses standard OpenSSL, 256-bit encryption libraries to perform the
+Also, Zenko uses standard OpenSSL, 256-bit encryption libraries to perform the
 actual payload encryption/decryption. This also supports the Intel
 AES-NI CPU acceleration library, making encryption nearly as fast as
 non-encrypted performance.

--- a/docs/docsource/Reference/introduction/https_protocols.rst
+++ b/docs/docsource/Reference/introduction/https_protocols.rst
@@ -1,7 +1,7 @@
 HTTP Protocols
 ==============
 
-Zenko Enterprise uses HTTP protocols as defined by RFC 2616. REST operations consist of
+Zenko uses HTTP protocols as defined by RFC 2616. REST operations consist of
 sending HTTP requests to Zenko, which returns HTTP responses. These HTTP
 requests contain a request method, a URI with an optional query string,
 headers, and a body. The responses contain status codes, headers, and

--- a/docs/docsource/Reference/introduction/index.rst
+++ b/docs/docsource/Reference/introduction/index.rst
@@ -1,7 +1,7 @@
 Introduction
 ============
 
-The Zenko Enterprise application programming interface’s operations are explained and detailed herein, their
+The Zenko application programming interface’s operations are explained and detailed herein, their
 parameters, responses, and errors.
 
 .. toctree::

--- a/docs/docsource/Reference/introduction/official_api_support/index.rst
+++ b/docs/docsource/Reference/introduction/official_api_support/index.rst
@@ -1,7 +1,7 @@
 Official API Support
 ====================
 
-The supported S3 API commands for Zenko Enterprise for the current
+The supported S3 API commands for Zenko for the current
 release are detailed herein.
 
 .. toctree::

--- a/docs/docsource/Reference/object_operations/complete_multipart_upload.rst
+++ b/docs/docsource/Reference/object_operations/complete_multipart_upload.rst
@@ -7,7 +7,7 @@ The Complete Multipart Upload operation is the last step in the
 multipart upload of a large object, pulling together previously uploaded
 parts, called only after a multipart upload is initiated and all of the
 relevant parts have been uploaded (refer to :ref:`Upload Part`).
-Upon receiving the Complete Multipart Upload request, Zenko Enterprise concatenates all
+Upon receiving the Complete Multipart Upload request, Zenko concatenates all
 the parts in ascending order by part number to create a new object.
 
 The parts list must be provided for a Complete Multipart Upload request.
@@ -16,9 +16,9 @@ part number and ETag header value are provided for each part (both of
 which were returned with the successful uploading of the part).
 
 Processing of a Complete Multipart Upload request can take several
-minutes to complete. Once Zenko Enterprise begins processing the request, it sends an
+minutes to complete. Once Zenko begins processing the request, it sends an
 HTTP response header that specifies a ``200 OK`` response. While
-processing is in progress, Zenko Enterprise periodically sends whitespace characters to
+processing is in progress, Zenko periodically sends whitespace characters to
 keep the connection from timing out. Because a request could fail after
 the initial response has been sent, it is important to check the
 response body to determine whether the request succeeded.

--- a/docs/docsource/Reference/object_operations/delete_object.rst
+++ b/docs/docsource/Reference/object_operations/delete_object.rst
@@ -5,12 +5,12 @@ DELETE Object
 
 The DELETE Object operation removes the null version (if there is one)
 of an object and inserts a delete marker, which becomes the current
-version of the object. If there isn’t a null version, Zenko Enterprise does not remove
+version of the object. If there isn’t a null version, Zenko does not remove
 any objects.
 
 Only the bucket owner can remove a specific version, using the versionId
 subresource, whichpermanently deletes the version. If the object deleted
-is a delete marker, Zenko Enterprise sets the response header x-amz-delete-marker to
+is a delete marker, Zenko sets the response header x-amz-delete-marker to
 true.
 
 Requests

--- a/docs/docsource/Reference/object_operations/get_object.rst
+++ b/docs/docsource/Reference/object_operations/get_object.rst
@@ -12,7 +12,9 @@ object. To return a different version, use the versionId subresource.
 
 .. tip::
 
-  If the current version of the object is a delete marker, Zenko Enterprise behaves as if the object was deleted and includes x-amz-delete-marker: true in the response.
+  If the current version of the object is a delete marker, Zenko behaves
+  as if the object was deleted and includes x-amz-delete-marker: true in
+  the response.
 
 Requests
 --------
@@ -33,7 +35,8 @@ Values for a set of response headers can be overridden in the GET Object
 response using the query parameters listed in the following table. These
 response header values are sent only on a successful request, one in
 which a status code *200 OK* is returned. The set of headers that can be
-overridden using these parameters is a subset of the headers that Zenko Enterprise accepts when an object is created, including ``Content-Type``,
+overridden using these parameters is a subset of the headers that Zenko
+accepts when an object is created, including ``Content-Type``,
 ``Content-Language``, ``Expires``, ``Cache-Control``,
 ``Content-Disposition``, and ``Content-Encoding``.
 
@@ -193,11 +196,9 @@ Responses
    |                       |                       | which is stored and   |
    |                       |                       | returned as a set of  |
    |                       |                       | key-value pairs.      |
-   |                       |                       | Zenko Enterprise does |
-   |                       |                       | not validate or       |
-   |                       |                       | interpret             |
-   |                       |                       | user-defined          |
-   |                       |                       | metadata.             |
+   |                       |                       | Zenko does not        |
+   |                       |                       | validate or interpret |
+   |                       |                       | user-defined metadata.|
    +-----------------------+-----------------------+-----------------------+
    | x-amz-version-id      | string                | Returns the version   |
    |                       |                       | ID of the retrieved   |
@@ -355,7 +356,7 @@ bytes of an object.
 
   .. note::
 
-    Zenko Enterprise does not support retrieving multiple ranges of data per GET request.
+    Zenko does not support retrieving multiple ranges of data per GET request.
 
 *Response Sample*
 

--- a/docs/docsource/Reference/object_operations/head_object.rst
+++ b/docs/docsource/Reference/object_operations/head_object.rst
@@ -120,9 +120,8 @@ responses (refer to :ref:`Common Response Headers`).
    |                       |                       | which is stored and   |
    |                       |                       | returned as a set of  |
    |                       |                       | key-value pairs.      |
-   |                       |                       | Zenko Enterprise does |
-   |                       |                       | not validate or       |
-   |                       |                       | interpret             |
+   |                       |                       | Zenko does not        |
+   |                       |                       | validate or interpret |
    |                       |                       | user-defined          |
    |                       |                       | metadata.             |
    +-----------------------+-----------------------+-----------------------+

--- a/docs/docsource/Reference/object_operations/initiate_multipart_upload.rst
+++ b/docs/docsource/Reference/object_operations/initiate_multipart_upload.rst
@@ -91,7 +91,7 @@ request headers in addition to those that are common to all operations
    |                       |                       | binary/octet-stream   |
    |                       |                       |                       |
    |                       |                       | Valid Values:         |
-   |                       |                       | MIME types            |
+   |                       |                       | MIME types            |
    |                       |                       |                       |
    |                       |                       | Constraints: None     |
    +-----------------------+-----------------------+-----------------------+
@@ -110,9 +110,8 @@ request headers in addition to those that are common to all operations
    |                       |                       | which is stored and   |
    |                       |                       | returned as a set of  |
    |                       |                       | key-value pairs.      |
-   |                       |                       | Zenko Enterprise does |
-   |                       |                       | not validate or       |
-   |                       |                       | interpret             |
+   |                       |                       | Zenko does not        |
+   |                       |                       | validate or interpret |
    |                       |                       | user-defined          |
    |                       |                       | metadata. Within the  |
    |                       |                       | PUT request header,   |
@@ -156,7 +155,7 @@ the Access Control List (ACL) on the object.
 
 *Specifying a Canned ACL*
 
-Zenko Enterprise supports a set of canned ACLs, each of which has a predefined set of
+Zenko supports a set of canned ACLs, each of which has a predefined set of
 grantees and permissions.
 
 .. tabularcolumns:: X{0.15\textwidth}X{0.10\textwidth}X{0.70\textwidth}
@@ -181,8 +180,8 @@ grantees and permissions.
 *Explicitly Specifying Access Permissions*
 
 A set of headers is available for explicitly granting access permissions
-to specific accounts or groups, each of which maps to specific Zenko Enterprise
-permissions Zenko Enterprise supports in an ACL.
+to specific accounts or groups, each of which maps to specific Zenko
+permissions Zenko supports in an ACL.
 
 In the header value, specify a list of grantees who get the specific
 permission.
@@ -251,7 +250,7 @@ Responses
 **Response Headers**
 
 The Initiate Multipart Upload operation may include any of the common
-response headers supported by the Zenko Enterprise (refer to :ref:`Common Response Headers`).
+response headers supported by the Zenko (refer to :ref:`Common Response Headers`).
 
 **Response Elements**
 

--- a/docs/docsource/Reference/object_operations/list_parts.rst
+++ b/docs/docsource/Reference/object_operations/list_parts.rst
@@ -37,56 +37,54 @@ return a subset of a bucket’s objects.
 .. tabularcolumns:: X{0.20\textwidth}X{0.10\textwidth}X{0.65\textwidth}
 .. table::
 
-   +-----------------------+-----------------------+-----------------------+
-   | Parameter             | Type                  | Description           |
-   +=======================+=======================+=======================+
-   | encoding-type         | string                | Requests that         |
-   |                       |                       | Zenko Enterprise      |
-   |                       |                       | encode the response   |
-   |                       |                       | and specifies the     |
-   |                       |                       | encoding method to    |
-   |                       |                       | use. An object key    |
-   |                       |                       | can contain any       |
-   |                       |                       | Unicode character;    |
-   |                       |                       | however, XML 1.0      |
-   |                       |                       | parser cannot parse   |
-   |                       |                       | some characters, such |
-   |                       |                       | as characters with an |
-   |                       |                       | ASCII value from 0 to |
-   |                       |                       | 10. For characters    |
-   |                       |                       | that are not          |
-   |                       |                       | supported in XML 1.0, |
-   |                       |                       | you can add this      |
-   |                       |                       | parameter to request  |
-   |                       |                       | that Zenko Enterprise |
-   |                       |                       | encode the keys       |
-   |                       |                       | in the response.      |
-   |                       |                       |                       |
-   |                       |                       | Default: None         |
-   +-----------------------+-----------------------+-----------------------+
-   | uploadID              | string                | Upload ID identifying |
-   |                       |                       | the multipart upload  |
-   |                       |                       | whose parts are being |
-   |                       |                       | listed                |
-   |                       |                       |                       |
-   |                       |                       | Default: None         |
-   +-----------------------+-----------------------+-----------------------+
-   | max-parts             | string                | Sets the maximum      |
-   |                       |                       | number of parts to    |
-   |                       |                       | return in the         |
-   |                       |                       | response body         |
-   |                       |                       |                       |
-   |                       |                       | Default: None         |
-   +-----------------------+-----------------------+-----------------------+
-   | part-number-marker    | string                | Specifies the part    |
-   |                       |                       | after which listing   |
-   |                       |                       | should begin. Only    |
-   |                       |                       | parts with higher     |
-   |                       |                       | part numbers will be  |
-   |                       |                       | listed.               |
-   |                       |                       |                       |
-   |                       |                       | Default: None         |
-   +-----------------------+-----------------------+-----------------------+
+   +--------------------+-----------------------+------------------------+
+   | Parameter          | Type                  | Description            |
+   +====================+=======================+========================+
+   | encoding-type      | string                | Requests that          |
+   |                    |                       | Zenko encode the       |
+   |                    |                       | response and specifies |
+   |                    |                       | the encoding method    |
+   |                    |                       | to use. An object key  |
+   |                    |                       | can contain any        |
+   |                    |                       | Unicode character;     |
+   |                    |                       | however, XML 1.0       |
+   |                    |                       | parser cannot parse    |
+   |                    |                       | some characters, such  |
+   |                    |                       | as characters with an  |
+   |                    |                       | ASCII value from 0 to  |
+   |                    |                       | 10. For characters     |
+   |                    |                       | that are not           |
+   |                    |                       | supported in XML 1.0,  |
+   |                    |                       | you can add this       |
+   |                    |                       | parameter to request   |
+   |                    |                       | that Zenko encode the  |
+   |                    |                       | keys in the response.  |
+   |                    |                       |                        |
+   |                    |                       | Default: None          |
+   +--------------------+-----------------------+------------------------+
+   | uploadID           | string                | Upload ID identifying  |
+   |                    |                       | the multipart upload   |
+   |                    |                       | whose parts are being  |
+   |                    |                       | listed                 |
+   |                    |                       |                        |
+   |                    |                       | Default: None          |
+   +--------------------+-----------------------+------------------------+
+   | max-parts          | string                | Sets the maximum       |
+   |                    |                       | number of parts to     |
+   |                    |                       | return in the          |
+   |                    |                       | response body          |
+   |                    |                       |                        |
+   |                    |                       | Default: None          |
+   +--------------------+-----------------------+------------------------+
+   | part-number-marker | string                | Specifies the part     |
+   |                    |                       | after which listing    |
+   |                    |                       | should begin. Only     |
+   |                    |                       | parts with higher      |
+   |                    |                       | part numbers will be   |
+   |                    |                       | listed.                |
+   |                    |                       |                        |
+   |                    |                       | Default: None          |
+   +--------------------+-----------------------+------------------------+
 
 **Request Headers**
 
@@ -103,7 +101,7 @@ Responses
 **Response Headers**
 
 The List Parts operation uses only the common response headers supported
-by Zenko Enterprise (refer to :ref:`Common Response Headers`).
+by Zenko (refer to :ref:`Common Response Headers`).
 
 **Response Elements**
 
@@ -124,9 +122,8 @@ response (includes XML containers):
    |                       |                       | upload was initiated  |
    +-----------------------+-----------------------+-----------------------+
    | Encoding-Type         | string                | Encoding type used by |
-   |                       |                       | Zenko Enterprise      |
-   |                       |                       | to encode object key  |
-   |                       |                       | names in the XML      |
+   |                       |                       | Zenko to encode object|
+   |                       |                       | key names in the XML  |
    |                       |                       | response              |
    |                       |                       |                       |
    |                       |                       | If the encoding-type  |

--- a/docs/docsource/Reference/object_operations/multi-object_delete.rst
+++ b/docs/docsource/Reference/object_operations/multi-object_delete.rst
@@ -3,15 +3,17 @@
 Multi-Object Delete
 ===================
 
-The Multi-Object Delete operation enables the deletion of multiple
-objects from a bucket using a single HTTP request. If object keys to be deleted are known, this operation provides a suitable alternative to sending individual delete requests, reducing per-request overhead. Refer to :ref:`DELETE Object`.
+The Multi-Object Delete operation enables the deletion of multiple objects from
+a bucket using a single HTTP request. If object keys to be deleted are known,
+this operation provides a suitable alternative to sending individual delete 
+requests, reducing per-request overhead. Refer to :ref:`DELETE Object`.
 
 The Multi-Object Delete request contains a list of up to 1000 keys that
 can be deleted. In the XML, provide the object key names. Optionally,
 provide version ID to delete a specific version of the object from a
-versioning-enabled bucket. For each key, Zenko Enterprise performs a delete operation and
+versioning-enabled bucket. For each key, Zenko performs a delete operation and
 returns the result of that delete, success or failure, in the response.
-If the object specified in the request is not found, Zenko Enterprise returns the result
+If the object specified in the request is not found, Zenko returns the result
 as deleted.
 
 The Multi-Object Delete operation supports two modes for the
@@ -173,11 +175,10 @@ of the response:
    +-----------------------+-----------------------+-----------------------+
    | VersionId             | String                | Version ID of the     |
    |                       |                       | versioned object      |
-   |                       |                       | Zenko Enterprise      |
-   |                       |                       | attempted to delete.  |
-   |                       |                       | includes this element |
-   |                       |                       | only in case of a     |
-   |                       |                       | versioned-delete      |
+   |                       |                       | Zenko attempted to    |
+   |                       |                       | delete. Includes this |
+   |                       |                       | element only in case  |
+   |                       |                       | of a versioned-delete |
    |                       |                       | request.              |
    |                       |                       |                       |
    |                       |                       | Ancestor: Deleted or  |
@@ -215,8 +216,7 @@ of the response:
    |                       |                       | Multi-Object Delete   |
    |                       |                       | either creates or     |
    |                       |                       | deletes a delete      |
-   |                       |                       | marker, Zenko         |
-   |                       |                       | Enterprise returns    |
+   |                       |                       | marker, Zenko returns |
    |                       |                       | this element in       |
    |                       |                       | response with the     |
    |                       |                       | version ID of the     |
@@ -264,7 +264,7 @@ of the response:
    |                       |                       | failed delete         |
    |                       |                       | operation that        |
    |                       |                       | describes the object  |
-   |                       |                       | that Zenko Enterprise |
+   |                       |                       | that Zenko    	   |
    |                       |                       | attempted to          |
    |                       |                       | delete and the error  |
    |                       |                       | it encountered.       |
@@ -277,8 +277,8 @@ of the response:
    |                       |                       | Message               |
    +-----------------------+-----------------------+-----------------------+
    | Key                   | String                | Key for the object    |
-   |                       |                       | Zenko Enterprise      |
-   |                       |                       | attempted to delete   |
+   |                       |                       | Zenko attempted to	   |
+   |                       |                       | delete         	   |
    |                       |                       |                       |
    |                       |                       | Ancestor: Error       |
    +-----------------------+-----------------------+-----------------------+
@@ -337,8 +337,8 @@ object).
 *Response Sample*
 
 The response includes a DeleteResult element that includes a Deleted
-element for the item that Zenko Enterprise successfully deleted and an Error element that
-Zenko Enterprise did not delete because the user didn’t have permission to delete the
+element for the item that Zenko successfully deleted and an Error element that
+Zenko did not delete because the user didn’t have permission to delete the
 object.
 
 .. code::
@@ -368,7 +368,7 @@ object.
 **Deleting Object from a Versioned Bucket**
 
 In deleting an item from a versioning enabled bucket, all versions of
-that object remain in the bucket; however, Zenko Enterprise inserts a delete marker.
+that object remain in the bucket; however, Zenko inserts a delete marker.
 
 The following scenarios describe the behavior of a Multi-Object Delete
 request when versioning is enabled for a bucket.
@@ -394,7 +394,7 @@ As shown, the Multi-Object Delete request specifies only one key.
      </Object>
    </Delete>
 
-As versioning is enabled on the bucket, Zenko Enterprise does not delete the object,
+As versioning is enabled on the bucket, Zenko does not delete the object,
 instead adding a delete marker. The response indicates that a delete
 marker was added (the DeleteMarker element in the response has a value
 of true) and the version number of the added delete marker.
@@ -445,8 +445,8 @@ of an object.
    </Object>
    </Delete>
 
-In this case, Zenko Enterprise deletes the specific object version from the bucket and
-returns the following response. In the response, Zenko Enterprise returns the key and
+In this case, Zenko deletes the specific object version from the bucket and
+returns the following response. In the response, Zenko returns the key and
 version ID of the deleted object.
 
 .. code::
@@ -472,9 +472,9 @@ version ID of the deleted object.
 **Scenario 3: Versioned Delete of a Delete Marker**
 
 In the preceding example, the request refers to a delete marker (in lieu
-of an object), then Zenko Enterprise deletes the delete marker. The effect of this
+of an object), then Zenko deletes the delete marker. The effect of this
 operation is to make the object reappear in the bucket. The response
-returned by Zenko Enterprise indicates the deleted delete marker (DeleteMarker element
+returned by Zenko indicates the deleted delete marker (DeleteMarker element
 with value true) and the version ID of the delete marker.
 
 .. code::
@@ -499,7 +499,7 @@ with value true) and the version ID of the delete marker.
    </Deleted>
    </DeleteResult>
 
-In general, when a Multi-Object Delete request results in Zenko Enterprise either adding
+In general, when a Multi-Object Delete request results in Zenko either adding
 a delete marker or removing a delete marker, the response returns the
 following elements:
 

--- a/docs/docsource/Reference/object_operations/put_object.rst
+++ b/docs/docsource/Reference/object_operations/put_object.rst
@@ -8,7 +8,7 @@ a bucket is necessary to add an object to it).
 
 .. note::
 
-  Zenko Enterprise never adds partial objects; if a success response is received, Zenko Enterprise added the
+  Zenko never adds partial objects; if a success response is received, Zenko added the
   entire object to the bucket.
 
 Object locking is not supported. If an object with the same name is
@@ -183,9 +183,8 @@ Request Headers`).
    |                       |                       | which is stored and   |
    |                       |                       | returned as a set of  |
    |                       |                       | key-value pairs.      |
-   |                       |                       | Zenko Enterprise does |
-   |                       |                       | not validate or       |
-   |                       |                       | interpret             |
+   |                       |                       | Zenko does not        |
+   |                       |                       | validate or interpret |
    |                       |                       | user-defined          |
    |                       |                       | metadata. Within the  |
    |                       |                       | PUT request header,   |
@@ -261,7 +260,7 @@ used to create the Access Control List (ACL) on the object.
 
 *Specifying a Canned ACL*
 
-Zenko Enterprise supports a set of canned ACLs, each of which has a predefined set of
+Zenko supports a set of canned ACLs, each of which has a predefined set of
 grantees and permissions.
 
 .. tabularcolumns:: X{0.20\textwidth}X{0.10\textwidth}X{0.65\textwidth}
@@ -286,8 +285,8 @@ grantees and permissions.
 *Explicitly Specifying Access Permissions*
 
 A set of headers is available for explicitly granting access permissions
-to specific Zenko Enterprise accounts or groups, each of which maps to specific
-permissions Zenko Enterprise supports in an ACL.
+to specific Zenko accounts or groups, each of which maps to specific
+permissions Zenko supports in an ACL.
 
 In the header value, specify a list of grantees who get the specific
 permission.

--- a/docs/docsource/Reference/object_operations/put_object_acl.rst
+++ b/docs/docsource/Reference/object_operations/put_object_acl.rst
@@ -78,7 +78,7 @@ grantee permissions.
 
 *Specifying a Canned ACL*
 
-Zenko Enterprise supports a set of canned ACLs, each of which has a predefined set of
+Zenko supports a set of canned ACLs, each of which has a predefined set of
 grantees and permissions.
 
 To grant access permissions by specifying canned ACLs, use the x-amz-acl
@@ -111,13 +111,13 @@ header and specify the canned ACL name as its value.
 *Explicitly Specifying Grantee Access Permissions*
 
 A set of x-amz-grant-permission headers is available for explicitly
-granting individualized object access permissions to specific Zenko Enterprise accounts
+granting individualized object access permissions to specific Zenko accounts
 or groups.
 
 .. note::
 
   Each of the x-amz-grant-permission headers maps to specific permissions
-  the Zenko Enterprise supports in an ACL. Please also note that the use of any of these
+  the Zenko supports in an ACL. Please also note that the use of any of these
   ACL-specific headers negates the use of the x-amz-acl header to set a
   canned ACL.
 

--- a/docs/docsource/Reference/object_operations/put_object_copy.rst
+++ b/docs/docsource/Reference/object_operations/put_object_copy.rst
@@ -63,7 +63,7 @@ two ways to grant the permissions using the request headers:
 -  Specify access permissions explicitly using thex-amz-grant-read,
    x-amz-grant-read-acp, x-amz-grant-write-acp, and
    x-amz-grant-full-control headers. These headers map to the set of
-   permissions Zenko Enterprise supports in an ACL.
+   permissions Zenko supports in an ACL.
 
 .. note::
 
@@ -142,13 +142,12 @@ headers in addition to those that are common to all operations (refer to
    |                       |        | location metadata from the source is not |
    |                       |        | copied. If you specify this metadata     |
    |                       |        | explicitly in the copy request, Zenko    |
-   |                       |        | Enterprise adds this metadata to the     |
-   |                       |        | the resulting object. If you specify     |
-   |                       |        | headers in the request specifying any    |
-   |                       |        | user-defined metadata, the connector     |
-   |                       |        | ignores these headers. To use new        |
-   |                       |        | user-defined metadata, REPLACE must be   |
-   |                       |        | selected.                                |
+   |                       |        | adds this metadata to the resulting      |
+   |                       |        | object. If you specify headers in the    |
+   |			   |	    | request specifying any user-defined      |
+   |			   |	    | metadata, the connector ignores these    |
+   |			   |	    | headers. To use new user-defined 	       |
+   |			   |	    | metadata, REPLACE must be selected.      |
    |                       |        |                                          |
    |                       |        | If replaced, all original metadata is    |
    |                       |        | replaced by the specified metadata.      |
@@ -235,7 +234,7 @@ headers:
 
 -  Consideration 1: If both of thex-amz-copy-source-if-match and
    x-amz-copy-source-if-unmodified-since headers are present in the
-   request as follows, Zenko Enterprise returns 200 OK and copies the data:
+   request as follows, Zenko returns 200 OK and copies the data:
 
    .. code::
 
@@ -244,7 +243,7 @@ headers:
 
 -  Consideration 2: If both of the x-amz-copy-source-if-none-match and
    x-amz-copy-source-if-modified-since headers are present in the
-   request as follows, Zenko Enterprise returns a 412 Precondition Failed response code:
+   request as follows, Zenko returns a 412 Precondition Failed response code:
 
    .. code::
 
@@ -261,7 +260,7 @@ information, refer to :ref:`ACL (Access Control List)`.
 
 *Specifying a Canned ACL*
 
-Zenko Enterprise supports a set of predefined ACLs, each of which has a predefined set of
+Zenko supports a set of predefined ACLs, each of which has a predefined set of
 grantees and permissions.
 
 To grant access permissions by specifying canned ACLs, use the x-amz-acl
@@ -293,12 +292,12 @@ header and specify the canned ACL name as its value.
 *Explicitly Specifying Grantee Access Permissions*
 
 A set of headers is available for explicitly granting access permissions
-to specific Zenko Enterprise accounts or groups.
+to specific Zenko accounts or groups.
 
 .. note::
 
   Each of the x-amz-grant-permission headers maps to specific permissions
-  the Zenko Enterprise supports in an ACL. Please also note that the use of any of these
+  the Zenko supports in an ACL. Please also note that the use of any of these
   ACL-specific headers negates the use of the x-amz-acl header to set a
   canned ACL.
 
@@ -383,73 +382,72 @@ all responses (refer to :ref:`Common Response Headers`).
 .. tabularcolumns:: X{0.30\textwidth}X{0.10\textwidth}X{0.55\textwidth}
 .. table::
 
-   +-----------------------+-----------------------+-----------------------+
-   | Header                | Type                  | Description           |
-   +=======================+=======================+=======================+
-   | x-amz-copy-source-\   | string                | Returns the version   |
-   | version-id            |                       | ID of the retrieved   |
-   |                       |                       | object if it has a    |
-   |                       |                       | unique version ID.    |
-   +-----------------------+-----------------------+-----------------------+
-   | x-amz-server-side-\   | string                | If server-side        |
-   | encryption            |                       | encryption is         |
-   |                       |                       | specified either with |
-   |                       |                       | an AWS KMS or         |
-   |                       |                       | Zenko Enterprise-     |
-   |                       |                       | managed encryption    |
-   |                       |                       | key in the copy       |
-   |                       |                       | request, the response |
-   |                       |                       | includes this header, |
-   |                       |                       | confirming the        |
-   |                       |                       | encryption algorithm  |
-   |                       |                       | that was used to      |
-   |                       |                       | encrypt the object.   |
-   +-----------------------+-----------------------+-----------------------+
-   | x-amz-server-side-\   | string                | If the                |
-   | encryption-aws-kms-\  |                       | x-amz-server-side-\   |
-   | key-id                |                       | encryption            |
-   |                       |                       | is present and has    |
-   |                       |                       | the value of aws:kms, |
-   |                       |                       | this header specifies |
-   |                       |                       | the ID of the AWS Key |
-   |                       |                       | Management Service    |
-   |                       |                       | (KMS) master          |
-   |                       |                       | encryption key that   |
-   |                       |                       | was used for the      |
-   |                       |                       | object.               |
-   +-----------------------+-----------------------+-----------------------+
-   | x-amz-server-side-\   | string                | If server-side        |
-   | encryption-customer-\ |                       | encryption with       |
-   | algorithm             |                       | customer-provided     |
-   |                       |                       | encryption keys       |
-   |                       |                       | (SSE-C) encryption    |
-   |                       |                       | was requested, the    |
-   |                       |                       | response will include |
-   |                       |                       | this header           |
-   |                       |                       | confirming the        |
-   |                       |                       | encryption algorithm  |
-   |                       |                       | used for the          |
-   |                       |                       | destination object.   |
-   |                       |                       |                       |
-   |                       |                       | Valid Values:         |
-   |                       |                       | ``AES256``            |
-   +-----------------------+-----------------------+-----------------------+
-   | x-amz-server-side-\   | string                | If SSE-C encryption   |
-   | encryption-customer-\ |                       | was requested, the    |
-   | key-MD5               |                       | response includes     |
-   |                       |                       | this header to        |
-   |                       |                       | provide roundtrip     |
-   |                       |                       | message integrity     |
-   |                       |                       | verification of the   |
-   |                       |                       | customer-provided     |
-   |                       |                       | encryption key used   |
-   |                       |                       | to encrypt the        |
-   |                       |                       | destination object.   |
-   +-----------------------+-----------------------+-----------------------+
-   | x-amz-version-id      | string                | Version of the copied |
-   |                       |                       | object in the         |
-   |                       |                       | destination bucket.   |
-   +-----------------------+-----------------------+-----------------------+
+   +-----------------------+-----------------------+------------------------+
+   | Header                | Type                  | Description            |
+   +=======================+=======================+========================+
+   | x-amz-copy-source-\   | string                | Returns the version    |
+   | version-id            |                       | ID of the retrieved    |
+   |                       |                       | object if it has a     |
+   |                       |                       | unique version ID.     |
+   +-----------------------+-----------------------+------------------------+
+   | x-amz-server-side-\   | string                | If server-side         |
+   | encryption            |                       | encryption is          |
+   |                       |                       | specified either with  |
+   |                       |                       | an AWS KMS or          |
+   |                       |                       | Zenko-managed          |
+   |                       |                       | encryption key in the  |
+   |                       |                       | copy request, the      |
+   |                       |                       | response includes this |
+   |                       |                       | header, confirming the |
+   |                       |                       | encryption algorithm   |
+   |                       |                       | that was used to       |
+   |                       |                       | encrypt the object.    |
+   +-----------------------+-----------------------+------------------------+
+   | x-amz-server-side-\   | string                | If the                 |
+   | encryption-aws-kms-\  |                       | x-amz-server-side-\    |
+   | key-id                |                       | encryption             |
+   |                       |                       | is present and has     |
+   |                       |                       | the value of aws:kms,  |
+   |                       |                       | this header specifies  |
+   |                       |                       | the ID of the AWS Key  |
+   |                       |                       | Management Service     |
+   |                       |                       | (KMS) master           |
+   |                       |                       | encryption key that    |
+   |                       |                       | was used for the       |
+   |                       |                       | object.                |
+   +-----------------------+-----------------------+------------------------+
+   | x-amz-server-side-\   | string                | If server-side         |
+   | encryption-customer-\ |                       | encryption with        |
+   | algorithm             |                       | customer-provided      |
+   |                       |                       | encryption keys        |
+   |                       |                       | (SSE-C) encryption     |
+   |                       |                       | was requested, the     |
+   |                       |                       | response will include  |
+   |                       |                       | this header            |
+   |                       |                       | confirming the         |
+   |                       |                       | encryption algorithm   |
+   |                       |                       | used for the           |
+   |                       |                       | destination object.    |
+   |                       |                       |                        |
+   |                       |                       | Valid Values:          |
+   |                       |                       | ``AES256``             |
+   +-----------------------+-----------------------+------------------------+
+   | x-amz-server-side-\   | string                | If SSE-C encryption    |
+   | encryption-customer-\ |                       | was requested, the     |
+   | key-MD5               |                       | response includes      |
+   |                       |                       | this header to         |
+   |                       |                       | provide roundtrip      |
+   |                       |                       | message integrity      |
+   |                       |                       | verification of the    |
+   |                       |                       | customer-provided      |
+   |                       |                       | encryption key used    |
+   |                       |                       | to encrypt the         |
+   |                       |                       | destination object.    |
+   +-----------------------+-----------------------+------------------------+
+   | x-amz-version-id      | string                | Version of the copied  |
+   |                       |                       | object in the          |
+   |                       |                       | destination bucket.    |
+   +-----------------------+-----------------------+------------------------+
 
 **Response Elements**
 

--- a/docs/docsource/Reference/object_operations/upload_part_copy.rst
+++ b/docs/docsource/Reference/object_operations/upload_part_copy.rst
@@ -18,7 +18,7 @@ The minimum allowable part size for a multipart upload is 5 MB.
   information, refer to :ref:`Upload Part`.
 
 A multipart upload must be initiated before uploading any part. In
-response to the initiate request, Zenko Enterprise returns a unique identifier — the
+response to the initiate request, Zenko returns a unique identifier — the
 *upload ID* — that must be included in the upload part request.
 
 Requests
@@ -100,8 +100,8 @@ x-amz-copy-source header specifies.
    | x-amz-copy-source-\   | String | Perform a copy if the source object       |
    | if-match              |        | entity tag (ETag) matches the specified   |
    |                       |        | value. If the value does not match, Zenko |
-   |                       |        | Enterprise returns an HTTP status code    |
-   |                       |        | ``412 Precondition Failed`` error.        |
+   |                       |        | returns an HTTP status code ``412         |
+   |                       |        | Precondition Failed`` error.              |
    |                       |        |                                           |
    |                       |        | **Note**: If both the                     |
    |                       |        | x-amz-copy-source-if-match                |
@@ -184,7 +184,7 @@ x-amz-copy-source header specifies.
 
 If the source object is encrypted using server-side encryption with a
 customer-provided encryption key, it is necessary to use the following
-headers providing encryption information so that Zenko Enterprise can decrypt the object
+headers providing encryption information so that Zenko can decrypt the object
 for copying.
 
 .. tabularcolumns:: X{0.30\textwidth}X{0.10\textwidth}X{0.50\textwidth}
@@ -249,9 +249,9 @@ If a bucket has versioning enabled, it is possible to have multiple
 versions of the same object. By default, x-amz-copy-source identifies
 the current version of the object to copy. If the current version is a
 delete marker and a versionId is not specified in the x-amz-copy-source,
-Zenko Enterprise returns a 404 error, because the object does not exist. If versionId is
+Zenko returns a 404 error, because the object does not exist. If versionId is
 specified in the x-amz-copy-source and the versionId is a delete marker,
-Zenko Enterprise returns an HTTP 400 error, because a delete marker cannot be specified
+Zenko returns an HTTP 400 error, because a delete marker cannot be specified
 as a version for the x-amz-copy-source.
 
 Optionally, a specific version of the source object to copy can be

--- a/docs/docsource/Reference/zenko_connector_api_knowledge_primers/acl_(access_control_list)_primer/grantable_permissions.rst
+++ b/docs/docsource/Reference/zenko_connector_api_knowledge_primers/acl_(access_control_list)_primer/grantable_permissions.rst
@@ -1,7 +1,7 @@
 Grantable Permissions
 =====================
 
-The set of permissions Zenko Enterprise supports in an ACL are detailed in the following
+The set of permissions Zenko supports in an ACL are detailed in the following
 table.
 
 .. tabularcolumns:: X{0.20\textwidth}X{0.35\textwidth}X{0.35\textwidth}

--- a/docs/docsource/Reference/zenko_connector_api_knowledge_primers/acl_(access_control_list)_primer/grantee_eligibility.rst
+++ b/docs/docsource/Reference/zenko_connector_api_knowledge_primers/acl_(access_control_list)_primer/grantee_eligibility.rst
@@ -3,7 +3,7 @@ Grantee Eligibility
 
 A grantee can be an account or one of the predefined groups. Permission
 is granted to an account by the email address or the canonical user ID.
-However, if an email address is provided in the grant request, Zenko Enterprise finds the
+However, if an email address is provided in the grant request, Zenko finds the
 canonical user ID for that account and adds it to the ACL. The resulting
 ACLs always contain the canonical user ID for the account, not the
 account’s email address.
@@ -18,7 +18,7 @@ added to the ACL with that account’s canonical user ID.
 Predefined Amazon S3 Groups
 ---------------------------
 
-Zenko Enterprise offers the use of Amazon S3 predefined groups. When granting account
+Zenko offers the use of Amazon S3 predefined groups. When granting account
 access to such a group, specify one of URIs instead of a canonical user
 ID.
 

--- a/docs/docsource/Reference/zenko_connector_api_knowledge_primers/acl_(access_control_list)_primer/index.rst
+++ b/docs/docsource/Reference/zenko_connector_api_knowledge_primers/acl_(access_control_list)_primer/index.rst
@@ -8,11 +8,11 @@ and objects.
 
 Each bucket and object has an ACL attached to it as a subresource,
 defining which accounts or groups are granted access and the type of
-access. When a request is received against a resource, Zenko Enterprise checks the
+access. When a request is received against a resource, Zenko checks the
 corresponding ACL to verify the requester has the necessary access
 permissions.
 
-When a bucket or object is created, Zenko Enterprise creates a default ACL that grants
+When a bucket or object is created, Zenko creates a default ACL that grants
 the resource owner full control over the resource as shown in the
 following sample bucket ACL (the default object ACL has the same
 structure).

--- a/docs/docsource/Reference/zenko_connector_api_knowledge_primers/acl_(access_control_list)_primer/sample_acl.rst
+++ b/docs/docsource/Reference/zenko_connector_api_knowledge_primers/acl_(access_control_list)_primer/sample_acl.rst
@@ -2,7 +2,7 @@ Sample ACL
 ==========
 
 The ACL on a bucket identifies the resource owner and a set of grants.
-The format is the XML representation of an ACL in the Zenko Enterprise API. The bucket
+The format is the XML representation of an ACL in the Zenko API. The bucket
 owner has FULL_CONTROL of the resource. In addition, the ACL shows how
 permissions are granted on a resource to two accounts, identified by
 canonical user ID, and two of the predefined Amazon S3 groups.

--- a/docs/docsource/Reference/zenko_connector_api_knowledge_primers/acl_(access_control_list)_primer/specifying_an_acl.rst
+++ b/docs/docsource/Reference/zenko_connector_api_knowledge_primers/acl_(access_control_list)_primer/specifying_an_acl.rst
@@ -1,7 +1,7 @@
 Specifying an ACL
 =================
 
-Using Zenko Enterprise, an ACL can be set at the creation point of a bucket or object.
+Using Zenko, an ACL can be set at the creation point of a bucket or object.
 An ACL can also be applied to an existing bucket or object.
 
 .. tabularcolumns:: X{0.32\textwidth}X{0.63\textwidth}

--- a/docs/docsource/Reference/zenko_connector_api_knowledge_primers/index.rst
+++ b/docs/docsource/Reference/zenko_connector_api_knowledge_primers/index.rst
@@ -1,5 +1,5 @@
-Zenko Enterprise API Knowledge Primers
-======================================
+Zenko API Knowledge Primers
+===========================
 
 .. toctree::
    :maxdepth: 2

--- a/docs/docsource/Reference/zenko_connector_api_knowledge_primers/response_headers.rst
+++ b/docs/docsource/Reference/zenko_connector_api_knowledge_primers/response_headers.rst
@@ -1,7 +1,7 @@
 Response Headers
 ================
 
-All Zenko Enterprise response headers are listed on separate lines.
+All Zenko response headers are listed on separate lines.
 
 .. _Common Response Headers:
 
@@ -110,7 +110,7 @@ Common Response Headers
    |                       |                       | versioning is         |
    |                       |                       | enabled, generates a  |
    |                       |                       | URL-ready hex string  |
-   |                       |                       | Zenko Enterprise      |
+   |                       |                       | Zenko                 |
    |                       |                       | to identify objects   |
    |                       |                       | added to a bucket. An |
    |                       |                       | example:              |


### PR DESCRIPTION
This PR replaces all instances of "Zenko Enterprise" with "Zenko."

This fixes #ZENKO-1636

