### PR TITLE
ci: fix log dump

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -15,18 +15,19 @@ models:
   - ShellCommand: &k8s_setup
       name: setup k8s env
       command: eve/scripts/setup-k8s.sh
+      haltOnFailure: true
       env:
         CI_KUBECONFIG: '%(secret:openstack_cluster_conf)s'
         NAMESPACE: '%(prop:bootstrap)s-${STAGE}'
         KUBECONFIG: /root/.kube/config
         CLUSTER_IP: '%(secret:openstack_cluster_ip)s'
-      haltOnFailure: true
   - ShellCommand: &k8s_cleanup
       name: Cleanup
       command: |
         kubectl -n ${HELM_NAMESPACE} delete cosmos --all
         kubectl delete namespace ${HELM_NAMESPACE} --wait
       alwaysRun: true
+      warnOnFailure: true
       sigtermTime: 1200
       env:
         KUBECONFIG: /root/.kube/config
@@ -55,12 +56,14 @@ models:
       command: make -e dump-logs
       workdir: build/tests
       alwaysRun: true
+      warnOnFailure: true
       env:
         HELM_NAMESPACE: '%(prop:bootstrap)s-${STAGE}'
   - ShellCommand: &start-mocks
       name: Start external service mocks
       command: make -e install-mocks
       workdir: build/tests
+      haltOnFailure: true
       env:
         HELM_NAMESPACE: '%(prop:bootstrap)s-${STAGE}'
   - SetPropertyFromCommand: &notify-build-start

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -23,7 +23,7 @@ COSBENCH_HELM_RELEASE := zenko-cosbench
 CEPH_HELM_RELEASE := zenko-ceph
 
 # This is for dumping logs, command is long so storing as a variable
-ZENKO_PODS := {{range .items}}{{$$pod := .metadata.name}}{{range .spec.containers}}"kubectl logs -n $(HELM_NAMESPACE) {{$$pod}} -c {{.name}} --previous=true >> artifacts/{{.name}}-{{$$pod}}.log;kubectl logs -n $(HELM_NAMESPACE) {{$$pod}} -c {{.name}} >> artifacts/{{.name}}-{{$$pod}}.log"{{"\n"}}{{end}}{{end}}
+ZENKO_PODS := {{range .items}}{{$$pod := .metadata.name}}{{range .spec.containers}}"kubectl logs -n $(HELM_NAMESPACE) {{$$pod}} -c {{.name}} --previous=true >> artifacts/{{.name}}-{{$$pod}}.log;kubectl logs -n $(HELM_NAMESPACE) {{$$pod}} -c {{.name}} >> artifacts/{{.name}}-{{$$pod}}.log ; exit 0"{{"\n"}}{{end}}{{end}}
 
 # Defaults for our test images
 IMAGE_REGISTRY := docker.io


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
Always exit 0 on log generation. This resolves the flaky logs dump step that occasionally fails because it is trying to access logs to a container that no longer exists. It also adds `warnOnFailure` to non-critical steps along with adding missing `haltOnFailure` to critical steps.
**Which issue does this PR fix?**

ZENKO-1833
