### PR TITLE
ZENKO-1776: package logs as .tar.gz files for easier download

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -35,7 +35,7 @@ models:
   - Upload: &upload_artifacts
       source: tests/artifacts
       urls:
-        - "*"
+        - "*.tar.gz"
   - ShellCommand: &private_registry_login
       name: Private Registry Login
       command: >

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -227,8 +227,10 @@ dump-logs: | artifacts
 	$(V)(kubectl  -n $(HELM_NAMESPACE) get pods -o go-template --template '$(ZENKO_PODS)') | xargs -n 1 -r sh -c;  \
 	(kubectl -n $(HELM_NAMESPACE) get pods -o jsonpath='$(E2E_LOG_PODS)') | \
 	while read -r pod; do \
+		kubectl -n $(HELM_NAMESPACE) logs $${pod} --previous=true; \
 		kubectl -n $(HELM_NAMESPACE) logs $${pod}; \
 	done;
+	tar -czvf ./artifacts/$(HELM_NAMESPACE).tar.gz ./artifacts
 .PHONY: dump-logs
 
 clean-s3c:


### PR DESCRIPTION
**What does this PR do, and why do we need it?**

Package the logs so it's easier to download.

Also fixes issue where queue and quorum pod logs are not dumped properly. Currently there are 3 tests run on 3 parallel zenko instances, but for each zenko instance, the queue and quorum pods do not have unique names. When the logs are being dumped, those logs will be overwritten. 

**Which issue does this PR fix?**

fixes ZENKO-1776
