### PR TITLE
bugfix: ZENKO-1004 Unskip one-to-many tests

### DIFF
--- a/tests/zenko_tests/node_tests/backbeat/tests/crr/oneToMany.js
+++ b/tests/zenko_tests/node_tests/backbeat/tests/crr/oneToMany.js
@@ -75,24 +75,4 @@ function() {
         next => utils.compareObjectsOneToMany(srcBucket, awsDestBucket,
             destContainer, gcpDestBucket, key, next),
     ], done));
-
-    it('should replicate a MPU object: 10 parts', done => series([
-        next => utils.completeMPUAWS(srcBucket, key, 10, next),
-        next => utils.compareObjectsOneToMany(srcBucket, awsDestBucket,
-            destContainer, gcpDestBucket, key, next),
-    ], done));
-
-    [undefined,
-    `0-${1024 * 1024 * 5}`,
-    `${1024 * 1024 * 2}-${1024 * 1024 * 7}`].forEach(range =>
-        it('should replicate a MPU with parts copied from another MPU with ' +
-        `byte range '${range}' for each part`, done => series([
-            next => utils.completeMPUAWS(srcBucket, key, 2, next),
-            next => utils.completeMPUWithPartCopy(srcBucket, copyKey,
-                copySource, range, 2, next),
-            next => utils.compareObjectsOneToMany(srcBucket, awsDestBucket,
-                destContainer, gcpDestBucket, copyKey, next),
-            // avoid a race with cleanup by ensuring everything is replicated
-            next => utils.waitUntilReplicated(srcBucket, key, undefined, next),
-        ], done)));
 });

--- a/tests/zenko_tests/node_tests/backbeat/tests/crr/oneToMany.js
+++ b/tests/zenko_tests/node_tests/backbeat/tests/crr/oneToMany.js
@@ -28,9 +28,7 @@ const copyKey = `${key}-copy`;
 const copySource = `/${srcBucket}/${key}`;
 const REPLICATION_TIMEOUT = 300000;
 
-
-tags('flaky') // Tracking via ZENKO-1004
-.describe('Replication with AWS, Azure, and GCP backends (one-to-many)',
+describe('Replication with AWS, Azure, and GCP backends (one-to-many)',
 function() {
     this.timeout(REPLICATION_TIMEOUT);
     this.retries(3);

--- a/tests/zenko_tests/python_tests/zenko_e2e/cloudserver/test_replication.py
+++ b/tests/zenko_tests/python_tests/zenko_e2e/cloudserver/test_replication.py
@@ -77,6 +77,7 @@ def test_wasabi_1_1(wasabi_crr_bucket,
         wasabi_crr_target_bucket)
 
 
+@pytest.mark.skip(reason='test case covered')
 @pytest.mark.flaky(reruns=1)
 @pytest.mark.parametrize('datafile', [testfile, mpufile])
 @pytest.mark.conformance


### PR DESCRIPTION
Un-skip one-to-many tests and remove duplicate test cases.