### PR TITLE
ci: fix clusterrole for nightlies

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -24,15 +24,15 @@ models:
   - ShellCommand: &k8s_cleanup
       name: Cleanup
       command: |
-        kubectl -n ${HELM_NAMESPACE} delete cosmos --all
-        kubectl delete namespace ${HELM_NAMESPACE} --wait
+        kubectl -n ${NAMESPACE} delete cosmos --all
+        kubectl delete clusterrolebinding ${NAMESPACE}-cosmos-operator
+        kubectl delete namespace ${NAMESPACE} --wait
       alwaysRun: true
       warnOnFailure: true
       sigtermTime: 1200
       env:
         KUBECONFIG: /root/.kube/config
-        ZENKO_HELM_RELEASE: 'zenko-offline'
-        HELM_NAMESPACE: '%(prop:bootstrap)s-${STAGE}'
+        NAMESPACE: '%(prop:bootstrap)s-${STAGE}'
   - Upload: &upload_artifacts
       source: tests/artifacts
       urls:
@@ -176,7 +176,6 @@ models:
       TAG_OVERRIDE: '%(prop:commit_short_revision)s'
 
   - env: &k8s_env # contains values for running helm and kubectl
-      ZENKO_HELM_RELEASE: 'zenko-test'
       HELM_NAMESPACE: '%(prop:bootstrap)s-${STAGE}'
       TILLER_NAMESPACE: '%(prop:bootstrap)s-${STAGE}'
       INSTALL_TIMEOUT: "600"
@@ -256,7 +255,6 @@ stages:
         env:
           <<: [*mock_env, *secrets_env, *docker_env]
           KUBECONFIG: /root/.kube/config
-          ZENKO_HELM_RELEASE: 'zenko-offline'
           HELM_NAMESPACE: '%(prop:bootstrap)s-${STAGE}'
           TILLER_NAMESPACE: '%(prop:bootstrap)s-${STAGE}'
           INSTALL_TIMEOUT: "720"
@@ -358,7 +356,6 @@ stages:
         env:
           <<: *global_env
           KUBECONFIG: /root/.kube/config
-          ZENKO_HELM_RELEASE: 'zenko-offline'
           HELM_NAMESPACE: '%(prop:bootstrap)s-${STAGE}'
           TILLER_NAMESPACE: '%(prop:bootstrap)s-${STAGE}'
           INSTALL_TIMEOUT: "720"

--- a/eve/scripts/cluster-registry-secret.sh
+++ b/eve/scripts/cluster-registry-secret.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -ex
+set -e
 
 DOCKERCONFIG="$(cat ~/.docker/config.json | base64 | tr -d \\n)"
 

--- a/eve/scripts/setup-k8s.sh
+++ b/eve/scripts/setup-k8s.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -ex
+set -e
 
 echo "Replacing existing credentials"
 rm -rf /root/.kube
@@ -27,14 +27,14 @@ metadata:
   name: ${NAMESPACE}-cosmos-operator
   labels:
     app: cosmos-operator
-    release: zenko-offline
+    release: zenko-test
 subjects:
 - kind: ServiceAccount
-  name: zenko-offline-cosmos-operator
+  name: zenko-test-cosmos-operator
   namespace: ${NAMESPACE}
 roleRef:
   kind: ClusterRole
-  name: zenko-offline-cosmos-operator
+  name: zenko-test-cosmos-operator
   apiGroup: rbac.authorization.k8s.io
 EOF
 

--- a/eve/workers/ci_env.sh
+++ b/eve/workers/ci_env.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+if [ -z $ZENKO_HELM_RELEASE ]; then
+    ZENKO_HELM_RELEASE='zenko-test'
+fi
+
 if [ "$1" == "env" ]; then
   CLI_FLAG="env"
   CI_PREFIX=""

--- a/tests/zenko_tests/create_buckets.py
+++ b/tests/zenko_tests/create_buckets.py
@@ -106,7 +106,7 @@ def wait_for_pods(delete, timeout):
 TIMEOUT = int(get_env('INSTALL_TIMEOUT'))
 
 K8S_NAMESPACE = os.getenv('HELM_NAMESPACE')
-ZENKO_HELM_RELEASE = os.getenv('ZENKO_HELM_RELEASE')
+ZENKO_HELM_RELEASE = get_env('ZENKO_HELM_RELEASE', 'zenko-test')
 ZENKO_ENDPOINT = get_env('CLOUDSERVER_FRONT_ENDPOINT',
                          'http://%s-cloudserver:80' % ZENKO_HELM_RELEASE)
 VERIFY_CERTIFICATES = get_env('VERIFY_CERTIFICATES', False)

--- a/tests/zenko_tests/python_tests/zenko_e2e/conf.py
+++ b/tests/zenko_tests/python_tests/zenko_e2e/conf.py
@@ -42,7 +42,7 @@ if K8S_NAMESPACE is None:
         raise RuntimeError('Unable to determine Zenko K8s namespace')
 
 
-ZENKO_HELM_RELEASE = os.getenv('ZENKO_HELM_RELEASE', None)
+ZENKO_HELM_RELEASE = get_env('ZENKO_HELM_RELEASE', 'zenko-test')
 
 ZENKO_ENDPOINT = get_env('CLOUDSERVER_FRONT_ENDPOINT',
                          'http://%s-cloudserver:80' % ZENKO_HELM_RELEASE)


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
Fixes the nightly failures on the cosmos tests by using a common release name. This is done by removing the `ZENKO_HELM_RELEASE` and relying on the default release name of `zenko-test` so that creation of the cluster role binding is accurate across all build stages. Additionally it explicitly  cleans up the clusterrolebinding as part of the cleanup.