### PR TITLE
improvement: include readinessProbe for cloudserver

### DIFF
--- a/kubernetes/zenko/charts/cloudserver/templates/deployment.yaml
+++ b/kubernetes/zenko/charts/cloudserver/templates/deployment.yaml
@@ -74,6 +74,10 @@ spec:
             httpGet:
               path: /_/healthcheck
               port: http
+          readinessProbe:
+            httpGet:
+              path: /_/healthcheck/deep
+              port: http
           volumeMounts:
             {{- if .Values.proxy.caCert }}
             - name: proxy-cert

--- a/kubernetes/zenko/charts/cloudserver/templates/manager-deployment.yaml
+++ b/kubernetes/zenko/charts/cloudserver/templates/manager-deployment.yaml
@@ -44,6 +44,10 @@ spec:
             httpGet:
               path: /_/healthcheck
               port: http
+          readinessProbe:
+            httpGet:
+              path: /_/healthcheck/deep
+              port: http
           volumeMounts:
             {{- if .Values.proxy.caCert }}
             - name: proxy-cert


### PR DESCRIPTION
Zenko-1800

This PR sets up a readiness probe on cloudserver so requests don't get sent to it until it's fully ready.

Will be running the builds a few times to check if it helps.