### PR TITLE
ft: Watch for location credential updates from Orbit

### DIFF
--- a/cosmos/scheduler/Makefile
+++ b/cosmos/scheduler/Makefile
@@ -1,5 +1,5 @@
 COSMOS_IMAGE := zenko/cosmos-scheduler
-COSMOS_TAG := 0.5.0
+COSMOS_TAG := 0.5.1
 COSMOS_BINARY := ./scheduler
 
 .PHONY: setup

--- a/kubernetes/zenko/values.yaml
+++ b/kubernetes/zenko/values.yaml
@@ -144,7 +144,7 @@ cosmos:
   scheduler:
     image:
       repository: zenko/cosmos-scheduler
-      tag: 0.5.0
+      tag: 0.5.1
       pullPolicy: IfNotPresent
 
     ## A namespace to watch can be specified otherwise will default to the


### PR DESCRIPTION
What does this PR do, and why do we need it?
Refactors some of the credential management into a reconciler to reduce duplicated code. In doing this I was able to more easily add a new function that will validate that all the location credentials are up-to-date or update them if they are not on every new overlay pushed from Orbit (e.g. any location changes). This function can be later extended to validate the location state against CRD state.