### PR TITLE
bugfix(ZENKO-1779): Improve flaky ceph tests

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -256,7 +256,7 @@ run-tests: | build-tests
 		--restart=Never \
 		--image=$(E2E_IMAGE)  \
 		--namespace $(HELM_NAMESPACE) \
-		--limits='cpu=500m,memory=1.5Gi' \
+		--limits='cpu=500m,memory=2Gi' \
 		--requests='cpu=500m,memory=1.5Gi' \
 		--env MOCHA_TAGS="$(NODE_TEST_TAGS)" \
 		--env CLOUDSERVER_ENDPOINT="http://$(ZENKO_HELM_RELEASE)-cloudserver:80" \

--- a/tests/zenko_tests/python_tests/tox.ini
+++ b/tests/zenko_tests/python_tests/tox.ini
@@ -32,12 +32,14 @@ passenv =
     CUSTOM_COMPILE_COMMAND
 
 [flake8]
-exclude = .tox,dist,*egg,build,venv,.venv,create_buckets.py
 max-line-length = 120
+exclude = .tox,dist,*egg,build,venv,.venv,create_buckets.py
 # F401	module imported but unused
 # F403	‘from module import *’ used; unable to detect undefined names
 # F405	name may be undefined, or defined from star imports: module
-ignore = F403, F401, F405
+# E402: module level import not at top of file -- to install logging filters
+
+ignore = F403, F401, F405, E402
 
 # Pylint configuration
 [MESSAGES CONTROL]
@@ -45,5 +47,5 @@ max-line-length = 120
 # C0111: Missing %s docstring -- not required for tests
 # W0621: Redefining name %r from outer scope -- required for pytest fixtures
 # W0511: TODO and related comments
-# W0614 Unused import XYZ from wildcard import
+# W0614: Unused import XYZ from wildcard import
 disable=C0111,W0621,W0511, W0614, wildcard-import, import-error

--- a/tests/zenko_tests/python_tests/zenko_e2e/__init__.py
+++ b/tests/zenko_tests/python_tests/zenko_e2e/__init__.py
@@ -1,0 +1,19 @@
+import logging
+
+class Blacklist(logging.Filter):  # noqa pylint: disable=too-few-public-methods
+    def __init__(self, *blacklist):  # pylint: disable=super-init-not-called
+        self.blacklist = [logging.Filter(name) for name in blacklist]
+
+    def filter(self, record):
+        return not any(f.filter(record) for f in self.blacklist)
+
+
+BLACKLIST = [
+    'botocore.vendored.requests.packages.urllib3.connectionpool',
+    'azure.storage.common.storageclient',
+    'storageclient.py',
+    'connectionpool.py',
+]
+
+for handler in logging.root.handlers:
+    handler.addFilter(Blacklist(*BLACKLIST))

--- a/tests/zenko_tests/python_tests/zenko_e2e/cloudserver/test_crr_retry.py
+++ b/tests/zenko_tests/python_tests/zenko_e2e/cloudserver/test_crr_retry.py
@@ -11,4 +11,4 @@ def test_crr_retry(aws_crr_bucket, aws_crr_target_bucket, testfile, objkey):
     )
     util.remark('Finished uploading')
     assert util.check_object(
-        objkey, testfile, aws_crr_bucket, aws_crr_target_bucket, timeout=30)
+        objkey, testfile, aws_crr_bucket, aws_crr_target_bucket)

--- a/tests/zenko_tests/python_tests/zenko_e2e/cloudserver/test_mpu.py
+++ b/tests/zenko_tests/python_tests/zenko_e2e/cloudserver/test_mpu.py
@@ -11,7 +11,7 @@ def test_mpu_aws(aws_ep_bucket, aws_target_bucket, mpufile, objkey):
     util.upload_object(aws_ep_bucket, objkey, mpufile)
     util.remark('Done uploading file, downloading and checking hash')
     assert util.check_object(
-        objkey, mpufile, aws_ep_bucket, aws_target_bucket, timeout=60)
+        objkey, mpufile, aws_ep_bucket, aws_target_bucket)
 
 
 @pytest.mark.flaky(reruns=3)
