### PR TITLE
documentation: ZENKO-195_S3C_OOB_Updates_Reference_Guide

### DIFF
--- a/docs/docsource/Reference/bucket_ingestion_metrics/get_all_metrics.rst
+++ b/docs/docsource/Reference/bucket_ingestion_metrics/get_all_metrics.rst
@@ -1,0 +1,38 @@
+GET All Metrics
+===============
+
+This request retrieves all metrics for all S3 Connector metadata
+ingestion locations. Zenko returns three categories of information
+(metrics) about system operations: completions, throughput, and 
+pending operations. Completions are returned for the preceding 24
+hours, throughput for the preceding 15 minutes, and pending
+transactions are returned as a simple aggregate.
+
+**Endpoint**
+
+/_/metrics/ingestion/all
+
+**Sample Response**
+
+.. code::
+
+   {
+     "completions": {
+       "description": "Number of completed ingestion operations (count) in the last 86400 seconds",
+       "results": {
+         "count":678979
+       }
+     },
+     "throughput": {
+       "description": "Current throughput for ingestion operations in ops/sec (count) in the last 900 seconds",
+       "results": {
+         "count":"34.25"
+       }
+     },
+     "pending": {
+       "description": "Number of pending ingestion operations (count)",
+       "results": {
+         "count":253417
+       }
+     }
+   }

--- a/docs/docsource/Reference/bucket_ingestion_metrics/get_completions_per_location.rst
+++ b/docs/docsource/Reference/bucket_ingestion_metrics/get_completions_per_location.rst
@@ -1,0 +1,22 @@
+GET Completions per Location
+============================
+
+This request retrieves the number of operations Zenko ingested
+(completed) from a specific location over the preceding 24 hours.
+
+**Endpoint**
+
+/_/metrics/ingestion/<location>/completions
+
+**Sample Response**
+
+.. code::
+
+   {
+     "completions": {
+       "description":"Number of completed ingestion operations (count) in the last 86400 seconds",
+       "results": {
+         "count":668900
+       }
+     }
+   }

--- a/docs/docsource/Reference/bucket_ingestion_metrics/get_metrics_per_location.rst
+++ b/docs/docsource/Reference/bucket_ingestion_metrics/get_metrics_per_location.rst
@@ -1,0 +1,38 @@
+GET Metrics for a Location
+==========================
+
+This request retrieves metrics for a single location, defined as a 
+bucket in the Orbit UI. 
+
+The response from the endpoint is formatted identically to the
+Get All Metrics request, (completions, throughput, and pending 
+operations) but constrained to the requested location only.
+
+**Endpoint**
+
+/_/metrics/ingestion/<location>/all
+
+**Sample Response**
+
+.. code::
+
+   {
+     "completions": {
+       "description": "Number of completed ingestion operations (count) in the last 86400 seconds",
+       "results": {
+         "count":678979
+       }
+     },
+     "throughput": {
+       "description": "Current throughput for ingestion operations in ops/sec (count) in the last 900 seconds",
+       "results": {
+         "count":"34.25"
+       }
+     },
+     "pending": {
+       "description": "Number of pending ingestion operations (count)",
+       "results": {
+         "count":253417
+       }
+     }
+   }

--- a/docs/docsource/Reference/bucket_ingestion_metrics/get_pending_object_count.rst
+++ b/docs/docsource/Reference/bucket_ingestion_metrics/get_pending_object_count.rst
@@ -1,0 +1,22 @@
+GET Pending Object Count
+========================
+
+This request retrieves the number of objects queued for Zenko 
+ingestion. 
+
+**Endpoint**
+
+/_/metrics/ingestion/<location>/pending
+
+**Sample Response**
+
+.. code::
+
+   {
+     "pending": {
+       "description":"Number of pending ingestion operations (count)",
+       "results": {
+         "count":253409
+       }
+     }
+   }

