### PR TITLE
improvement: zenko chart version

### DIFF
--- a/kubernetes/zenko/Chart.yaml
+++ b/kubernetes/zenko/Chart.yaml
@@ -1,6 +1,6 @@
 name: zenko
-version: 1.1.0-alpha.0
-appVersion: 1.1.0-alpha.0
+version: 1.1.0-rc.1
+appVersion: 1.1.0-rc.1
 kubeVersion: ">=1.11.3"
 description: Zenko is the open source multi-cloud data controller
 home: https://www.zenko.io/
@@ -8,7 +8,6 @@ icon: https://rawgit.com/scality/Zenko/development/0.9/res/zenko.io-logo-color-c
 sources:
   - https://github.com/Scality/Zenko
 maintainers:
-  - name: giacomoguiulfo
   - name: ssalaues
   - name: tmacro
 engine: gotpl


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
Changes the version `helm ls` will display to rc.1
