### PR TITLE
Add ReadTheDocs build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ![Zenko logo](res/zenko.io-logo-wide-bw.png)
 
+[![Documentation Status](https://readthedocs.org/projects/zenko/badge/?version=latest)](https://zenko.readthedocs.io/en/latest/?badge=latest)
+
 Zenko is  [Scality](http://www.scality.com/)’s open source multi-cloud data
 controller.
 


### PR DESCRIPTION
bugfix: Adding a badge so we can keep an eye on build status of the CI.

fixes #ZENKO-32
