### PR TITLE
bf: semVer check for pre-releases

### DIFF
--- a/kubernetes/zenko/Chart.yaml
+++ b/kubernetes/zenko/Chart.yaml
@@ -1,7 +1,7 @@
 name: zenko
 version: 1.1.0-rc.3
 appVersion: 1.1.0-rc.3
-kubeVersion: ">=1.11.3"
+kubeVersion: ">=1.11.3-0"
 description: Zenko is the open source multi-cloud data controller
 home: https://www.zenko.io/
 icon: https://rawgit.com/scality/Zenko/development/0.9/res/zenko.io-logo-color-cmyk.png


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
Currently, helm install will fail on most managed K8s installs. This is because of the custom versions used such as `v1.11.7-gke.6` is considered a pre-release in the library used by helm and thus doesn't satisfy the requirements. This fix allows for compatibility with such versions by evaluating them within the requirement range.

**Which issue does this PR fix?**
fixes # ZENKO-1904

**Special notes for your reviewers**:
Related to:
https://github.com/helm/helm/issues/3810