### PR TITLE
improvement/ZENKO-1753 split tests into parallel stages

### DIFF
--- a/eve/ci-values.yaml
+++ b/eve/ci-values.yaml
@@ -2,13 +2,14 @@ ingress:
   enabled: true
 
 maintenance:
+  # Both options are enabled to test templating
   enabled: true
-  accessKey: HEYIMAACCESSKEY
-  secretKey: loOkAtMEImASecRetKEy123=
+  retryFailed:
+    schedule: "* 23 * * *"
+  retryPending:
+    schedule: "* 23 * * *"
   debug:
     enabled: true
-  accessKey: HEYIMAACCESSKEY
-  secretKey: loOkAtMEImASecRetKEy123=
 
 s3-data:
   persistentVolume:
@@ -46,39 +47,6 @@ zenko-queue:
     enabled: false
   rbac:
     enabled: false
-  configurationOverrides:
-    "offsets.topic.replication.factor": 1 # - replication factor for the offsets topic
-    "auto.create.topics.enable": false    # - enable auto creation of topic on the server
-    "min.insync.replicas": 1              # - min number of replicas that must acknowledge a write
-    "message.max.bytes": "5000000"        # - the largest record batch size allowed
-  topics:
-    - name: backbeat-gc
-      partitions: 1
-      replicationFactor: 1
-    - name: backbeat-ingestion
-      partitions: 1
-      replicationFactor: 1
-    - name: backbeat-lifecycle-object-tasks
-      partitions: 1
-      replicationFactor: 1
-    - name: backbeat-lifecycle-bucket-tasks
-      partitions: 1
-      replicationFactor: 1
-    - name: backbeat-metrics
-      partitions: 1
-      replicationFactor: 1
-    - name: backbeat-replication
-      partitions: 1
-      replicationFactor: 1
-    - name: backbeat-replication-status
-      partitions: 1
-      replicationFactor: 1
-    - name: backbeat-replication-failed
-      partitions: 1
-      replicationFactor: 1
-    - name: backbeat-sanitycheck
-      partitions: 1
-      replicationFactor: 1
 
 zenko-quorum:
   persistence:

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -128,7 +128,9 @@ stages:
         haltOnFailure: true
         stage_names:
         - build-doc
-        - online-zenko
+        - python-tests
+        - node-tests-01
+        - node-tests-02
 
   build-doc:
     worker:
@@ -156,17 +158,20 @@ stages:
           - "html/index.html"
           - "latex/*.pdf"
 
-  online-zenko:
+  online-zenko: &online-zenko
     worker: &kube_cluster
       type: kube_pod
       path: eve/workers/zenko.yaml
+      vars:
     steps:
     - Git: *git_pull
     - ShellCommand: *private_registry_login
     - ShellCommand: *k8s_setup
     - ShellCommand:
         name: Setup and run e2e
-        command: make -e VERBOSE=1 test
+        command: |
+          sh ../eve/scripts/only-docs.sh
+          make -e VERBOSE=1 test
         workdir: build/tests
         env:
           <<: [*secrets_env, *docker_env]
@@ -178,6 +183,10 @@ stages:
     - ShellCommand: *dump_logs
     - Upload: *upload_artifacts
     - ShellCommand: *k8s_cleanup
+
+  python-tests: *online-zenko
+  node-tests-01: *online-zenko
+  node-tests-02: *online-zenko
 
   test-latest-zenko:
     worker: *kube_cluster

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -170,7 +170,7 @@ stages:
     - ShellCommand:
         name: Setup and run e2e
         command: |
-          sh ../eve/scripts/only-docs.sh
+          . ../eve/scripts/only-docs.sh
           make -e VERBOSE=1 test
         workdir: build/tests
         env:

--- a/eve/scripts/only-docs.sh
+++ b/eve/scripts/only-docs.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+if git branch | grep \* | cut -d ' ' -f2 | grep -q '^documentation*' ; then
+    echo "On documentaion branch, checking diff"
+    diff="$(git diff --name-only HEAD~1 | grep -v docs/)"
+    if [ ! -z "$diff" ]; then
+        echo "Found files changed outside of docs directory:"
+        echo "$diff"
+    else
+        echo "Did not find files changed outside of docs directory."
+        export DOCS_ONLY=true
+        echo "Running e2e suite"
+    fi
+else
+    echo "Not documentation branch running test suite"
+fi

--- a/eve/workers/ci_env.sh
+++ b/eve/workers/ci_env.sh
@@ -6,6 +6,7 @@ if [ "$1" == "env" ]; then
   printf -- "\
 --env ZENKO_HELM_RELEASE=$ZENKO_HELM_RELEASE \
 --env HELM_NAMESPACE=$HELM_NAMESPACE \
+--env STAGE=$STAGE \
 --env NUM_CPUS=1 \
 --env INSTALL_TIMEOUT=$INSTALL_TIMEOUT "
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -145,7 +145,7 @@ install-cosbench:
 		--wait
 .PHONY: install-cosbench
 
-install-zenko:
+install-zenko: | install-tiller
 ifndef NO_INSTALL
 	$(HELM) upgrade $(ZENKO_HELM_RELEASE) \
 		--namespace $(HELM_NAMESPACE) \
@@ -210,7 +210,11 @@ test-flaky:
 	$(call run-tests)
 .PHONY: test-flaky
 
-test: | install-common install-zenko run-tests dump-logs
+ifeq ($(DOCS_ONLY),)
+test: | install-zenko install-common run-tests dump-logs
+else
+test:
+endif
 test-latest: | install-common install-latest-zenko run-tests test-flaky dump-logs
 .PHONY: test test-latest
 

--- a/tests/zenko_tests/docker-entrypoint.sh
+++ b/tests/zenko_tests/docker-entrypoint.sh
@@ -20,7 +20,17 @@ if [ "$?" -ne "0" ]; then
 fi
 
 # Run the tests
-enter_and_run python_tests "./run.sh $PYTHON_ARGS"
-enter_and_run node_tests "npm_chain.sh test_crr test_api test_crr_pause_resume test_location_quota test_bucket_get_v2"
+echo "Running test stage: $STAGE"
+if [ "$STAGE" = 'python-tests' ]; then
+    enter_and_run python_tests "./run.sh $PYTHON_ARGS"
+elif [ "$STAGE" = 'node-tests-01' ]; then
+    enter_and_run node_tests "npm_chain.sh test_aws_crr"
+elif [ "$STAGE" = 'node-tests-02' ]; then
+    enter_and_run node_tests "npm_chain.sh test_gcp_crr test_azure_crr test_one_to_many test_crr_pause_resume test_api test_location_quota test_bucket_get_v2"
+else
+    enter_and_run python_tests "./run.sh $PYTHON_ARGS"
+    # test_crr runs "test_aws_crr test_gcp_crr test_azure_crr test_one_to_many"
+    enter_and_run node_tests "npm_chain.sh test_crr test_api test_crr_pause_resume test_location_quota test_bucket_get_v2"
+fi
 
 exit "$EXIT_STATUS"

--- a/tests/zenko_tests/node_tests/package.json
+++ b/tests/zenko_tests/node_tests/package.json
@@ -17,10 +17,15 @@
     "azure-storage": "^2.10.0",
     "mocha": "^5.2.0",
     "mocha-tags": "^1.0.1",
+    "npm-run-all": "~4.0.2",
     "request": "^2.87.0"
   },
   "scripts": {
-    "test_crr": "mocha --tags ${MOCHA_TAGS} --exit -t 10000 --recursive backbeat/tests/crr",
+    "test_aws_crr": "mocha --tags ${MOCHA_TAGS} --exit -t 10000 backbeat/tests/crr/awsBackend.js",
+    "test_azure_crr": "mocha --tags ${MOCHA_TAGS} --exit -t 10000 backbeat/tests/crr/azureBackend.js",
+    "test_gcp_crr": "mocha --tags ${MOCHA_TAGS} --exit -t 10000 backbeat/tests/crr/gcpBackend.js",
+    "test_one_to_many": "mocha --tags ${MOCHA_TAGS} --exit -t 10000 backbeat/tests/crr/oneToMany.js",
+    "test_crr": "npm-run-all test_aws_crr test_azure_crr test_gcp_crr test_one_to_many",
     "test_api": "mocha --tags ${MOCHA_TAGS} --exit -t 10000 --recursive backbeat/tests/api",
     "test_retry": "mocha --tags ${MOCHA_TAGS} --exit -t 10000 --recursive backbeat/tests/retry",
     "test_crr_pause_resume": "mocha --tags ${MOCHA_TAGS} --exit -t 10000 --recursive backbeat/tests/crr-pause-resume",


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
- Splits the tests into parallel stages for quicker build times
- Slight rearrangement of the make steps to wait less for stabilization
- Bypasses pre-merge tests if on a `documentation` branch that only contains changes within the docs folder
- Removes unnecessary ci-values putting the zenko installs closer to a default

**Which issue does this PR fix?**
ZENKO-1753

**Special notes for your reviewers**:
