### PR TITLE
documentation: ZENKO-1667_remove_scality-zenko_instances

### DIFF
--- a/docs/docsource/Operation-Architecture/Zenko_CLI/index.rst
+++ b/docs/docsource/Operation-Architecture/Zenko_CLI/index.rst
@@ -24,8 +24,7 @@ S3 API
 ------
 
 Zenko supports a limited set of S3 API commands. For a comprehensive
-listing of supported S3 commands, see the *Scality Zenko Reference
-Manual (v. 1.0)*.
+listing of supported S3 commands, see the *Zenko Reference Guide*.
 
 Setup
 ~~~~~

--- a/docs/docsource/Reference/bucket_website_operations/bucket_website_specification.rst
+++ b/docs/docsource/Reference/bucket_website_operations/bucket_website_specification.rst
@@ -3,18 +3,21 @@
 Bucket Website Specification
 ============================
 
-Scality Zenko implements the `AWS S3 Bucket Website
-APIs <http://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html>`__
+Zenko implements the `AWS S3 Bucket Website APIs
+<http://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html>`__
 per the AWS specifications. This makes the objects accessible through a
 bucket website.
 
 Website Redirect Rules Attached to Particular Objects
 -----------------------------------------------------
 
-When an object is put (either through a :ref:`Put Object` call, an :ref:`Initiate Multipart Upload` call, or a :ref:`Put Object - Copy` call), an ``x-amz-website-redirect-location`` header may be added to the call. If
+When an object is put (either through a :ref:`Put Object` call, an 
+:ref:`Initiate Multipart Upload` call, or a :ref:`Put Object - Copy` call), an
+``x-amz-website-redirect-location`` header may be added to the call. If
 such a header is provided, it will be saved with an object’s metadata
-and will be retrieved on either a :ref:`Get Object` call or :ref:`Head Object` call. Requests to the object at the bucket website endpoint will be redirected to the
-location specified by the header.
+and will be retrieved on either a :ref:`Get Object` call or :ref:`Head Object`
+call. Requests to the object at the bucket website endpoint will be redirected
+to the location specified by the header.
 
 The header is described by the `AWS protocol for putting
 objects <http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html>`__.
@@ -26,7 +29,11 @@ header (the same behavior as AWS).
 Using Bucket Websites
 ---------------------
 
-To experience bucket website behavior, a user must make a request to a bucket website endpoint rather than the usual REST endpoints. Refer to `Website Endpoints <https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteEndpoints.html>`_ for the difference in response from a bucket endpoint versus the usual REST endpoint.
+To experience bucket website behavior, a user must make a request to a bucket
+website endpoint rather than the usual REST endpoints. Refer to `Website 
+Endpoints <https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteEndpoints.html>`_
+for the difference in response from a bucket endpoint versus the usual REST
+endpoint.
 
 To set up Zenko with website endpoints, in Federation env_s3 should have a
 website_endpoints section that contains a list of all desired website

--- a/docs/docsource/Reference/index.rst
+++ b/docs/docsource/Reference/index.rst
@@ -1,10 +1,5 @@
-.. Scality Zenko Reference documentation master file, created by
-   sphinx-quickstart on Mon Nov  5 19:34:16 2018.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
-Scality Zenko Reference
-=======================
+Reference Guide
+===============
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
This PR removes "Scality Zenko" in the four places it appeared in the documentation

This fixes ZENKO-1667