--- a/docs/docsource/Reference/bucket_ingestion_metrics/get_throughput_rate_per_location.rst
+++ b/docs/docsource/Reference/bucket_ingestion_metrics/get_throughput_rate_per_location.rst
@@ -1,0 +1,22 @@
+GET Throughput per Location
+===========================
+
+This request queries the managed S3 namespace for throughput, expressed as 
+operations per second, over the preceding 15 minutes.
+
+**Endpoint** 
+
+/_/metrics/ingestion/<location>/throughput
+
+**Sample Response**
+
+.. code::
+
+   {
+     "throughput": {
+       "description":"Current throughput for ingestion operations in ops/sec (count) in the last 900 seconds",
+       "results": {
+         "count":"25.72"
+       }
+     }
+   }

--- a/docs/docsource/Reference/bucket_ingestion_metrics/index.rst
+++ b/docs/docsource/Reference/bucket_ingestion_metrics/index.rst
@@ -1,0 +1,30 @@
+Bucket Ingestion Metrics
+========================
+
+Zenko can make queries against S3 Connector instances named as bucket
+locations under its management. Querying the managed namespace, Zenko
+can retrieve information about the number of transfers completed and
+pending, and the rate at which they are completing.
+
+Zenko provides a REST API that makes these metrics available to users. To
+access these, make a request to the endpoints as specified in the following
+sections. Enter the listed endpoints verbatim, substituting a location 
+that matches the bucket/location queried if the query requires it.
+
+For example,
+
+.. code::
+
+   $ curl http://zenko-instance.net/_/metrics/ingestion/us-west-video-dailies/all
+
+where zenko-instance.net is the Zenko server's URL and us-west-video-dailies
+is the bucket name (location).
+
+.. toctree::
+   :maxdepth: 2
+
+   get_all_metrics
+   get_metrics_per_location
+   get_throughput_rate_per_location
+   get_completions_per_location
+   get_pending_object_count

--- a/docs/docsource/Reference/bucket_operations/get_bucket_location.rst
+++ b/docs/docsource/Reference/bucket_operations/get_bucket_location.rst
@@ -3,15 +3,15 @@
 GET Bucket Location
 ===================
 
-The GET Bucket Location operation uses the locationsubresource to return
+The GET Bucket Location operation uses the location subresource to return
 a bucket’s location. The bucket’s location is set up using the
-LocationConstraint request parameter in a PUT Bucket request. Refer to :ref:`PUT Bucket`.
+LocationConstraint request parameter in a PUT Bucket request. Refer to 
+:ref:`PUT Bucket`.
 
 .. note::
 
   The possible options for a LocationConstraint are configured in the
-  env_s3 setting of the S3 Configuration. For more information, refer to
-  “Modifying the Group Variables (all) File” in Zenko Installation.
+  env_s3 setting of the S3 Configuration.
 
 Requests
 --------
@@ -65,12 +65,7 @@ in the response:
    |                       |                       | parameter is          |
    |                       |                       | configured in the     |
    |                       |                       | env_s3 setting of the |
-   |                       |                       | S3 Configuration. For |
-   |                       |                       | more information,     |
-   |                       |                       | refer to “Modifying   |
-   |                       |                       | the Group Variables   |
-   |                       |                       | (all) File” in        |
-   |                       |                       | Zenko Installation.   |
+   |                       |                       | S3 Configuration.     |
    +-----------------------+-----------------------+-----------------------+
 
 Examples

--- a/docs/docsource/Reference/index.rst
+++ b/docs/docsource/Reference/index.rst
@@ -11,6 +11,7 @@ Reference Guide
    bucket_website_operations/index
    bucket_cors_operations/index
    bucket_lifecycle_operations/index
+   bucket_ingestion_metrics/index
    object_operations/index
    backbeat/index
    zenko_connector_api_knowledge_primers/index


### PR DESCRIPTION
This PR: 
Adds a section on bucket ingestion metrics.
Fixes a typo.
Gets rid of legacy S3C documentation references.

We need it because it is best for documentation to be comprehensive, accurate, and timely. 

This fixes, in part, #ZENKO-195. 