### PR TITLE
documentation: ZENKO-1896_Add_link_to_MK8s

### DIFF
--- a/docs/docsource/installation/prepare/setting_up_a_cluster.rst
+++ b/docs/docsource/installation/prepare/setting_up_a_cluster.rst
@@ -6,10 +6,10 @@ Setting Up a Cluster
 While running Zenko on a single machine is desirable for certain use cases,
 a clustered operating environment is required for high-availability deployments.
 If you can set up a Kubernetes cluster on your own, review the :ref:`General
-Cluster Requirements` and skip to :ref:`Install_Zenko`. Otherwise, download
-MetalK8s and follow its instructions (or review the requirements and
-instructions in Zenko/docs/gke.md) to establish a working Kubernetes instance
-on your cluster.
+Cluster Requirements` and skip to :ref:`Install_Zenko`. Otherwise, 
+`download MetalK8s <https://github.com/scality/metalk8s/releases>`_
+and follow its instructions (or review the requirements and instructions in 
+Zenko/docs/gke.md) to establish a working Kubernetes instance on your cluster.
 
 .. note: 
    


### PR DESCRIPTION
This PR adds a link to the MetalK8s download page. 

We need it because it makes the documentation more usable. 

This PR fixes ZENKO-1896