### PR TITLE
ft(ZENKO-1769): Lower backbeat replication retry timeouts for CI

### DIFF
--- a/eve/ci-values.yaml
+++ b/eve/ci-values.yaml
@@ -96,6 +96,31 @@ backbeat:
     pullPolicy: Always
   replication:
     replicaFactor: 2
+    retry:
+      aws_s3:
+        timeoutS: 900
+        maxRetries: 5
+        backoff:
+          min: 2000
+          max: 10000
+          jitter: 0.1
+          factor: 1.5
+      azure:
+        timeoutS: 900
+        maxRetries: 5
+        backoff:
+          min: 2000
+          max: 10000
+          jitter: 0.1
+          factor: 1.5
+      gcp:
+        timeoutS: 900
+        maxRetries: 5
+        backoff:
+          min: 2000
+          max: 10000
+          jitter: 0.1
+          factor: 1.5
   lifecycle:
     conductor:
       cronRule: "* * * * *"


### PR DESCRIPTION
<!--
Thank you for contributing to Zenko!

Please enter applicable information below.
-->

**What does this PR do, and why do we need it?**
Lowers the range of time backbeat waits before retrying a failed replication to 2-10 seconds. Transient errors such as socket hangups can cause replication to fail, which coupled with a 1 minute initial timeout would cause tests to timeout before backbeat has a chance to retry. This should reduce flakiness by allowing backbeat to retry objects before a test timeouts and fails.

