### PR TITLE
documentation: ZENKOIO-98 non-parallel_heading_in_install_guide

### DIFF
--- a/docs/docsource/installation/index.rst
+++ b/docs/docsource/installation/index.rst
@@ -8,4 +8,4 @@ Zenko Installation
    install/index
    configure/index
    upgrade/upgrade_zenko
-   uninstall
+   uninstall/index

--- a/docs/docsource/installation/uninstall/index.rst
+++ b/docs/docsource/installation/uninstall/index.rst
@@ -1,5 +1,5 @@
-Uninstalling a Zenko Deployment
--------------------------------
+Uninstall
+=========
 
 To uninstall/delete the “my-zenko” deployment:
 
@@ -8,4 +8,4 @@ To uninstall/delete the “my-zenko” deployment:
    $ helm delete my-zenko
 
 The command removes all Kubernetes components associated with the
-chart and deletes the release.
+chart and deletes the deployed instance.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    tox -e pip-compile
 #
--e git+https://github.com/scality/sphinx-tools.git@v1.1#egg=sphinx_scality
+-e git+https://github.com/scality/sphinx-tools.git@v1.0#egg=sphinx_scality
 alabaster==0.7.12         # via sphinx
 attrs==19.1.0             # via packaging
 babel==2.7.0              # via sphinx


### PR DESCRIPTION
Changed non-parallel heading "Uninstalling a Zenko..." to "Uninstall" to match other
first-level headings.

Renamed this PR, because the old name was not pleasing to Bert-E the Malevolent. 

This PR fixes ZENKOIO-98