### PR TITLE
INTEGRATION [PR#776 > development/1.1] bf(ZENKO-1947): Fix incorrect install timeout error

### DIFF
--- a/tests/zenko_tests/create_buckets.py
+++ b/tests/zenko_tests/create_buckets.py
@@ -75,8 +75,8 @@ def wait_for_pods(delete, timeout):
     delete_opt = client.V1DeleteOptions()
 
     passed_count = 0
-    timeout = time.time() + timeout
-    while time.time() < timeout:
+    timed_out = time.time() + timeout
+    while time.time() < timed_out:
         ret = v1.list_namespaced_pod(K8S_NAMESPACE)
         passed = True
         for i in ret.items:
@@ -181,7 +181,7 @@ while time.time() < timeout:
         backoff = backoff ** 2
 
 if not created:
-    _log.critical('Failed to create buckets and %i secs has elasped!' % TIMEOUT)
+    _log.critical('Failed to create buckets and %i secs has elapsed!' % TIMEOUT)
     sys.exit(1)
 else:
     _log.info('Created buckets')


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #776.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/1.1/bugfix/ZENKO-1947_Incorrect_install_timeout_reported`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/1.1/bugfix/ZENKO-1947_Incorrect_install_timeout_reported
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/1.1/bugfix/ZENKO-1947_Incorrect_install_timeout_reported
```

Please always comment pull request #776 instead of this one.