### PR TITLE
bugfix: ZENKO-2104 Disable flaky test

### DIFF
--- a/tests/zenko_tests/node_tests/backbeat/tests/api/objectMonitor.js
+++ b/tests/zenko_tests/node_tests/backbeat/tests/api/objectMonitor.js
@@ -91,7 +91,8 @@ describe('Backbeat object monitor CRR metrics', function() {
         },
     ], done));
 
-    it('should monitor part uploads of an MPU object', done => waterfall([
+    // Disabled because the test is flaky. See ZENKO-2104.
+    it.skip('should monitor part uploads of an MPU object', done => waterfall([
         next => scalityUtils.completeMPUAWS(srcBucket, key, 50, next),
         (data, next) => {
             const path = `/_/backbeat/api/metrics/crr/${destLocation}` +


### PR DESCRIPTION
Disable a flaky CRR object monitor test while a cause/fix is being investigated.