### PR TITLE
documentation: ZENKOIO-98 non-parallel_heading_in_install_guide

### DIFF
--- a/docs/docsource/installation/index.rst
+++ b/docs/docsource/installation/index.rst
@@ -8,4 +8,4 @@ Zenko Installation
    install/index
    configure/index
    upgrade/upgrade_zenko
-   uninstall
+   uninstall/index

--- a/docs/docsource/installation/uninstall/index.rst
+++ b/docs/docsource/installation/uninstall/index.rst
@@ -1,5 +1,5 @@
-Uninstalling a Zenko Deployment
--------------------------------
+Uninstall
+=========
 
 To uninstall/delete the “my-zenko” deployment:
 
@@ -8,4 +8,4 @@ To uninstall/delete the “my-zenko” deployment:
    $ helm delete my-zenko
 
 The command removes all Kubernetes components associated with the
-chart and deletes the release.
+chart and deletes the deployed instance.


### PR DESCRIPTION
This PR changes the non-parallel heading "Uninstalling a Zenko..." to "Uninstall" to match other
first-level headings.

This PR fixes ZENKOIO-98
