### PR TITLE
improvement: increase kafka queue max heap size

### DIFF
--- a/kubernetes/zenko/values.yaml
+++ b/kubernetes/zenko/values.yaml
@@ -197,6 +197,7 @@ zenko-queue:
 ## Extensive list of configurables can be found here:
 ## https://github.com/kubernetes/charts/blob/master/incubator/kafka/values.yaml
   replicas: *nodeCount
+  kafkaHeapOptions: "-Xmx6G -Xms1G"
   rbac:
     enabled: true
   configurationOverrides:


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
Increases the Max Java heap size to 6Gb which is commonly used as a default optimal value. The default is max/min 1Gb. These changes set max of 6Gb and min 1Gb.

https://docs.confluent.io/current/kafka/deployment.html
https://www.infoq.com/articles/apache-kafka-best-practices-to-optimize-your-deployment/