@@ -22,7 +22,7 @@ def test_mpu_gcp(gcp_ep_bucket, gcp_target_bucket, mpufile, objkey):
     util.upload_object(gcp_ep_bucket, objkey, mpufile)
     util.remark('Done uploading file, downloading and checking hash')
     assert util.check_object(
-        objkey, mpufile, gcp_ep_bucket, gcp_target_bucket, timeout=60)
+        objkey, mpufile, gcp_ep_bucket, gcp_target_bucket)
 
 
 @pytest.mark.flaky(reruns=3)
@@ -33,7 +33,7 @@ def test_mpu_azure(azure_ep_bucket, azure_target_bucket, mpufile, objkey):
     util.upload_object(azure_ep_bucket, objkey, mpufile)
     util.remark('Done uploading file, downloading and checking hash')
     assert util.check_object(
-        objkey, mpufile, azure_ep_bucket, azure_target_bucket, timeout=60)
+        objkey, mpufile, azure_ep_bucket, azure_target_bucket)
 
 
 @pytest.mark.conformance
@@ -43,7 +43,7 @@ def test_mpu_ceph(ceph_ep_bucket, ceph_target_bucket, mpufile, objkey):
     util.upload_object(ceph_ep_bucket, objkey, mpufile)
     util.remark('Done uploading file, downloading and checking hash')
     assert util.check_object(
-        objkey, mpufile, ceph_ep_bucket, ceph_target_bucket, timeout=60)
+        objkey, mpufile, ceph_ep_bucket, ceph_target_bucket)
 
 
 @pytest.mark.skip(reason='Wasabi not implemented in CI')

--- a/tests/zenko_tests/python_tests/zenko_e2e/cloudserver/test_replication.py
+++ b/tests/zenko_tests/python_tests/zenko_e2e/cloudserver/test_replication.py
@@ -18,7 +18,7 @@ def test_aws_1_1(aws_crr_bucket, aws_crr_target_bucket, objkey, datafile):
     data = datafile()
     util.upload_object(aws_crr_bucket, objkey, data)
     assert util.check_object(
-        objkey, data, aws_crr_bucket, aws_crr_target_bucket, timeout=300)
+        objkey, data, aws_crr_bucket, [aws_crr_target_bucket])
 
 
 @pytest.mark.flaky(reruns=3)
@@ -29,7 +29,7 @@ def test_gcp_1_1(gcp_crr_bucket, gcp_crr_target_bucket, objkey, datafile):
     data = datafile()
     util.upload_object(gcp_crr_bucket, objkey, data)
     assert util.check_object(
-        objkey, data, gcp_crr_bucket, gcp_crr_target_bucket, timeout=300)
+        objkey, data, gcp_crr_bucket, [gcp_crr_target_bucket])
 
 
 @pytest.mark.flaky(reruns=3)
@@ -41,7 +41,7 @@ def test_azure_1_1(
     data = datafile()
     util.upload_object(azure_crr_bucket, objkey, data)
     assert util.check_object(
-        objkey, data, azure_crr_bucket, azure_crr_target_bucket, timeout=300)
+        objkey, data, azure_crr_bucket, [azure_crr_target_bucket])
 
 
 @pytest.mark.parametrize('datafile', [testfile, mpufile])
@@ -50,9 +50,15 @@ def test_ceph_1_1(
         ceph_crr_bucket, ceph_crr_target_bucket, objkey, datafile):
     util.mark_test('CEPH 1-1 REPLICATION')
     data = datafile()
-    util.upload_object(ceph_crr_bucket, objkey, data)
+    success, ver_id = util.upload_object(ceph_crr_bucket, objkey, data)
+    assert success
     assert util.check_object(
-        objkey, data, ceph_crr_bucket, ceph_crr_target_bucket, timeout=300)
+        objkey,
+        data,
+        ceph_crr_bucket,
+        [ceph_crr_target_bucket],
+        version_id=ver_id
+    )
 
 
 @pytest.mark.skip(reason='Wasabi not implemented in CI')
