### PR TITLE
INTEGRATION [PR#708 > development/1.1] bugfix: ZENKO-1826 set UV_THREADPOOL_SIZE in data processor pod

### DIFF
--- a/kubernetes/zenko/charts/backbeat/templates/replication/data_processor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/replication/data_processor_deployment.yaml
@@ -54,6 +54,8 @@ spec:
               value: "{{- printf "%s-zenko-queue:9092" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: LOG_LEVEL
               value: {{ .Values.logging.level }}
+            - name: UV_THREADPOOL_SIZE
+              value: "64"
             - name: EXTENSIONS_REPLICATION_SOURCE_S3_HOST
               value: "{{- printf "%s-cloudserver" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: EXTENSIONS_REPLICATION_SOURCE_S3_PORT


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #708.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/1.1/bugfix/ZENKO-1826-slowReplication`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/1.1/bugfix/ZENKO-1826-slowReplication
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/1.1/bugfix/ZENKO-1826-slowReplication
```

Please always comment pull request #708 instead of this one.