### PR TITLE
feature: ZENKO-1760 prometheus endpoint via healthcheck server

### DIFF
--- a/kubernetes/zenko/charts/backbeat/templates/api/deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/api/deployment.yaml
@@ -49,6 +49,8 @@ spec:
               value: "{{- printf "%s-cloudserver:80" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: MONGODB_HOSTS
               value: "{{ template "backbeat.mongodb-hosts" . }}"
+            - name: COLLECT_DEFAULT_METRICS_INTERVAL_MS
+              value: {{ quote .Values.monitoring.collectDefaultMetricsIntervalMs }}
           livenessProbe:
             httpGet:
               path: /_/healthcheck

--- a/kubernetes/zenko/charts/backbeat/templates/gc/deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/gc/deployment.yaml
@@ -15,6 +15,8 @@ spec:
       labels:
         app: {{ template "backbeat.name" . }}-gc
         release: {{ .Release.Name }}
+      annotations:
+{{ toYaml .Values.monitoring.annotations | indent 8 }}
     spec:
       containers:
         - name: gc-consumer
@@ -38,6 +40,8 @@ spec:
               value: "80"
             - name: MONGODB_HOSTS
               value: "{{ template "backbeat.mongodb-hosts" . }}"
+            - name: COLLECT_DEFAULT_METRICS_INTERVAL_MS
+              value: {{ quote .Values.monitoring.collectDefaultMetricsIntervalMs }}
           livenessProbe:
             httpGet:
               path: {{ .Values.health.path.liveness}}

--- a/kubernetes/zenko/charts/backbeat/templates/lifecycle/bucket_processor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/lifecycle/bucket_processor_deployment.yaml
@@ -15,6 +15,8 @@ spec:
       labels:
         app: {{ template "backbeat.name" . }}-lifecycle
         release: {{ .Release.Name }}
+      annotations:
+{{ toYaml .Values.monitoring.annotations | indent 8 }}
     spec:
       containers:
         - name: bucket-processor
@@ -38,6 +40,8 @@ spec:
               value: "80"
             - name: LOG_LEVEL
               value: {{ .Values.logging.level }}
+            - name: COLLECT_DEFAULT_METRICS_INTERVAL_MS
+              value: {{ quote .Values.monitoring.collectDefaultMetricsIntervalMs }}
             - name: EXTENSIONS_LIFECYCLE_AUTH_TYPE
               value: service
             - name: EXTENSIONS_LIFECYCLE_AUTH_ACCOUNT

--- a/kubernetes/zenko/charts/backbeat/templates/lifecycle/conductor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/lifecycle/conductor_deployment.yaml
@@ -15,6 +15,8 @@ spec:
       labels:
         app: {{ template "backbeat.name" . }}-lifecycle
         release: {{ .Release.Name }}
+      annotations:
+{{ toYaml .Values.monitoring.annotations | indent 8 }}
     spec:
       containers:
         - name: conductor
@@ -32,6 +34,8 @@ spec:
               value: "{{- printf "%s-zenko-queue:9092" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: LOG_LEVEL
               value: {{ .Values.logging.level }}
+            - name: COLLECT_DEFAULT_METRICS_INTERVAL_MS
+              value: {{ quote .Values.monitoring.collectDefaultMetricsIntervalMs }}
             - name: EXTENSIONS_LIFECYCLE_ZOOKEEPER_PATH
               value: "{{ .Values.lifecycle.zookeeper.path }}"
             - name: EXTENSIONS_LIFECYCLE_BACKLOG_METRICS_ZKPATH

--- a/kubernetes/zenko/charts/backbeat/templates/lifecycle/object_processor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/lifecycle/object_processor_deployment.yaml
@@ -15,6 +15,8 @@ spec:
       labels:
         app: {{ template "backbeat.name" . }}-lifecycle
         release: {{ .Release.Name }}
+      annotations:
+{{ toYaml .Values.monitoring.annotations | indent 8 }}
     spec:
       containers:
         - name: object-processor
