### PR TITLE
ci: fixes OOM issues on data processor pods

### DIFF
--- a/eve/ci-values.yaml
+++ b/eve/ci-values.yaml
@@ -163,15 +163,22 @@ backbeat:
 
   replication:
     dataProcessor:
+      resources:
+        limits:
+          cpu: 250m
+          memory: 1Gi
+        requests:
+          cpu: 100m
+          memory: 512Mi
+    populator:
       resources: &backbeat
         limits:
           cpu: 250m
-          memory: 512Mi
+          memory: 256Mi
         requests:
           cpu: 100m
           memory: 128Mi
-    populator:
-      resources: *backbeat
+
     statusProcessor:
       resources: *backbeat
     retry:


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
Increases the upper memory limit for the  data processor pods. The memory usage has increased significantly possibly due to https://github.com/scality/Zenko/pull/708 leading to the pods being killed by K8s when it quickly reaches the threshold.

**Which issue does this PR fix?**
fixes ZENKO-1868

**Special notes for your reviewers**:
