### PR TITLE
bugfix: ZENKO-1777 reduce transient source test flakiness

### DIFF
--- a/tests/zenko_tests/python_tests/zenko_e2e/cloudserver/test_transient_src.py
+++ b/tests/zenko_tests/python_tests/zenko_e2e/cloudserver/test_transient_src.py
@@ -11,7 +11,7 @@ def test_transient_src(transient_src_bucket, transient_target_bucket,
     util.mark_test('TRANSIENT SOURCE')
     util.upload_object(transient_src_bucket, objkey, testfile)
     assert util.check_object(
-        objkey, testfile, transient_target_bucket, timeout=30)
+        objkey, testfile, transient_target_bucket, timeout=300)
     then = datetime.utcnow()
     passed = False
     while datetime.utcnow() - then < TIMEOUT:


### PR DESCRIPTION
Increase timeout of util.check_object() from 30 seconds to 5 minutes,
as replication can take significant time to complete it should help
reduce flakiness.
