### PR TITLE
bf: update registry url

### DIFF
--- a/eve/workers/testrail.yaml
+++ b/eve/workers/testrail.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
     - name: testrail
-      image: registry.oci.scality.net/testrail/testrail:0.0.1-alpha2
+      image: registry.scality.net/testrail/testrail:0.0.1-alpha2
       command: ["/bin/sh", "-c", "buildbot-worker create-worker . ${BUILDMASTER}:${BUILDMASTER_PORT} ${WORKERNAME} ${WORKERPASS} && buildbot-worker start --nodaemon"]
       resources:
         requests:


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
Fixes the reference to the old registry URL which is causing builds to get stuck on eve.

**Which issue does this PR fix?**

fixes #<ISSUE>

**Special notes for your reviewers**:
