### PR TITLE
bugfix: ZENKO-1880 set LOG_LEVEL env in backbeat API deployment

### DIFF
--- a/kubernetes/zenko/charts/backbeat/templates/api/deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/api/deployment.yaml
@@ -26,6 +26,8 @@ spec:
           env:
             - name: REMOTE_MANAGEMENT_DISABLE
               value: "{{- if .Values.global.orbit.enabled }}0{{- else }}1{{- end }}"
+            - name: LOG_LEVEL
+              value: {{ .Values.logging.level }}
             - name: ZOOKEEPER_AUTO_CREATE_NAMESPACE
               value: "1"
             - name: ZOOKEEPER_CONNECTION_STRING


### PR DESCRIPTION
Set the environment variable LOG_LEVEL in deployment chart of backbeat
API from the configured backbeat.logging.level value.
