### PR TITLE
bf: treat bucket exists as success

### DIFF
--- a/tests/zenko_tests/python_tests/zenko_e2e/util/bucket.py
+++ b/tests/zenko_tests/python_tests/zenko_e2e/util/bucket.py
@@ -15,6 +15,8 @@ def bucket_safe_create(bucket):
     try:
         bucket.create()
     except bucket.meta.client.exceptions.BucketAlreadyOwnedByYou:
+        print('Bucket %s already owned by you!' % bucket.name)
+    except bucket.meta.client.exceptions.BucketAlreadyExists:
         print('Bucket %s already exists!' % bucket.name)
     except Exception as exp:  # pylint: disable=broad-except
         print('Error creating bucket %s' % bucket.name)


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
Some regular flakiness on bucket creation causing cascading failures as seen here:
https://eve.devsca.com/github/scality/zenko/#/builders/10/builds/18298/steps/7/logs/stdio

This simply adds an exception for BucketAlreadyExists errors.

**Which issue does this PR fix?**
fixes ZENKO-1856

**Special notes for your reviewers**:
