### PR TITLE
Bugfix/zenko 1736 report handler

### DIFF
--- a/kubernetes/zenko/templates/_helpers.tpl
+++ b/kubernetes/zenko/templates/_helpers.tpl
@@ -49,6 +49,14 @@ Create a common name for debug resources
 {{- end -}}
 
 {{/*
+Create a common name for reporting resources
+*/}}
+{{- define "zenko.reporting" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s-reporting" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Disables kafka from deploying it's own zookeeper
 */}}
 {{- define ".Values.zookeeper.enabled" -}}

--- a/kubernetes/zenko/templates/maintenance/debug/s3utils.yaml
+++ b/kubernetes/zenko/templates/maintenance/debug/s3utils.yaml
@@ -22,8 +22,8 @@ spec:
     spec:
       containers:
       - name: utils
-        image: {{ .Values.maintenance.s3Utils.image.repository }}:{{ .Values.maintenance.s3Utils.image.tag }}
-        imagePullPolicy: {{ .Values.maintenance.s3Utils.image.pullPolicy }}
+        image: {{ .Values.s3Utils.image.repository }}:{{ .Values.s3Utils.image.tag }}
+        imagePullPolicy: {{ .Values.s3Utils.image.pullPolicy }}
         command:
           - sh
           - -c

--- a/kubernetes/zenko/templates/maintenance/mongo-capabilites.yaml
+++ b/kubernetes/zenko/templates/maintenance/mongo-capabilites.yaml
@@ -17,8 +17,8 @@ spec:
       restartPolicy: OnFailure
       initContainers:
       - name: wait
-        image: {{ .Values.maintenance.s3Utils.image.repository }}:{{ .Values.maintenance.s3Utils.image.tag }}
-        imagePullPolicy: {{ .Values.maintenance.s3Utils.image.pullPolicy }}
+        image: {{ .Values.s3Utils.image.repository }}:{{ .Values.s3Utils.image.tag }}
+        imagePullPolicy: {{ .Values.s3Utils.image.pullPolicy }}
         command: ["/bin/bash"]
         args:
         - -exc
@@ -35,8 +35,8 @@ spec:
           done
       containers:
       - name: upgrade
-        image: {{ .Values.maintenance.s3Utils.image.repository }}:{{ .Values.maintenance.s3Utils.image.tag }}
-        imagePullPolicy: {{ .Values.maintenance.s3Utils.image.pullPolicy }}
+        image: {{ .Values.s3Utils.image.repository }}:{{ .Values.s3Utils.image.tag }}
+        imagePullPolicy: {{ .Values.s3Utils.image.pullPolicy }}
         command: ["/usr/bin/mongo"]
         args:
         - --host={{ template "zenko.mongodb-hosts" . }}

--- a/kubernetes/zenko/templates/maintenance/retry-failed-cron.yaml
+++ b/kubernetes/zenko/templates/maintenance/retry-failed-cron.yaml
@@ -18,12 +18,12 @@ spec:
           restartPolicy: OnFailure
           containers:
           - name: failed
-            image: {{ .Values.maintenance.s3Utils.image.repository }}:{{ .Values.maintenance.s3Utils.image.tag }}
-            imagePullPolicy: {{ .Values.maintenance.s3Utils.image.pullPolicy }}
+            image: {{ .Values.s3Utils.image.repository }}:{{ .Values.s3Utils.image.tag }}
+            imagePullPolicy: {{ .Values.s3Utils.image.pullPolicy }}
             command: ["/bin/bash"]
             args:
             - -c
-            - node autoRetryFailedCRR.js 
+            - node autoRetryFailedCRR.js
             env:
             - name: ENDPOINT
               value: "{{ .Release.Name }}-cloudserver"

--- a/kubernetes/zenko/templates/maintenance/retry-pending-cron.yaml
+++ b/kubernetes/zenko/templates/maintenance/retry-pending-cron.yaml
@@ -18,12 +18,12 @@ spec:
           restartPolicy: OnFailure
           containers:
           - name: pending
-            image: {{ .Values.maintenance.s3Utils.image.repository }}:{{ .Values.maintenance.s3Utils.image.tag }}
-            imagePullPolicy: {{ .Values.maintenance.s3Utils.image.pullPolicy }}
+            image: {{ .Values.s3Utils.image.repository }}:{{ .Values.s3Utils.image.tag }}
+            imagePullPolicy: {{ .Values.s3Utils.image.pullPolicy }}
             command: ["/bin/bash"]
             args:
             - -c
-            - node stalled.js 
+            - node stalled.js
             env:
             - name: ENDPOINT
               value: "{{ .Release.Name }}-cloudserver"

--- a/kubernetes/zenko/templates/reporting/countItems.yaml
+++ b/kubernetes/zenko/templates/reporting/countItems.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.reporting.enabled -}}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ template "zenko.reporting" . }}-count-items
+  labels:
+{{ include "zenko.labels.standard" . | indent 4 }}
+spec:
+  schedule: "{{ .Values.reporting.countItems.schedule }}"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: {{ .Values.reporting.successfulJobsHistory }}
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: count-items
+            image: {{ .Values.s3Utils.image.repository }}:{{ .Values.s3Utils.image.tag }}
+            imagePullPolicy: {{ .Values.s3Utils.image.pullPolicy }}
+            command: ["/bin/bash"]
+            args:
+            - -c
+            - node countItems.js
+            env:
+            - name: MONGODB_REPLICASET
+              value: "{{ template "zenko.mongodb-hosts" . }}"
+{{- end -}}

--- a/kubernetes/zenko/values.yaml
+++ b/kubernetes/zenko/values.yaml
@@ -36,7 +36,7 @@ global:
 s3Utils:
   image:
     repository: zenko/s3utils
-    tag: v0.8
+    tag: "1.0" 
     pullPolicy: IfNotPresent
 
 maintenance:

--- a/kubernetes/zenko/values.yaml
+++ b/kubernetes/zenko/values.yaml
@@ -33,6 +33,12 @@ global:
   locationConstraints: {}
   replicationEndpoints: []
 
+s3Utils:
+  image:
+    repository: zenko/s3utils
+    tag: v0.8
+    pullPolicy: IfNotPresent
+
 maintenance:
   # Enables a retry CronJobs that will attempt to retry CRR objects stuck in
   # pending or failed state based off the specified schedule. For Orbit enabled
@@ -55,11 +61,6 @@ maintenance:
     enabled: false
     accessKey: ""
     secretKey: ""
-  s3Utils:
-    image:
-      repository: zenko/s3utils
-      tag: v0.8
-      pullPolicy: IfNotPresent
   kafkaClient:
     image:
       repository: solsson/kafka

--- a/kubernetes/zenko/values.yaml
+++ b/kubernetes/zenko/values.yaml
@@ -66,6 +66,13 @@ maintenance:
       repository: solsson/kafka
       tag: 0.11.0.0
       pullPolicy: IfNotPresent
+# Enables reporting cronjobs that are essential for displaying information
+# in Orbit like total number of objects in the namespace
+reporting:
+  enabled: true
+  successfulJobsHistory: 1
+  countItems:
+    schedule: "* */1 * * *"
 
 cloudserver:
   replicaCount: *nodeCount


### PR DESCRIPTION

### Report handler task to perform expensive reporting tasks in the background
- **improvement: move s3utils to its own section**
This avoids duplicating the section so that it can be shared
- **bugfix: ZENKO-1736 introduce countItems cronjob**
This cronjob allows running background queries in MongoDB and updating
appropriate collections so that Orbit receives instance level reporting.
Running this as a cronjob alleviates the pressure on MongoDB whenever
a new report is requested from Cloudserver.