@@ -67,8 +73,7 @@ def test_wasabi_1_1(wasabi_crr_bucket,
         objkey,
         testfile,
         wasabi_crr_bucket,
-        wasabi_crr_target_bucket,
-        timeout=30)
+        wasabi_crr_target_bucket)
 
 
 @pytest.mark.flaky(reruns=1)
@@ -86,7 +91,7 @@ def test_multi_1_M(  # pylint: disable=invalid-name, too-many-arguments
     util.upload_object(multi_crr_bucket, objkey, data)
     assert util.check_object(objkey, data,
                              multi_crr_bucket,
-                             aws_crr_target_bucket,
-                             gcp_crr_target_bucket,
-                             azure_crr_target_bucket,
-                             timeout=300)
+                             [
+                                 aws_crr_target_bucket,
+                                 gcp_crr_target_bucket,
+                                 azure_crr_target_bucket])

--- a/tests/zenko_tests/python_tests/zenko_e2e/cloudserver/test_transient_src.py
+++ b/tests/zenko_tests/python_tests/zenko_e2e/cloudserver/test_transient_src.py
@@ -11,7 +11,7 @@ def test_transient_src(transient_src_bucket, transient_target_bucket,
     util.mark_test('TRANSIENT SOURCE')
     util.upload_object(transient_src_bucket, objkey, testfile)
     assert util.check_object(
-        objkey, testfile, transient_target_bucket, timeout=300)
+        objkey, testfile, transient_target_bucket, tries=2)
     then = datetime.utcnow()
     passed = False
     while datetime.utcnow() - then < TIMEOUT:

--- a/tests/zenko_tests/python_tests/zenko_e2e/conftest.py
+++ b/tests/zenko_tests/python_tests/zenko_e2e/conftest.py
@@ -1,8 +1,12 @@
+# flake8: noqa
+# pylint: disable=wrong-import-position
 import os
 import os.path
 
-import boto3
 
+
+# NOTE These are import here to allow us to install the logging filters above
+import boto3
 import pytest
 
 import zenko_e2e.prometheus.client

--- a/tests/zenko_tests/python_tests/zenko_e2e/util/bucket.py
+++ b/tests/zenko_tests/python_tests/zenko_e2e/util/bucket.py
@@ -4,6 +4,7 @@ import hashlib
 import tempfile
 import time
 from boto3.s3.transfer import TransferConfig
+from botocore.exceptions import ClientError, WaiterError
 import requests
 from awsauth import S3Auth
 import zenko_e2e.conf as conf
@@ -37,12 +38,15 @@ def enable_versioning(bucket):
     bucket.Versioning().enable()
 
 
-def get_object_hash(bucket, key, timeout=0, backoff=5, _timestamp=None):
+def get_object_hash(bucket, key, timeout=0, backoff=5, versionid=None, _timestamp=None):
     if _timestamp is None:
         _timestamp = time.time()
+    extra_args = {}
+    if versionid is not None:
+        extra_args['VersionId'] = versionid
     try:
         with tempfile.TemporaryFile() as tfile:
-            bucket.download_fileobj(key, tfile)
+            bucket.download_fileobj(key, tfile, ExtraArgs=extra_args)
             tfile.seek(0)
             return hashobj(tfile.read())
     except Exception as exp:  # pylint: disable=broad-except
@@ -57,30 +61,55 @@ def get_object_hash(bucket, key, timeout=0, backoff=5, _timestamp=None):
                            _timestamp=_timestamp, backoff=backoff)
 
 
