### PR TITLE
INTEGRATION [PR#739 > development/1.2] bugfix: ZENKO-1880 set LOG_LEVEL env in backbeat API deployment

### DIFF
--- a/kubernetes/zenko/charts/backbeat/templates/api/deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/api/deployment.yaml
@@ -26,6 +26,8 @@ spec:
           env:
             - name: REMOTE_MANAGEMENT_DISABLE
               value: "{{- if .Values.global.orbit.enabled }}0{{- else }}1{{- end }}"
+            - name: LOG_LEVEL
+              value: {{ .Values.logging.level }}
             - name: ZOOKEEPER_AUTO_CREATE_NAMESPACE
               value: "1"
             - name: ZOOKEEPER_CONNECTION_STRING


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #739.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/1.2/bugfix/ZENKO-1880-setLogLevelForBackbeatAPI`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/1.2/bugfix/ZENKO-1880-setLogLevelForBackbeatAPI
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/1.2/bugfix/ZENKO-1880-setLogLevelForBackbeatAPI
```

Please always comment pull request #739 instead of this one.