### PR TITLE
bugfix: ZENKO-1677 increase tests lifecycle cron delay to 1mn

### DIFF
--- a/eve/ci-values.yaml
+++ b/eve/ci-values.yaml
@@ -128,7 +128,7 @@ backbeat:
     replicaFactor: 2
   lifecycle:
     conductor:
-      cronRule: "*/5 * * * * *"
+      cronRule: "* * * * *"
 
 grafana:
   persistentVolume:


### PR DESCRIPTION
Revert tests cron job delay to every minute, so that transitions do not
overlap on the same object. In theory nothing very bad should happen
in such case (no data loss) but it's possible that transitions cannot
occur timely and need to be retried.

