### PR TITLE
bugfix: explicit file backend

### DIFF
--- a/eve/workers/mocks/aws-mock.yaml
+++ b/eve/workers/mocks/aws-mock.yaml
@@ -38,6 +38,8 @@ spec:
       value: "1"
     - name: ENDPOINT
       value: "aws-mock"
+    - name: S3BACKEND
+      value: file
     ports:
     - name: http
       containerPort: 8000


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
Explicitly use file backend to prevent any issues when using multiple backend
 
**Which issue does this PR fix?**
fixes ZENKO-1665

**Special notes for your reviewers**:
