### PR TITLE
documentation: ZENKO-1940_Add_Manual_MongoDB_Upgrade

### DIFF
--- a/docs/docsource/installation/upgrade/upgrade_zenko.rst
+++ b/docs/docsource/installation/upgrade/upgrade_zenko.rst
@@ -101,8 +101,8 @@ To upgrade from 1.0.x to 1.1:
 
      $ helm upgrade {{zenko-release-name}} ./zenko --set cosmos.enabled=false
 
-   If you are using custom values, be sure to reuse the options.yaml file on
-   upgrades.
+   If you are using custom values, be sure to reuse your options.yaml file on
+   any upgrade.
    ::
 
       $ helm upgrade {{zenko-server-name}} ./zenko --set cosmos.enabled=false -f options.yaml
@@ -116,25 +116,61 @@ To upgrade from 1.0.x to 1.1:
 
 #. A pod is deployed. When the upgrade is successful, it shows a "Completed"
    status.
+
    ::
 
-     {{zenko-release-name}}-zenko-mongo-capabilities       0/1     Completed          0          4h
+     {{zenko-release-name}}-zenko-mongo-upgrade          0/1     Completed          0          4h
 
    .. note::
 
       Upgrade failures typically show up as an "Error" or "Crash" state.
 
-#. You can validate the upgrade was successful by checking the logs. Any errors
-   encountered during the upgrade proceedure would be listed here as well.
+#. If, after a few minutes of stabilization, ``kubectl get pods`` shows a
+   CrashLoopBackoff error involving the mongodb-upgrade pod (rather than a
+   Completed status), manually upgrade MongoDB on the primary MongoDB
+   instance. To do this:
+
+   a. Find the primary MongoDB instance with a ``kubectl logs`` query:
+
+      :: 
+
+         kubectl logs -lcomponent=mongodb-upgrade
+
+      On a three-node Zenko cluster, this returns a response resembling:
+
+      ::
+
+         kubectl logs --selector component=mongodb-upgrade                                                                                                                       
+         Checking zenko-mongodb-replicaset-0.zenko-mongodb-replicaset.default.svc.cluster.local:27017 SECONDARY
+         Checking zenko-mongodb-replicaset-1.zenko-mongodb-replicaset.default.svc.cluster.local:27017 PRIMARY
+         Checking zenko-mongodb-replicaset-2.zenko-mongodb-replicaset.default.svc.cluster.local:27017 SECONDARY
+         Unable to upgrade capabilities, manual upgrade may be neccessary
+
+   #. Enter the following command, replicating the primary instance's pod name:
+
+      ::
+
+         kubectl exec -it {{primary-zenko-pod-name}} -- mongo --eval='db.adminCommand({ setFeatureCompatibilityVersion: "3.6" });'
+
+      In the present example, this command reads:
+
+      :: 
+
+         kubectl exec -it zenko-mongodb-replicaset-1 -- mongo --eval='db.adminCommand({ setFeatureCompatibilityVersion: "3.6" });'
+
+
+#. Validate the upgrade's successful by checking the logs. Any errors
+   encountered during the upgrade procedure are listed here as well.
+
    ::
 
      $ kubectl logs --selector component=mongodb-upgrade
        Finished successfully! Compatibility set to version 3.6
 
-#. Once your upgrade is successful, these Zenko upgrade flags should not be
+#. Once the upgrade is successful, these Zenko upgrade flags are no longer
    needed for further 1.1.x upgrades. You can now run the typical upgrade command
-   to ensure the desired 1.1 state
+   to ensure the desired 1.1 state:
    ::
 
-     $ helm upgrade {{zenko-release-name}} ./zenko  -f options.yaml
+     $ helm upgrade {{zenko-release-name}} ./zenko -f options.yaml
 


### PR DESCRIPTION
This PR adds a procedure for Fixing a CrashLoopBackoff on a MongoDB upgrade.

This PR fixes issue# ZENKO-1940