@@ -38,6 +40,8 @@ spec:
               value: "80"
             - name: LOG_LEVEL
               value: {{ .Values.logging.level }}
+            - name: COLLECT_DEFAULT_METRICS_INTERVAL_MS
+              value: {{ quote .Values.monitoring.collectDefaultMetricsIntervalMs }}
             - name: EXTENSIONS_LIFECYCLE_AUTH_TYPE
               value: service
             - name: EXTENSIONS_LIFECYCLE_AUTH_ACCOUNT

--- a/kubernetes/zenko/charts/backbeat/templates/replication/data_processor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/replication/data_processor_deployment.yaml
@@ -18,6 +18,8 @@ spec:
       labels:
         app: {{ template "backbeat.name" . }}-replication
         release: {{ .Release.Name }}
+      annotations:
+{{ toYaml .Values.monitoring.annotations | indent 8 }}
     spec:
       {{- if not .Values.global.orbit.enabled }}
       initContainers:
@@ -57,6 +59,8 @@ spec:
               value: {{ .Values.logging.level }}
             - name: UV_THREADPOOL_SIZE
               value: "64"
+            - name: COLLECT_DEFAULT_METRICS_INTERVAL_MS
+              value: {{ quote .Values.monitoring.collectDefaultMetricsIntervalMs }}
             - name: EXTENSIONS_REPLICATION_SOURCE_S3_HOST
               value: "{{- printf "%s-cloudserver" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: EXTENSIONS_REPLICATION_SOURCE_S3_PORT

--- a/kubernetes/zenko/charts/backbeat/templates/replication/populator_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/replication/populator_deployment.yaml
@@ -18,6 +18,8 @@ spec:
       labels:
         app: {{ template "backbeat.name" . }}-replication
         release: {{ .Release.Name }}
+      annotations:
+{{ toYaml .Values.monitoring.annotations | indent 8 }}
     spec:
       containers:
         - name: replication-populator
@@ -58,6 +60,8 @@ spec:
               value: "{{ .Values.redis.sentinel.name }}"
             - name: LOG_LEVEL
               value: {{ .Values.logging.level }}
+            - name: COLLECT_DEFAULT_METRICS_INTERVAL_MS
+              value: {{ quote .Values.monitoring.collectDefaultMetricsIntervalMs }}
           livenessProbe:
             httpGet:
               path: {{ .Values.health.path.liveness}}

--- a/kubernetes/zenko/charts/backbeat/templates/replication/status_processor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/replication/status_processor_deployment.yaml
@@ -18,6 +18,8 @@ spec:
       labels:
         app: {{ template "backbeat.name" . }}-replication
         release: {{ .Release.Name }}
+      annotations:
+{{ toYaml .Values.monitoring.annotations | indent 8 }}
     spec:
       containers:
         - name: replication-status-processor
@@ -60,6 +62,8 @@ spec:
               value: "{{ .Values.redis.sentinel.name }}"
             - name: LOG_LEVEL
               value: {{ .Values.logging.level }}
+            - name: COLLECT_DEFAULT_METRICS_INTERVAL_MS
+              value: {{ quote .Values.monitoring.collectDefaultMetricsIntervalMs }}
           livenessProbe:
             httpGet:
               path: {{ .Values.health.path.liveness}}

--- a/kubernetes/zenko/charts/backbeat/values.yaml
+++ b/kubernetes/zenko/charts/backbeat/values.yaml
@@ -31,6 +31,13 @@ health:
   path:
     liveness: /_/health/readiness
 
+monitoring:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "4042"
+    prometheus.io/path: "/_/monitoring/metrics"
+  collectDefaultMetricsIntervalMs: 10000
+
 api:
   replicaCount: 1
   service:


### PR DESCRIPTION
Expose Prometheus metrics via a new route in healthcheck server, for
the following backbeat components:

- lifecycle conductor
- lifecycle bucket processor
- lifecycle object processor
- queue populator
- replication data processor
- replication status processor
- garbage collector
