### PR TITLE
ft: deploy pfsd based off node count

### DIFF
--- a/cosmos/api/types/v1alpha1/cosmos.go
+++ b/cosmos/api/types/v1alpha1/cosmos.go
@@ -18,8 +18,13 @@ type CosmosList struct {
 
 type CosmosSpec struct {
 	FullnameOverride string                     `json:"fullnameOverride"`
+	Pfsd             CosmosPfsdSpec             `json:"pfsd"`
 	Rclone           CosmosRcloneSpec           `json:"rclone"`
 	PersistentVolume CosmosPersistentVolumeSpec `json:"persistentVolume"`
+}
+
+type CosmosPfsdSpec struct {
+	ReplicaCount string `json:"replicaCount"`
 }
 
 type CosmosRcloneSpec struct {

--- a/cosmos/scheduler/Makefile
+++ b/cosmos/scheduler/Makefile
@@ -1,5 +1,5 @@
 COSMOS_IMAGE := zenko/cosmos-scheduler
-COSMOS_TAG := 0.2.2
+COSMOS_TAG := 0.2.3
 COSMOS_BINARY := ./scheduler
 
 .PHONY: setup

--- a/cosmos/scheduler/cmd/scheduler.go
+++ b/cosmos/scheduler/cmd/scheduler.go
@@ -20,6 +20,7 @@ type Scheduler struct {
 	KubeClientset     *kubernetes.Clientset
 	Pensieve          *pensieve.Helper
 	Namespace         string
+	NodeCount         string
 	Cloudserver       string
 	StorageClass      string
 	MongodbClient     *mongo.Client
@@ -279,6 +280,9 @@ func (s *Scheduler) createCosmosFromLocation(location *pensieve.Location, bucket
 		},
 		Spec: v1alpha1.CosmosSpec{
 			FullnameOverride: location.Name,
+			Pfsd: v1alpha1.CosmosPfsdSpec{
+				ReplicaCount: s.NodeCount,
+			},
 			Rclone: v1alpha1.CosmosRcloneSpec{
 				Schedule: s.IngestionSchedule,
 				Destination: v1alpha1.CosmosRcloneDestinationSpec{

--- a/cosmos/scheduler/main.go
+++ b/cosmos/scheduler/main.go
@@ -29,6 +29,9 @@ func init() {
 	viper.SetDefault("namespace", "default")
 	viper.BindEnv("namespace")
 
+    viper.SetDefault("node_count", "3")
+    viper.BindEnv("node_count")
+
 	viper.SetDefault("mongodb_hosts", "localhost:27017")
 	viper.BindEnv("mongodb_hosts")
 
@@ -78,6 +81,7 @@ func main() {
 		KubeClientset:     kubeClient,
 		Pensieve:          pensieve.NewHelper(mongoClient.Database(metadataDatabase).Collection(pensieveCollection)),
 		Namespace:         viper.GetString("namespace"),
+		NodeCount:         viper.GetString("node_count"),
 		Cloudserver:       viper.GetString("cloudserver_endpoint"),
 		StorageClass:      viper.GetString("storage_class"),
 		SecretName:        viper.GetString("ingestion_secret_name"),

--- a/kubernetes/zenko/templates/cosmos-scheduler/deployment.yaml
+++ b/kubernetes/zenko/templates/cosmos-scheduler/deployment.yaml
@@ -46,6 +46,8 @@ spec:
           value: "http://{{ .Release.Name }}-cloudserver"
         - name: MONGODB_HOSTS
           value: "{{ template "zenko.mongodb-hosts" . }}"
+        - name: NODE_COUNT
+          value: "{{ .Values.nodeCount }}"
         - name: STORAGE_CLASS
           value: "{{ template "cosmos-operator.storageclass" . }}"
         resources:

--- a/kubernetes/zenko/values.yaml
+++ b/kubernetes/zenko/values.yaml
@@ -126,7 +126,7 @@ cosmos:
   scheduler:
     image:
       repository: zenko/cosmos-scheduler
-      tag: 0.2.2
+      tag: 0.2.3
       pullPolicy: IfNotPresent
 
     ## A namespace to watch can be specified otherwise will default to the


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
These changes configure the pass through daemon to scale with the number of nodes. This allows for out of the box performance for NFS based reads.

**Which issue does this PR fix?**
fixes ZENKO-1919

**Special notes for your reviewers**: