### PR TITLE
bf: fix cloudserver prometheus scraping

### DIFF
--- a/kubernetes/zenko/Chart.yaml
+++ b/kubernetes/zenko/Chart.yaml
@@ -1,6 +1,6 @@
 name: zenko
-version: 1.1.3
-appVersion: 1.1.3
+version: 1.1.4
+appVersion: 1.1.4
 kubeVersion: ">=1.11.3-0"
 description: Zenko is the open source multi-cloud data controller
 home: https://www.zenko.io/

--- a/kubernetes/zenko/charts/cloudserver/Chart.yaml
+++ b/kubernetes/zenko/charts/cloudserver/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "8.1.17"
 description: A Helm chart for Kubernetes
 name: cloudserver
-version: 1.1.3
+version: 1.1.4

--- a/kubernetes/zenko/charts/cloudserver/dashboards/cloudserver.json
+++ b/kubernetes/zenko/charts/cloudserver/dashboards/cloudserver.json
@@ -1204,8 +1204,8 @@
     ]
   },
   "time": {
-    "from": "2018-08-24T19:23:30.943Z",
-    "to": "2018-08-24T19:33:30.943Z"
+    "from": "now-15m",
+    "to": "now"
   },
   "timepicker": {
     "refresh_intervals": [

--- a/kubernetes/zenko/charts/cloudserver/templates/deployment.yaml
+++ b/kubernetes/zenko/charts/cloudserver/templates/deployment.yaml
@@ -16,12 +16,20 @@ spec:
   template:
     metadata:
       annotations:
+        {{- if .Values.metrics.enabled }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8000"
+        prometheus.io/path: "/_/monitoring/metrics"
+        {{- end }}
         {{- if .Values.proxy.https }}
         checksum/config: {{ include (print $.Template.BasePath "/certificate.yaml") . | sha256sum }}
         {{- end }}
         {{- if not .Values.global.orbit.enabled }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/config: {{ include (print $.Template.BasePath "/accounts.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if .Values.annotations }}
+{{ toYaml .Values.annotations | indent 8 }}
         {{- end }}
       labels:
         app: {{ template "cloudserver.name" . }}

--- a/kubernetes/zenko/charts/cloudserver/values.yaml
+++ b/kubernetes/zenko/charts/cloudserver/values.yaml
@@ -77,6 +77,10 @@ logging:
 
 allowHealthchecksFrom: '0.0.0.0/0'
 
+# enables prometheus metrics and service discovery
+metrics:
+  enabled: true
+
 env: {}
 
 mongodb:
@@ -118,10 +122,6 @@ proxy:
 service:
   type: ClusterIP
   port: 80
-  annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "8000"
-    prometheus.io/path: "/_/monitoring/metrics"
 
 ingress:
   enabled: false


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
Fixes the Prometheus metrics scraping for the Cloudserver. This allows the Cloudserver Grafana Dashboard to function and report per pod metrics from the deployment.