### PR TITLE
bf: safely handle multiple ingestion buckets

### DIFF
--- a/cosmos/scheduler/Makefile
+++ b/cosmos/scheduler/Makefile
@@ -1,5 +1,5 @@
 COSMOS_IMAGE := zenko/cosmos-scheduler
-COSMOS_TAG := 0.2.1
+COSMOS_TAG := 0.2.2
 COSMOS_BINARY := ./scheduler
 
 .PHONY: setup

--- a/kubernetes/zenko/values.yaml
+++ b/kubernetes/zenko/values.yaml
@@ -126,7 +126,7 @@ cosmos:
   scheduler:
     image:
       repository: zenko/cosmos-scheduler
-      tag: 0.2.1
+      tag: 0.2.2
       pullPolicy: IfNotPresent
 
     ## A namespace to watch can be specified otherwise will default to the


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
This safely handles when an additional ingestion bucket is created. It does this
by using a label with the bucket value that is referenced when attempting to
`ApplyChanges`.

**Which issue does this PR fix?**
ZENKO-1756