### PR TITLE
improvement: ZENKO-1628 more time between lifecycle cron jobs

### DIFF
--- a/kubernetes/zenko/charts/backbeat/values.yaml
+++ b/kubernetes/zenko/charts/backbeat/values.yaml
@@ -76,7 +76,7 @@ ingestion:
 
 lifecycle:
   conductor:
-    cronRule: "0 */5 * * * *"
+    cronRule: "0 */6 * * *"
     resources: {}
     nodeSelector: {}
     tolerations: []


### PR DESCRIPTION
Change the lifecycle cron rule to trigger every 6 hours by default, so
4 times per day.

This has been discussed as a trade-off between granularity of rule
execution, regularity to avoid too much queueing at once, while
preventing too many retries consuming unnecessary bandwidth, if some
objects cannot be transitioned for any reason.
