### PR TITLE
improvement: ZENKO-1944 add vault service host

### DIFF
--- a/kubernetes/zenko/charts/cloudserver/templates/_env.tpl
+++ b/kubernetes/zenko/charts/cloudserver/templates/_env.tpl
@@ -78,6 +78,13 @@ env:
     value: "{{- .Values.global.orbit.endpoint -}}"
   - name: PUSH_ENDPOINT
     value: "{{- .Values.global.orbit.pushEndpoint -}}"
+  {{- else if .Values.vault.enabled }}
+  - name: REMOTE_MANAGEMENT_DISABLE
+    value: "1"
+  - name: S3VAULT
+    value: "scality"
+  - name: VAULTD_HOST
+    value: "{{ .Values.vault.host }}"
   {{- else }}
   - name: REMOTE_MANAGEMENT_DISABLE
     value: "1"

--- a/kubernetes/zenko/charts/cloudserver/values.yaml
+++ b/kubernetes/zenko/charts/cloudserver/values.yaml
@@ -146,6 +146,10 @@ kmip:
   bucketAttributeName: ''
   pipelineDepth: 8
 
+vault:
+  enabled: false
+  host: "zenko-vault"
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
Adds an env variable for vault host. In accordance to vault operator and Pull request #[1958](https://github.com/scality/cloudserver/pull/1958)

**Which issue does this PR fix?**

fixes #[ZENKO-1944](https://scality.atlassian.net/browse/ZENKO-1944)

**Special notes for your reviewers**:
Future work: Do the same for backbeat