### PR TITLE
bf: ZENKO-1744 inc ingestion populator thread pool

### DIFF
--- a/kubernetes/zenko/charts/backbeat/templates/ingestion/producer_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/ingestion/producer_deployment.yaml
@@ -48,6 +48,8 @@ spec:
               value: "{{ .Values.redis.sentinel.name }}"
             - name: QUEUE_POPULATOR_BATCH_MAX_READ
               value: "1000"
+            - name: UV_THREADPOOL_SIZE
+              value: "64"
           livenessProbe:
             httpGet:
               path: {{ .Values.health.path.liveness }}


### PR DESCRIPTION
Based off manual testing, if ingestion has many active
locations being read, the populator pod experiences
slower responses to the liveness probe, leading to the
pod getting killed.

Following same reasons as PR#708, increase thread pool
size.
