### PR TITLE
ci: fix ring bucket cleanup

### DIFF
--- a/tests/zenko_tests/docker-entrypoint.sh
+++ b/tests/zenko_tests/docker-entrypoint.sh
@@ -28,14 +28,14 @@ if [ "$STAGE" = 'python-tests' ]; then
     enter_and_run python_tests "./run.sh $PYTHON_ARGS"
 elif [ "$STAGE" = 'node-tests-01' ]; then
     enter_and_run node_tests "npm_chain.sh test_aws_crr test_api test_location_quota test_bucket_get_v2 test_ingestion_oob_s3c"
-    python3 cleans3c.py
 elif [ "$STAGE" = 'node-tests-02' ]; then
     enter_and_run node_tests "npm_chain.sh test_gcp_crr test_azure_crr test_one_to_many test_lifecycle test_crr_pause_resume"
 else
     enter_and_run python_tests "./run.sh $PYTHON_ARGS"
     # test_crr runs "test_aws_crr test_gcp_crr test_azure_crr test_one_to_many"
     enter_and_run node_tests "npm_chain.sh test_crr test_api test_crr_pause_resume test_location_quota test_bucket_get_v2"
-    python3 cleans3c.py
 fi
+
+python3 cleans3c.py
 
 exit "$EXIT_STATUS"


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
This fixes an issue causing buckets to be created but never cleaned up in the CI environment. Since there is a dedicated Scality RING used for tests, the cleanup should always run.

**Which issue does this PR fix?**
ZENKO-1884

**Special notes for your reviewers**:
