### PR TITLE
bf(ZENKO-1821): Remove helm install wait for ceph

### DIFF
--- a/eve/workers/ceph/Dockerfile
+++ b/eve/workers/ceph/Dockerfile
@@ -1,4 +1,4 @@
-FROM ceph/daemon
+FROM ceph/daemon:v3.2.1-stable-3.2-mimic-centos-7
 
 ENV CEPH_DAEMON demo
 ENV CEPH_DEMO_DAEMONS mon,mgr,osd,rgw
@@ -8,11 +8,12 @@ ENV CEPH_DEMO_ACCESS_KEY accessKey1
 ENV CEPH_DEMO_SECRET_KEY verySecretKey1
 ENV CEPH_DEMO_BUCKET zenkobucket
 
-# ENV RGW_NAME=zenko-ceph-ceph-in-a-box
 ENV CEPH_PUBLIC_NETWORK 0.0.0.0/0
 ENV MON_IP 0.0.0.0
 ENV NETWORK_AUTO_DETECT 0
 ENV RGW_CIVETWEB_PORT 8001
+
+RUN rm /etc/yum.repos.d/tcmu-runner.repo
 
 ADD ./entrypoint-wrapper.sh /
 RUN chmod +x /entrypoint-wrapper.sh && \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -166,8 +166,7 @@ install-cosbench:
 install-ceph:
 	$(HELM) upgrade $(CEPH_HELM_RELEASE) \
 		--namespace $(HELM_NAMESPACE) \
-		--install ../eve/workers/ceph/chart \
-		--wait
+		--install ../eve/workers/ceph/chart
 .PHONY: install-ceph
 
 install-zenko: | install-tiller

--- a/tests/zenko_tests/wait_for_ceph.sh
+++ b/tests/zenko_tests/wait_for_ceph.sh
@@ -8,5 +8,4 @@ EP="zenko-ceph-ceph-in-a-box"
 echo "Waiting for ceph at $EP"
 while [ -z "$(curl $EP 2>/dev/null)" ]; do
     sleep 1
-    echo -n "."
 done


### PR DESCRIPTION
As we already have a wait-for-ceph script, remove the wait from `helm install` and rely on the script to wait and CI timeouts to cleanup hung builds. Also use this opportunity to port changes from Cloudserver's ceph worker to Zenko's