### PR TITLE
documentation: ZENKO-1885_reinstate_S3C_OOB_to_1.1

### DIFF
--- a/docs/docsource/reference/backbeat/crr_retry.rst
+++ b/docs/docsource/reference/backbeat/crr_retry.rst
@@ -15,7 +15,7 @@ This GET request retrieves a listing of failed operations at a site. Use
 this operation to learn if any CRR operations have failed at the site,
 and to retrieve the entire listing.
 
-**Request:** GET /_/backbeat/api/_/crr/failed?sitename=<site>&marker=<next-marker>
+**Request:** GET /_/backbeat/api/crr/failed?sitename=<site>&marker=<next-marker>
 
 **Non-Truncated Response**
 
@@ -59,7 +59,7 @@ This GET request retrieves a listing of all failed operations for a
 specific object version. Use this operation to monitor a specific
 object’s replication status.
 
-**Request:** GET /_/backbeat/api/_/crr/failed/<bucket>/<key>?versionId=<version-id>
+**Request:** GET /_/backbeat/api/crr/failed/<bucket>/<key>?versionId=<version-id>
 
 **Response**
 
@@ -87,7 +87,7 @@ Retry Failed Operations
 
 This POST request retries a set of failed operations.
 
-**Request:** POST /_/backbeat/api/_/crr/failed
+**Request:** POST /_/backbeat/api/crr/failed
 
 **Request Body**
 

--- a/docs/docsource/reference/bucket_ingestion_metrics/get_all_metrics.rst
+++ b/docs/docsource/reference/bucket_ingestion_metrics/get_all_metrics.rst
@@ -1,0 +1,40 @@
+GET All Metrics	
+===============	
+
+This request retrieves all metrics for all S3 Connector metadata	
+ingestion locations. Zenko returns three categories of information	
+(metrics) about system operations: completions, throughput, and 	
+pending operations. Completions are returned for the preceding 24	
+hours, throughput for the preceding 15 minutes, and pending    
+transactions are returned as a simple aggregate.    
+
+**Endpoint**	 
+
+ .. code::
+
+   /_/metrics/ingestion/all	
+
+**Sample Response**		
+
+ .. code::			
+
+    {				
+     "completions": {		
+       "description": "Number of completed ingestion operations (count) in the last 86400 seconds",	
+       "results": {   
+         "count":678979	
+       } 
+     },	 
+     "throughput": {	
+       "description": "Current throughput for ingestion operations in ops/sec (count) in the last 900 seconds",	
+       "results": {   
+         "count":"34.25"	
+       } 
+     },	 
+     "pending": {	
+       "description": "Number of pending ingestion operations (count)",	
+       "results": {   
+         "count":253417	
+       } 
+     } 
+   }

--- a/docs/docsource/reference/bucket_ingestion_metrics/get_all_metrics.rst
+++ b/docs/docsource/reference/bucket_ingestion_metrics/get_all_metrics.rst
@@ -10,13 +10,13 @@ transactions are returned as a simple aggregate.
 
 **Endpoint**	 
 
- .. code::
+.. code::
 
-   /_/metrics/ingestion/all	
+   /_/backbeat/api/metrics/ingestion/all	
 
 **Sample Response**		
 
- .. code::			
+.. code::			
 
     {				
      "completions": {		

--- a/docs/docsource/reference/bucket_ingestion_metrics/get_completions_per_location.rst
+++ b/docs/docsource/reference/bucket_ingestion_metrics/get_completions_per_location.rst
@@ -8,7 +8,7 @@ This request retrieves the number of operations Zenko ingested
 
 .. code::
 
-   /_/metrics/ingestion/<location>/completions	
+   /_/backbeat/api/metrics/ingestion/<location>/completions	
 
 **Sample Response**				
 

--- a/docs/docsource/reference/bucket_ingestion_metrics/get_completions_per_location.rst
+++ b/docs/docsource/reference/bucket_ingestion_metrics/get_completions_per_location.rst
@@ -1,0 +1,24 @@
+GET Completions per Location	
+============================	
+
+This request retrieves the number of operations Zenko ingested	
+(completed) from a specific location over the preceding 24 hours.	
+
+**Endpoint**	
+
+.. code::
+
+   /_/metrics/ingestion/<location>/completions	
+
+**Sample Response**				
+
+.. code::					
+
+   {						
+      "completions": {				
+         "description":"Number of completed ingestion operations (count) in the last 86400 seconds",	
+         "results": {
+            "count":668900
+         }
+      }
+   }

--- a/docs/docsource/reference/bucket_ingestion_metrics/get_metrics_per_location.rst
+++ b/docs/docsource/reference/bucket_ingestion_metrics/get_metrics_per_location.rst
@@ -1,0 +1,40 @@
+GET Metrics for a Location	
+==========================	
+
+This request retrieves metrics for a single location, defined as a	
+bucket in the Orbit UI. 	
+
+The response from the endpoint is formatted identically to the	
+Get All Metrics request, (completions, throughput, and pending 	
+operations) but constrained to the requested location only.	
+
+**Endpoint**	
+
+.. code::
+
+   /_/metrics/ingestion/<location>/all	
+
+**Sample Response**			
+
+.. code::				
+
+   {					
+      "completions": {			
+         "description": "Number of completed ingestion operations (count) in the last 86400 seconds",	
+         "results": {   
+            "count":678979	
+         } 
+      },	 
+      "throughput": {	
+         "description": "Current throughput for ingestion operations in ops/sec (count) in the last 900 seconds",	
+         "results": {   
+            "count":"34.25"	
+         } 
+      },	 
+      "pending": {	
+         "description": "Number of pending ingestion operations (count)",	
+         "results": {   
+            "count":253417	
+         } 
+      }
+   }

--- a/docs/docsource/reference/bucket_ingestion_metrics/get_metrics_per_location.rst
+++ b/docs/docsource/reference/bucket_ingestion_metrics/get_metrics_per_location.rst
@@ -12,7 +12,7 @@ operations) but constrained to the requested location only.
 
 .. code::
 
-   /_/metrics/ingestion/<location>/all	
+   /_/backbeat/api/metrics/ingestion/<location>/all
 
 **Sample Response**			
 

--- a/docs/docsource/reference/bucket_ingestion_metrics/get_pending_object_count.rst
+++ b/docs/docsource/reference/bucket_ingestion_metrics/get_pending_object_count.rst
@@ -8,7 +8,7 @@ ingestion.
 
 .. code::
 
-   /_/metrics/ingestion/<location>/pending	
+   /_/backbeat/api/metrics/ingestion/<location>/pending	
 
 **Sample Response**				
 

--- a/docs/docsource/reference/bucket_ingestion_metrics/get_pending_object_count.rst
+++ b/docs/docsource/reference/bucket_ingestion_metrics/get_pending_object_count.rst
@@ -1,0 +1,24 @@
+GET Pending Object Count	
+========================
+
+This request retrieves the number of objects queued for Zenko	
+ingestion.    
+
+**Endpoint** 
+
+.. code::
+
+   /_/metrics/ingestion/<location>/pending	
+
+**Sample Response**				
+
+.. code::					
+
+   {						
+      "pending": {				
+         "description":"Number of pending ingestion operations (count)",	
+         "results": {	     
+            "count":253409	     
+         } 
+      } 
+   }

--- a/docs/docsource/reference/bucket_ingestion_metrics/get_throughput_rate_per_location.rst
+++ b/docs/docsource/reference/bucket_ingestion_metrics/get_throughput_rate_per_location.rst
@@ -8,7 +8,7 @@ operations per second, over the preceding 15 minutes.
 
 .. code::
 
-   /_/metrics/ingestion/<location>/throughput	
+   /_/backbeat/api/metrics/ingestion/<location>/throughput	
 
 **Sample Response**				
 

--- a/docs/docsource/reference/bucket_ingestion_metrics/get_throughput_rate_per_location.rst
+++ b/docs/docsource/reference/bucket_ingestion_metrics/get_throughput_rate_per_location.rst
@@ -1,0 +1,24 @@
+GET Throughput per Location	
+===========================
+
+This request queries the managed S3 namespace for throughput, expressed as	
+operations per second, over the preceding 15 minutes.	       
+
+**Endpoint**  
+
+.. code::
+
+   /_/metrics/ingestion/<location>/throughput	
+
+**Sample Response**				
+
+.. code::					
+
+   {						
+      "throughput": {				
+         "description":"Current throughput for ingestion operations in ops/sec (count) in the last 900 seconds",	
+         "results": {	      
+            "count":"25.72"      
+         } 
+      } 
+   } 

--- a/docs/docsource/reference/bucket_ingestion_metrics/index.rst
+++ b/docs/docsource/reference/bucket_ingestion_metrics/index.rst
@@ -1,0 +1,30 @@
+Bucket Ingestion Metrics
+========================
+
+Zenko can make queries against S3 Connector instances named as bucket
+locations under its management. Querying the managed namespace, Zenko
+can retrieve information about the number of transfers completed and
+pending, and the rate at which they are completing.
+
+Zenko provides a REST API that makes these metrics available to users. To
+access these, make a request to the endpoints as specified in the following
+sections. Enter the listed endpoints verbatim, substituting a location
+that matches the bucket/location queried if the query requires it.
+
+For example,
+
+.. code::
+
+    $ curl http://zenko-instance.net/_/metrics/ingestion/us-west-video-dailies/all
+
+where zenko-instance.net is the Zenko server's URL and us-west-video-dailies		
+is the bucket name (location).
+
+.. toctree::
+   :maxdepth: 2
+
+   get_all_metrics
+   get_metrics_per_location
+   get_throughput_rate_per_location
+   get_completions_per_location
+   get_pending_object_count

--- a/docs/docsource/reference/bucket_ingestion_metrics/index.rst
+++ b/docs/docsource/reference/bucket_ingestion_metrics/index.rst
@@ -15,7 +15,7 @@ For example,
 
 .. code::
 
-    $ curl http://zenko-instance.net/_/metrics/ingestion/us-west-video-dailies/all
+    $ curl http://zenko-instance.net/_/backbeat/api/metrics/ingestion/us-west-video-dailies/all
 
 where zenko-instance.net is the Zenko server's URL and us-west-video-dailies		
 is the bucket name (location).

--- a/docs/docsource/reference/index.rst
+++ b/docs/docsource/reference/index.rst
@@ -11,6 +11,7 @@ Zenko Reference
    bucket_website_operations/index
    bucket_cors_operations/index
    bucket_lifecycle_operations/index
+   bucket_ingestion_metrics/index
    object_operations/index
    backbeat/index
    zenko_connector_api_knowledge_primers/index


### PR DESCRIPTION
Reinstated files and corrections from ZENKO-1801 and ZENKO-195_second_try.

This PR reinstates to development/1.1 changes mades in ZENKO-1801 and removed in ZENKO-195_remerge_2nd_try

We need it because it looks like S3C will be ready for 1.1 after all. 

This fixes #ZENKO-1885