-def check_object(key, data, local, *args, timeout=0, backoff=5):
-    ref_hash = hashobj(data)
-    local_hash = get_object_hash(local, key, timeout, backoff)
-    if local_hash is None:
-        _log.error('Unable to retrieve %s/%s from zenko', local.name, key)
-        contents = list(local.objects.all())
-        _log.debug('%s bucket contents %s', local.name, contents)
-    if ref_hash != local_hash:
-        _log.error('Local object hash != data hash')
+def wait_for_object(bucket, key, version_id=None, tries=1):
+    kwargs = {}
+    if version_id is not None:
+        kwargs['VersionId'] = version_id
+    for _ in range(tries):
+        try:
+            bucket.Object(key).wait_until_exists(**kwargs)
+            return True
+        except WaiterError:
+            pass
+    return False
+
+
+def get_object(bucket, key, version_id=None, tries=1):
+    if wait_for_object(bucket, key, version_id=version_id, tries=tries):
+        resp = bucket.Object(key).get()
+        return True, hashobj(resp['Body'].read())
+    return False, None
+
+
+def check_remote_object(bucket, key, ref_hash, version_id=None, tries=1):
+    success, remote_hash = get_object(bucket, key, version_id, tries)
+    if not success:
+        err = 'Failed to retrieve object from %s/%s' % (bucket.name, key)
+        _log.error(err)
+        return False, err
+    if ref_hash != remote_hash:
+        err = 'Reference hash != hash from %s/%s' % (bucket.name, key)
+        _log.error(err)
+        return False, err
+    return True, None
+
+
+def check_object(key, data, local, remote=[], version_id=None, tries=1):  # noqa pylint: disable=dangerous-default-value,too-many-arguments
+    if not isinstance(remote, list):
+        remote = [remote]
+    reference_hash = hashobj(data)
+    passed, error = check_remote_object(local, key, reference_hash,
+                                        version_id, tries)
+    if not passed:
+        _log.error(error)
         return False
-    passed = True
-    for bucket in args:
-        remotekey = '%s/%s' % (local.name,
-                key) if not conf.BUCKET_MATCH and local is not bucket else key  # noqa pylint: disable=bad-continuation
-        remote_hash = get_object_hash(bucket, remotekey, timeout, backoff)
-        if remote_hash is None:
-            _log.error('Unable to retrieve %s/%s from cloud backend',
-                       bucket.name, remotekey)
-            contents = list(bucket.objects.all())
-            _log.debug('%s bucket contents %s', bucket.name, contents)
-        if remote_hash != ref_hash:
-            _log.error('Object in %s did not match data!', bucket)
-            passed = False
-    return passed
+    for bucket in remote:
+        passed, error = check_remote_object(bucket, key, reference_hash,
+                                            tries=tries)
+        if not passed:
+            _log.error(error)
+            return False
+    return True
 
 
 def cleanup_bucket(bucket, replicated=False, delete_bucket=True): # noqa pylint: disable=too-many-locals
@@ -149,14 +178,23 @@ def cleanup_gcp_bucket(bucket, delete_bucket=False):
 UPLOAD_CONFIG = TransferConfig(multipart_threshold=10 * 1024 * 1024)  # 10MB
 
 
-def upload_object(bucket, key, data, **kwargs):
-    with tempfile.TemporaryFile() as upload:
+# Returns  <bool>, <str/None>
+#         success, version_id
+def upload_object(bucket, key, data, _retries=3, **kwargs):
+    obj = bucket.Object(key)
+    with tempfile.SpooledTemporaryFile() as upload:
         upload.write(data)
         upload.seek(0)
-        return bucket.upload_fileobj(upload,
-                                     key,
-                                     Config=UPLOAD_CONFIG,
-                                     ExtraArgs=kwargs)
+        # We use upload_fileobj as its a managed auto-mpu transfer
+        obj.upload_fileobj(upload, ExtraArgs=kwargs)
+    try:
+        obj.reload()  # Refresh object metadata from server
+        return True, obj.version_id
+    except ClientError:
+        _log.error('Falied to upload file, retrying... %i/3', str(3 - _retries))
+        if _retries > 0:
+            return upload_object(bucket, key, data, _retries=_retries - 1, **kwargs)
+    return False, None
 
 
 def get_from_preferred_read(bucket, key, location):


### PR DESCRIPTION
Add support for version ids to the local zenko check
Refactor object existence checking to use boto3's builtin `wait_until_exists`
Refactor object checking into seperate functions for simplicity
Also bump the max line length to 120 to make the javascript standards
