### PR TITLE
documentation: ZENKO-1836_Scheduler_updates_with_cron

### DIFF
--- a/docs/docsource/installation/configure/set_up_NFS_for_OOB.rst
+++ b/docs/docsource/installation/configure/set_up_NFS_for_OOB.rst
@@ -82,7 +82,9 @@ all future created NFS locations.
        # Run hourly
        schedule: "@hourly"
 
-This does not change the cron schedule on existing NFS locations.
+.. note::
+
+   This does not change the cron schedule on existing NFS locations.
 
 
 Modify Cron on Existing NFS Locations

--- a/docs/docsource/reference/prometheus/index.rst
+++ b/docs/docsource/reference/prometheus/index.rst
@@ -7,7 +7,7 @@ into Kubernetes platform (MetalK8s) and Zenko functionality.
 Lifecycle Metrics
 -----------------
 
-The lifecycle trransition policies feature generates useful metrics, currently
+The lifecycle transition policies feature generates useful metrics, currently
 exposed through SoundCloud's Prometheus toolkit. Exposure through the Backbeat
 API is under development.
 


### PR DESCRIPTION
Moved note on cron schedule on existing NFS locations into a note box.

fixed a typo

This PR does very little. It changes one sentence into a Note admonition, and fixes a typo.

This PR fixes #ZENKO-1836