### PR TITLE
documentation/ZENKOIO-52_remove_expiration-only_lifecycle_descriptions

### DIFF
--- a/docs/docsource/installation/configure/set_up_NFS_for_OOB.rst
+++ b/docs/docsource/installation/configure/set_up_NFS_for_OOB.rst
@@ -1,11 +1,11 @@
 Set Up Out-of-Band Updates from an NFS Mount
 ============================================
 
-Zenko 1.1 allows ingestion and Out-of-Band (OOB) updates from existing NFS
-mount points. This new feature does not copy the files themselves; rather, the
+Zenko 1.1 allows ingestion and Out-of-Band (OOB) updates from existing NFS mount
+points. This new feature does not copy the files themselves; rather, the
 system's attributes are copied to Zenko for data management. Using this
 information, Zenko can act on NFS mounts as it would any other type of bucket,
-thus enabling metadata search, cloud replication, and lifecycle
+thus enabling metadata search, cloud replication, and lifecycle transition or
 expiration. Writes from Zenko users to buckets at NFS locations are not
 permitted.
 

--- a/docs/docsource/operation/Orbit_UI/Bucket_Management/Lifecycle_Management-Transition.rst
+++ b/docs/docsource/operation/Orbit_UI/Bucket_Management/Lifecycle_Management-Transition.rst
@@ -30,7 +30,7 @@ To establish a lifecycle transition rule:
 #. The **Add New Transition Rule** dialog displays:
 
    .. image:: ../../Resources/Images/Orbit_Screencaps/Orbit_lifecycle_add_transition_rule.png
-      :scale: 75 %
+      :scale: 50 %
       :align: center
 
    You may specify an prefix to identify objects to which the rule applies. Enter

--- a/docs/docsource/operation/Zenko_CLI/Object_Lifecycle_Management.rst
+++ b/docs/docsource/operation/Zenko_CLI/Object_Lifecycle_Management.rst
@@ -3,13 +3,12 @@
 Object Lifecycle Management
 ===========================
 
-Cloud users can apply lifecycle rules (specified in Amazon’s `AWS S3
-API <https://docs.aws.amazon.com/AmazonS3/latest/API/Welcome.html>`__) to
-buckets managed through Zenko. These rules are triggered after a defined time
-has passed since the object’s last modification. Zenko supports expiration of
-versioned or non-versioned objects, when a defined number of days has passed
-since those objects’ creation. This enables automatic deletion of older
-versions of versioned objects to reclaim storage space.
+Cloud users can apply lifecycle rules (specified in Amazon’s `AWS S3 API
+<https://docs.aws.amazon.com/AmazonS3/latest/API/Welcome.html>`__) to buckets
+managed through Zenko. These rules are triggered after a defined time has passed
+since the object’s last modification. Zenko supports expiration and transition
+of objects when a defined number of days has passed since those objects’
+creation. This enables automated deletion or movement of older vobjects.
 
 Installation
 ------------
@@ -21,19 +20,19 @@ deployment configuration files.
 Operation
 ---------
 
-Lifecycle management conforms partially to the S3 lifecycle management
-syntax described at
+Lifecycle management conforms partially to the S3 lifecycle management syntax
+described at
 https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html.
-Zenko lifecycle actions are constrained to expiration actions, and not
-transition actions. Files that exceed a preconfigured temporal threshold
-(for example, 90 days) are expired and deleted from the bucket in which
-they are stored.
+Zenko lifecycle management supports expiration and transition actions. Files
+that exceed a preconfigured temporal threshold (for example, 90 days) are
+expired and deleted from the bucket in which they are stored or transitioned and
+moved.
 
 Bucket lifecycle characteristics inhere to the bucket: Zenko’s lifecycle
 management feature does not set lifecycle characteristics, but does
 enforce them. When lifecycle management is enabled, the host cloud
 enforces buckets’ lifecycle rules. If CRR operation is enabled, Zenko
-replicates the expiration to all backup clouds.
+replicates the lifecycle event to all backup clouds.
 
 To configure bucket lifecycle, follow the AWS S3 Lifecycle Configuration
 Element syntax described in
@@ -41,16 +40,15 @@ Element syntax described in
 <https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html>`__.
 
 .. note:: To implement the S3 API effectively in a cross-cloud context, Zenko
-   reinterprets S3's ``<StorageClass>`` field somewhat differently from how
-   AWS defines it. Where Amazon uses StorageClass to indicate various
-   proprietary Amazon storage locations that can be described by their quality
-   of service, Zenko uses this parameter to identify cloud service locations
-   by a user-defined name. So, instead of using 
-   ``<StorageClass>GLACIER<\StorageClass>`` for inexpensive, high-latency
-   storage, the Zenko user must define a cloud location with satisfactory
-   storage and pricing requirements and use that cloud location as the target
-   cloud storage location. Zenko reads and writes to this location based on
-   the StorageClass tag definition.
+   interprets S3's ``<StorageClass>`` field differently from how AWS defines
+   it. Where Amazon uses StorageClass to indicate various proprietary Amazon
+   storage locations that can be described by their quality of service, Zenko
+   uses this parameter to identify cloud service locations by a user-defined
+   name. So, instead of using ``<StorageClass>GLACIER<\StorageClass>`` for
+   inexpensive, high-latency storage, the Zenko user must define a cloud
+   location with satisfactory storage and pricing requirements and use that
+   cloud location as the target cloud storage location. Zenko reads and writes
+   to this location based on the StorageClass tag definition.
 
 Zenko API Calls
 ---------------

--- a/docs/docsource/reference/bucket_lifecycle_operations/get_bucket_lifecycle.rst
+++ b/docs/docsource/reference/bucket_lifecycle_operations/get_bucket_lifecycle.rst
@@ -325,7 +325,7 @@ configurations from a specified bucket.
 
 *Sample Request*
 
-..code::
+::
 
   GET /?lifecycle HTTP/1.1
   Host: examplebucket.s3.amazonaws.com


### PR DESCRIPTION
Searched the documentation on "expir" for lingering definitions of Lifecycle Management as being solely about expiration. 

fixes #ZENKOIO-52
