### PR TITLE
ci: fix setup race

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -302,7 +302,7 @@ test-flaky:
 .PHONY: test-flaky
 
 ifeq ($(DOCS_ONLY),)
-test: | install-zenko install-common run-tests dump-logs
+test: | install-common install-zenko run-tests dump-logs
 else
 test:
 endif


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
This commit fixes a bug introduced in #652 which attempted to optimize setup
time by rearranging the build steps. This however caused a race between the
Zenko setup and the orbit-sim setup. This reverts the change allowing orbit-sim
to setup first prior to Zenko.

**Which issue does this PR fix?**
ZENKO-1792

**Special notes for your reviewers**:
