### PR TITLE
bugfix: ZENKO-1730 generalize backlog metrics config

### DIFF
--- a/kubernetes/zenko/charts/backbeat/templates/lifecycle/bucket_processor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/lifecycle/bucket_processor_deployment.yaml
@@ -42,16 +42,16 @@ spec:
               value: {{ .Values.logging.level }}
             - name: COLLECT_DEFAULT_METRICS_INTERVAL_MS
               value: {{ quote .Values.monitoring.collectDefaultMetricsIntervalMs }}
+            - name: KAFKA_BACKLOG_METRICS_ZKPATH
+              value: "{{ .Values.kafka.backlog_metrics.path }}"
+            - name: KAFKA_BACKLOG_METRICS_INTERVALS
+              value: "{{ .Values.kafka.backlog_metrics.interval }}"
             - name: EXTENSIONS_LIFECYCLE_AUTH_TYPE
               value: service
             - name: EXTENSIONS_LIFECYCLE_AUTH_ACCOUNT
               value: service-lifecycle
             - name: EXTENSIONS_LIFECYCLE_ZOOKEEPER_PATH
               value: "{{ .Values.lifecycle.zookeeper.path }}"
-            - name: EXTENSIONS_LIFECYCLE_BACKLOG_METRICS_ZKPATH
-              value: "{{ .Values.lifecycle.zookeeper.backlog_metrics.path }}"
-            - name: EXTENSIONS_LIFECYCLE_BACKLOG_METRICS_INTERVALS
-              value: "{{ .Values.lifecycle.zookeeper.backlog_metrics.interval }}"
             - name: EXTENSIONS_LIFECYCLE_BUCKET_TASK_TOPIC
               value: backbeat-lifecycle-bucket-tasks
             - name: EXTENSIONS_LIFECYCLE_OBJECT_TASK_TOPIC

--- a/kubernetes/zenko/charts/backbeat/templates/lifecycle/conductor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/lifecycle/conductor_deployment.yaml
@@ -36,12 +36,12 @@ spec:
               value: {{ .Values.logging.level }}
             - name: COLLECT_DEFAULT_METRICS_INTERVAL_MS
               value: {{ quote .Values.monitoring.collectDefaultMetricsIntervalMs }}
+            - name: KAFKA_BACKLOG_METRICS_ZKPATH
+              value: "{{ .Values.kafka.backlog_metrics.path }}"
+            - name: KAFKA_BACKLOG_METRICS_INTERVALS
+              value: "{{ .Values.kafka.backlog_metrics.interval }}"
             - name: EXTENSIONS_LIFECYCLE_ZOOKEEPER_PATH
               value: "{{ .Values.lifecycle.zookeeper.path }}"
-            - name: EXTENSIONS_LIFECYCLE_BACKLOG_METRICS_ZKPATH
-              value: "{{ .Values.lifecycle.zookeeper.backlog_metrics.path }}"
-            - name: EXTENSIONS_LIFECYCLE_BACKLOG_METRICS_INTERVALS
-              value: "{{ .Values.lifecycle.zookeeper.backlog_metrics.interval }}"
             - name: EXTENSIONS_LIFECYCLE_BUCKET_TASK_TOPIC
               value: backbeat-lifecycle-bucket-tasks
             - name: EXTENSIONS_LIFECYCLE_OBJECT_TASK_TOPIC

--- a/kubernetes/zenko/charts/backbeat/templates/lifecycle/object_processor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/lifecycle/object_processor_deployment.yaml
@@ -42,16 +42,16 @@ spec:
               value: {{ .Values.logging.level }}
             - name: COLLECT_DEFAULT_METRICS_INTERVAL_MS
               value: {{ quote .Values.monitoring.collectDefaultMetricsIntervalMs }}
+            - name: KAFKA_BACKLOG_METRICS_ZKPATH
+              value: "{{ .Values.kafka.backlog_metrics.path }}"
+            - name: KAFKA_BACKLOG_METRICS_INTERVALS
+              value: "{{ .Values.kafka.backlog_metrics.interval }}"
             - name: EXTENSIONS_LIFECYCLE_AUTH_TYPE
               value: service
             - name: EXTENSIONS_LIFECYCLE_AUTH_ACCOUNT
               value: service-lifecycle
             - name: EXTENSIONS_LIFECYCLE_ZOOKEEPER_PATH
               value: "{{ .Values.lifecycle.zookeeper.path }}"
-            - name: EXTENSIONS_LIFECYCLE_BACKLOG_METRICS_ZKPATH
-              value: "{{ .Values.lifecycle.zookeeper.backlog_metrics.path }}"
-            - name: EXTENSIONS_LIFECYCLE_BACKLOG_METRICS_INTERVALS
-              value: "{{ .Values.lifecycle.zookeeper.backlog_metrics.interval }}"
             - name: EXTENSIONS_LIFECYCLE_BUCKET_TASK_TOPIC
               value: backbeat-lifecycle-bucket-tasks
             - name: EXTENSIONS_LIFECYCLE_OBJECT_TASK_TOPIC

--- a/kubernetes/zenko/charts/backbeat/values.yaml
+++ b/kubernetes/zenko/charts/backbeat/values.yaml
@@ -38,6 +38,11 @@ monitoring:
     prometheus.io/path: "/_/monitoring/metrics"
   collectDefaultMetricsIntervalMs: 10000
 
+kafka:
+  backlog_metrics:
+    path: "/backbeat/run/kafka-backlog-metrics"
+    interval: 60
+
 api:
   replicaCount: 1
   service:
@@ -107,9 +112,6 @@ lifecycle:
 
   zookeeper:
     path: "/lifecycle"
-    backlog_metrics:
-      path: "/lifecycle/run/backlog-metrics"
-      interval: 60
 
   rules:
     expiration:


### PR DESCRIPTION
Change lifecycle-specific config for kafka backlog metrics to generic
config values in kafka section.

The goal is to provide extended metrics for Kafka, that are used
internally by various services to check progress on various topics.
