### PR TITLE
feature: ZENKO-1805 add Prometheus configuration to backbeat API

### DIFF
--- a/kubernetes/zenko/charts/backbeat/templates/api/deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/api/deployment.yaml
@@ -49,6 +49,8 @@ spec:
               value: "{{- printf "%s-cloudserver:80" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: MONGODB_HOSTS
               value: "{{ template "backbeat.mongodb-hosts" . }}"
+            - name: PROMETHEUS_ENDPOINT
+              value: "{{- printf "%s-prometheus-server:80" .Release.Name | trunc 63 | trimSuffix "-" -}}"
             - name: COLLECT_DEFAULT_METRICS_INTERVAL_MS
               value: {{ quote .Values.monitoring.collectDefaultMetricsIntervalMs }}
           livenessProbe:


### PR DESCRIPTION
Set the PROMETHEUS_ENDPOINT environment variable to provide access to
Prometheus in backbeat API.
