### PR TITLE
bugfix: incorrect cb name

### DIFF
--- a/tests/zenko_tests/node_tests/backbeat/tests/ingestion/ingestionS3C.js
+++ b/tests/zenko_tests/node_tests/backbeat/tests/ingestion/ingestionS3C.js
@@ -116,7 +116,7 @@ describe('Ingesting existing data from RING S3C bucket', () => {
             }, (err, data) => next(err, zenkoData, data)),
         ], (err, zenkoData, s3cData) => {
             if (err) {
-                return cb(err);
+                return done(err);
             }
             assert.strictEqual(zenkoData.Versions.length, s3cData.Versions.length);
             assert.strictEqual(zenkoData.DeleteMarkers.length, s3cData.DeleteMarkers.length);


### PR DESCRIPTION
The cb function for one of the tests is incorrect

fixes ZENKO-1780
