### PR TITLE
documentation:ZENKOIO-23 Add Jira project link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Learn more at  [Zenko.io](http://www.zenko.io/).
 
 ## Contributing
 
+You can find the roadmap, features in development and bugs for the next release on [Zenko Jira Project](https://scality.atlassian.net/projects/ZENKOIO/issues/ZENKOIO-19?filter=allopenissues) as well as for the future releases.
+At this time if you have suggestions or questions you can leave the comments on the [forum](https://forum.zenko.io/) or create issues on this repository.
+
 If you'd like to contribute, please review the
 [Contributing Guidelines](https://github.com/scality/Guidelines/blob/master/CONTRIBUTING.md).
 


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
Updating README with a link to Zenko open source Jira project

**Which issue does this PR fix?**
[ZENKIO-23](https://scality.atlassian.net/browse/ZENKOIO-23)
