### PR TITLE
ci: fix nightly runs

### DIFF
--- a/eve/ci-values.yaml
+++ b/eve/ci-values.yaml
@@ -28,10 +28,10 @@ s3-data:
     enabled: false
   resources:
     requests:
-      cpu: 100m
+      cpu: 150m
       memory: 256Mi
     limits:
-      cpu: 100m
+      cpu: 150m
       memory: 256Mi
 
 
@@ -156,18 +156,18 @@ cloudserver:
   affinity: ""
   resources:
     limits:
-      cpu: 250m
+      cpu: 500m
       memory: 512Mi
     requests:
-      cpu: 250m
+      cpu: 500m
       memory: 512Mi
   manager:
     resources:
       limits:
-        cpu: 200m
+        cpu: 250m
         memory: 384Mi
       requests:
-        cpu: 200m
+        cpu: 250m
         memory: 384Mi
 
 backbeat:
@@ -176,27 +176,27 @@ backbeat:
   api:
     resources:
       limits:
-        cpu: 250m
+        cpu: 350m
         memory: 384Mi
       requests:
-        cpu: 250m
+        cpu: 350m
         memory: 384Mi
   replication:
     dataProcessor:
       resources:
         limits:
-          cpu: 200m
-          memory: 1Gi
+          cpu: 250m
+          memory: 768Mi
         requests:
-          cpu: 200m
-          memory: 1Gi
+          cpu: 250m
+          memory: 768Mi
     populator:
       resources: &backbeat
         limits:
-          cpu: 150m
+          cpu: 175m
           memory: 256Mi
         requests:
-          cpu: 150m
+          cpu: 175m
           memory: 256Mi
 
     statusProcessor:

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -175,7 +175,7 @@ models:
       IMAGE_REGISTRY: '%(secret:private_registry_url)s'
       TAG_OVERRIDE: '%(prop:commit_short_revision)s'
 
-  - env: &k8s_env # containes values for running helm and kubectl
+  - env: &k8s_env # contains values for running helm and kubectl
       ZENKO_HELM_RELEASE: 'zenko-test'
       HELM_NAMESPACE: '%(prop:bootstrap)s-${STAGE}'
       TILLER_NAMESPACE: '%(prop:bootstrap)s-${STAGE}'
@@ -259,7 +259,7 @@ stages:
           ZENKO_HELM_RELEASE: 'zenko-offline'
           HELM_NAMESPACE: '%(prop:bootstrap)s-${STAGE}'
           TILLER_NAMESPACE: '%(prop:bootstrap)s-${STAGE}'
-          INSTALL_TIMEOUT: "600"
+          INSTALL_TIMEOUT: "720"
     - ShellCommand: *dump_logs
     - Upload: *upload_artifacts
     - ShellCommand: *k8s_cleanup
@@ -361,7 +361,7 @@ stages:
           ZENKO_HELM_RELEASE: 'zenko-offline'
           HELM_NAMESPACE: '%(prop:bootstrap)s-${STAGE}'
           TILLER_NAMESPACE: '%(prop:bootstrap)s-${STAGE}'
-          INSTALL_TIMEOUT: "600"
+          INSTALL_TIMEOUT: "720"
     - ShellCommand: *dump_logs
     - Upload: *upload_artifacts
     - ShellCommand: *trigger-build-reporter

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -174,8 +174,8 @@ ifndef NO_INSTALL
 	$(HELM) upgrade $(ZENKO_HELM_RELEASE) \
 		--namespace $(HELM_NAMESPACE) \
 		--install ../kubernetes/zenko \
-        --set cosmos.namespace=$(HELM_NAMESPACE) \
-		-f ../eve/ci-values.yaml
+		-f ../eve/ci-values.yaml \
+	--set cosmos.namespace=$(HELM_NAMESPACE)
 endif
 .PHONY: install-zenko
 
@@ -186,7 +186,7 @@ ifndef NO_INSTALL
                 --tiller-namespace $(HELM_NAMESPACE) \
 		--install ../kubernetes/zenko \
 		-f ../eve/ci-values.yaml \
-        --set cosmos.namespace=$(HELM_NAMESPACE) \
+	--set cosmos.namespace=$(HELM_NAMESPACE) \
         --set backbeat.image.repository=$(BACKBEAT_IMAGE) \
         --set-string backbeat.image.tag='$(BACKBEAT_TAG)' \
         --set cloudserver.image.repository=$(CLOUDSERVER_IMAGE) \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -175,7 +175,8 @@ ifndef NO_INSTALL
 		--namespace $(HELM_NAMESPACE) \
 		--install ../kubernetes/zenko \
 		-f ../eve/ci-values.yaml \
-	--set cosmos.namespace=$(HELM_NAMESPACE)
+	--set cosmos.namespace=$(HELM_NAMESPACE) \
+	--set-string cloudserver.replicaCount='1'
 endif
 .PHONY: install-zenko
 
@@ -187,6 +188,7 @@ ifndef NO_INSTALL
 		--install ../kubernetes/zenko \
 		-f ../eve/ci-values.yaml \
 	--set cosmos.namespace=$(HELM_NAMESPACE) \
+	--set-string mongodb-replicaset.resources.limits.cpu='2'\
         --set backbeat.image.repository=$(BACKBEAT_IMAGE) \
         --set-string backbeat.image.tag='$(BACKBEAT_TAG)' \
         --set cloudserver.image.repository=$(CLOUDSERVER_IMAGE) \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -345,5 +345,5 @@ upload-cosbench-results: | get-cosbench-results
 		-- python insert_data.py
 .PHONY: upload-cosbench-results
 
-test-cosbench: | install-common get-latest-commit install-latest-zenko install-cosbench build-cosbench-runner wait-for-zenko trigger-cosbench upload-cosbench-results
+test-cosbench: | install-common get-latest-commit install-latest-zenko install-cosbench build-cosbench-runner wait-for-zenko trigger-cosbench upload-cosbench-results clean-s3c
 .PHONY: test-cosbench


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
- Fixes latest 1.1 nightly failing on cosmos tests
- Fixes cleanup for Cosbench runs that leave artifacts
- Improves resource allocations specifically for 1.1 (higher requests/limits)

In testing these changes, I've noticed several builds will stabilize just past the timeout. As a result the timeout is increased by 2 minutes.

