### PR TITLE
bugfix: ZENKO-1826 set UV_THREADPOOL_SIZE in data processor pod

### DIFF
--- a/kubernetes/zenko/charts/backbeat/templates/replication/data_processor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/replication/data_processor_deployment.yaml
@@ -54,6 +54,8 @@ spec:
               value: "{{- printf "%s-zenko-queue:9092" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: LOG_LEVEL
               value: {{ .Values.logging.level }}
+            - name: UV_THREADPOOL_SIZE
+              value: "64"
             - name: EXTENSIONS_REPLICATION_SOURCE_S3_HOST
               value: "{{- printf "%s-cloudserver" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: EXTENSIONS_REPLICATION_SOURCE_S3_PORT


### PR DESCRIPTION
Set the UV_THREADPOOL_SIZE environment variable to 64 (default is 4)
in the data processor pods, to fix replication tasks being very slow
when the number of zenko locations is large (~20).

The current theory explaining the fix: the libuv thread pool is
normally used for a few things like external nan modules or DNS
queries, not to block the main event loop. 4 threads is apparently not
enough to handle the load generated by KafkaConsumer instances (using
librdkafka underneath), and it slows down the processing of
http.request() calls, likely because of pending DNS queries. I assume
things must get queued faster than they can be processed, eventually
resulting in very large delays.

Choosing 64 as a heuristic, 128 is the hard maximum we can set. We can
experiment with this value and change it later if it causes issues.
