### PR TITLE
ft: reportHandler ingestion locations

### DIFF
--- a/kubernetes/zenko/charts/cloudserver/Chart.yaml
+++ b/kubernetes/zenko/charts/cloudserver/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "8.1.17"
+appVersion: "8.2.0"
 description: A Helm chart for Kubernetes
 name: cloudserver
-version: 1.1.3
+version: 1.2.0

--- a/kubernetes/zenko/charts/cloudserver/values.yaml
+++ b/kubernetes/zenko/charts/cloudserver/values.yaml
@@ -97,7 +97,7 @@ replicaFactor: 1
 
 image:
   repository: zenko/cloudserver
-  tag: 8.1.17
+  tag: 8.2.0
   pullPolicy: IfNotPresent
 
 proxy:


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
Cloudserver version bump.
 - Adds AWS and Ceph ingestion locations to the report handler for Orbit compatibility.

