### PR TITLE
bugfix: ZENKO-1778 Remove duplicate test coverage

### DIFF
--- a/tests/zenko_tests/python_tests/zenko_e2e/cloudserver/test_mpu.py
+++ b/tests/zenko_tests/python_tests/zenko_e2e/cloudserver/test_mpu.py
@@ -3,6 +3,7 @@ from ..fixtures import *
 from .. import util
 
 
+@pytest.mark.skip(reason='test case covered')
 @pytest.mark.flaky(reruns=3)
 @pytest.mark.conformance
 def test_mpu_aws(aws_ep_bucket, aws_target_bucket, mpufile, objkey):
@@ -25,6 +26,7 @@ def test_mpu_gcp(gcp_ep_bucket, gcp_target_bucket, mpufile, objkey):
         objkey, mpufile, gcp_ep_bucket, gcp_target_bucket, timeout=60)
 
 
+@pytest.mark.skip(reason='test case covered')
 @pytest.mark.flaky(reruns=3)
 @pytest.mark.conformance
 def test_mpu_azure(azure_ep_bucket, azure_target_bucket, mpufile, objkey):

--- a/tests/zenko_tests/python_tests/zenko_e2e/cloudserver/test_replication.py
+++ b/tests/zenko_tests/python_tests/zenko_e2e/cloudserver/test_replication.py
@@ -10,6 +10,7 @@ logging.basicConfig(level=logging.INFO,
                     datefmt='%S')
 
 
+@pytest.mark.skip(reason='test case covered')
 @pytest.mark.flaky(reruns=3)
 @pytest.mark.parametrize('datafile', [testfile, mpufile])
 @pytest.mark.conformance
@@ -32,6 +33,7 @@ def test_gcp_1_1(gcp_crr_bucket, gcp_crr_target_bucket, objkey, datafile):
         objkey, data, gcp_crr_bucket, gcp_crr_target_bucket, timeout=300)
 
 
+@pytest.mark.skip(reason='test case covered')
 @pytest.mark.flaky(reruns=3)
 @pytest.mark.parametrize('datafile', [testfile, mpufile])
 @pytest.mark.conformance


### PR DESCRIPTION
Some tests cases are covered by both python and node.js CRR test suites.

This change will run certain node.js tests in favor or python tests because the latter have been tracked as failing more frequently.