### PR TITLE
improvement: fix warning caused by -exit flag

### DIFF
--- a/tests/zenko_tests/node_tests/package.json
+++ b/tests/zenko_tests/node_tests/package.json
@@ -31,8 +31,8 @@
     "test_crr_pause_resume": "mocha --tags ${MOCHA_TAGS} --exit -t 10000 --recursive backbeat/tests/crr-pause-resume",
     "test_lifecycle": "mocha --tags ${MOCHA_TAGS} --exit -t 10000 --recursive backbeat/tests/lifecycle",
     "test_ingestion_oob_s3c": "mocha --tags ${MOCHA_TAGS} --exit -t 300000 --recursive backbeat/tests/ingestion",
-    "test_location_quota": "mocha --tags ${MOCHA_TAGS} -exit -t 10000 --recursive cloudserver/locationQuota/tests",
-    "test_bucket_get_v2": "mocha --tags ${MOCHA_TAGS} -exit -t 10000 --recursive cloudserver/bucketGetV2/tests"
+    "test_location_quota": "mocha --tags ${MOCHA_TAGS} --exit -t 10000 --recursive cloudserver/locationQuota/tests",
+    "test_bucket_get_v2": "mocha --tags ${MOCHA_TAGS} --exit -t 10000 --recursive cloudserver/bucketGetV2/tests"
   },
   "author": ""
 }


### PR DESCRIPTION
During CI tests, I noticed a warning line as follows:

```
> mocha --tags ${MOCHA_TAGS} -exit -t 10000 --recursive cloudserver/bucketGetV2/tests
Warning: Could not find any test files matching pattern: 10000
```

This means mocha was unable to recognize the correct timeout value of `10000`. Not aware of any issues it has caused so far, so fixing it as an improvement.

fixes #ZENKO-1811

