### PR TITLE
ZENKOIO-28 bumping the chart version to 1.2.0-development

### DIFF
--- a/kubernetes/zenko/Chart.yaml
+++ b/kubernetes/zenko/Chart.yaml
@@ -1,6 +1,6 @@
 name: zenko
-version: 1.1.0-rc.2
-appVersion: 1.1.0-rc.2
+version: 1.2.0-development
+appVersion: 1.2.0-development
 kubeVersion: ">=1.11.3"
 description: Zenko is the open source multi-cloud data controller
 home: https://www.zenko.io/

--- a/kubernetes/zenko/charts/backbeat/Chart.yaml
+++ b/kubernetes/zenko/charts/backbeat/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "8.1.9"
 description: A Helm chart for Zenko Backbeat
 name: backbeat
-version: 1.1.0-rc.2
+version: 1.2.0-development

--- a/kubernetes/zenko/charts/cloudserver/Chart.yaml
+++ b/kubernetes/zenko/charts/cloudserver/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "8.1.10"
 description: A Helm chart for Kubernetes
 name: cloudserver
-version: 1.1.0-rc.2
+version: 1.2.0-development


### PR DESCRIPTION
Bumping the chart version to `1.2.0-development` so that the development/1.2  > development/1.1 this way bert-e is happy.

Feel free to request any changes (if I missed something).

