### PR TITLE
ft: add backbeat api hpa

### DIFF
--- a/kubernetes/single-node-values.yaml
+++ b/kubernetes/single-node-values.yaml
@@ -16,6 +16,10 @@ s3-data:
     size: 10Gi
 
 backbeat:
+  api:
+    autoscaler:
+      enabled: false
+    resources: {}
   replication:
     dataProcessor:
       replicaCount: *nodeCount

--- a/kubernetes/zenko/charts/backbeat/templates/api/hpa.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/api/hpa.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.api.autoscaling.enabled -}}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "backbeat.fullname" . }}-api
+  labels:
+    app: {{ template "backbeat.name" . }}-api
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  scaleTargetRef:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: {{ template "backbeat.fullname" . }}-api
+{{ toYaml .Values.api.autoscaling.config | indent 2 }}
+{{- end -}}

--- a/kubernetes/zenko/charts/backbeat/values.yaml
+++ b/kubernetes/zenko/charts/backbeat/values.yaml
@@ -52,6 +52,14 @@ api:
       prometheus.io/scrape: "true"
       prometheus.io/port: "8900"
       prometheus.io/path: "/_/monitoring/metrics"
+  autoscaling:
+    enabled: false
+    config:
+      minReplicas: 1
+      maxReplicas: 5
+      # Note: when setting this, a `resources.request.cpu` is required. You
+      # likely want to set it to `1` or some lower value.
+      targetCPUUtilizationPercentage: 70
 
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious

--- a/kubernetes/zenko/values.yaml
+++ b/kubernetes/zenko/values.yaml
@@ -86,6 +86,16 @@ cloudserver:
       # secret:
 
 backbeat:
+  api:
+    autoscaling:
+      enabled: true
+      config:
+        maxReplicas: *nodeCount
+    resources:
+      requests:
+        cpu: 250m
+      limits:
+        cpu: 1
   replication:
     dataProcessor:
       replicaCount: *nodeCount


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
Adds a horizontal pod autoscaler to the Backbeat API deployment. This will allow the API pods to scale up to `nodeCount` as necessary in situations when a single pod starts to use more than 70% of CPU usage. This serves not only to prevent a bottleneck in the API service but as well as an indicator that the service is under heavy load.