### PR TITLE
ft: chart release script

### DIFF
--- a/eve/scripts/release
+++ b/eve/scripts/release
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+
+import argparse
+import io
+import sys
+# this is the only external dependency
+import ruamel.yaml
+
+
+PY2  = sys.version_info[0] == 2
+
+if PY2:
+    from urllib2        import urlopen, HTTPError
+else:
+    from urllib.request import urlopen
+    from urllib.error   import HTTPError
+
+RELATIVE_PATH = '../../kubernetes/zenko'
+MAJOR = '8'
+CHANGES = [
+    'appVersion',
+    'version',
+]
+CHARTS = [
+    'cloudserver',
+    's3-data',
+    'backbeat',
+]
+URL = 'https://github.com/scality/{}/releases/tag/{}.{}.{}'
+CHART_PATH = '{}/charts/{}/Chart.yaml'
+VALUES_PATH = _PATH = '{}/charts/{}/values.yaml'
+
+def get_args():
+    parser = argparse.ArgumentParser(description='Release Generation Script for Zenko',
+        epilog='This script assumes that docker images have already been built and will'
+          'simply look for the latest release corresponding to the minor version.')
+    parser.add_argument('version', action='store', metavar='version', help='intended release version e.g 1.3.2')
+    parser.add_argument('path', action='store', metavar='path', default=RELATIVE_PATH,
+        help='The path to the Zenko chart folder. If not set, will assume it is currently'
+          'in the eve/scripts folder and attempt a build.')
+    parser.add_argument('-v', '--verbose', action='store_true', help='Verbose mode')
+    return parser.parse_args()
+
+def open_file(path, verbose=False):
+    yaml = ruamel.yaml.YAML()
+    with io.open(path, 'r') as stream:
+        if verbose:
+            print("opening %s" % path)
+        return yaml.load(stream)
+
+def save_file(data, path, verbose=False):
+    yaml = ruamel.yaml.YAML()
+    with io.open(path, 'w', encoding='utf8') as outfile:
+        if verbose:
+            print("saving %s" % path)
+        yaml.dump(data, outfile)
+
+def update_chart(chart, values, chart_version, app_version, verbose=False, dep=True):
+    chart['version'] = chart_version
+    if dep:
+        tag = '{}.{}.{}'.format(MAJOR, app_version[0], app_version[1])
+        chart['appVersion'] = tag
+        values['image']['tag'] = tag
+    else:
+        chart['appVersion'] = chart_version
+    if verbose:
+        print(chart)
+        if dep:
+            print(tag)
+            print(values['image'])
+    return chart, values
+
+
+args = get_args()
+if args.verbose:
+    print(args)
+version = args.version.split('.', 3)
+zenko_version = {
+    'major' : version[0],
+    'minor' : version[1],
+    'patch' : version[2],
+}
+
+# update sub charts
+for chart in CHARTS:
+    patch = 0
+    while True:
+        try:
+            if args.verbose:
+                print('looking for latest %s release tag: %s.%s.%s' % (chart, MAJOR, zenko_version['minor'], patch))
+            if chart == 's3-data':
+                repo = 'cloudserver'
+            else:
+                repo = chart
+            urlopen(URL.format(repo, MAJOR, zenko_version['minor'], patch))
+            patch += 1
+        except HTTPError:
+            patch -= 1
+            if args.verbose:
+                print('latest %s release tag found: %s.%s.%s' % (chart, MAJOR, zenko_version['minor'], patch))
+            break
+    chart_path = CHART_PATH.format(args.path, chart)
+    values_path = VALUES_PATH.format(args.path, chart)
+    chart, values = update_chart(open_file(chart_path, verbose=args.verbose), open_file(values_path, verbose=args.verbose),
+        args.version, [zenko_version['minor'], patch], verbose=args.verbose)
+    save_file(chart, chart_path)
+    save_file(values, values_path)
+# update Zenko
+update_chart(open_file('%s/Chart.yaml' % args.path, verbose=args.verbose), None, args.version, None, verbose=args.verbose, dep=False)

--- a/kubernetes/zenko/charts/backbeat/Chart.yaml
+++ b/kubernetes/zenko/charts/backbeat/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "8.2.0"
+appVersion: 8.2.0
 description: A Helm chart for Zenko Backbeat
 name: backbeat
-version: 1.2.0
+version: 1.2.0-rc.1

--- a/kubernetes/zenko/charts/backbeat/values.yaml
+++ b/kubernetes/zenko/charts/backbeat/values.yaml
@@ -15,7 +15,7 @@ image:
 
 logging:
    # Options: info, debug, trace
-   level: info
+  level: info
 
 mongodb:
   replicaSet: rs0
@@ -33,14 +33,14 @@ health:
 
 monitoring:
   annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "4042"
-    prometheus.io/path: "/_/monitoring/metrics"
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '4042'
+    prometheus.io/path: /_/monitoring/metrics
   collectDefaultMetricsIntervalMs: 10000
 
 kafka:
   backlog_metrics:
-    path: "/backbeat/run/kafka-backlog-metrics"
+    path: /backbeat/run/kafka-backlog-metrics
     interval: 60
 
 api:
@@ -49,9 +49,9 @@ api:
     name: backbeat-api
     type: ClusterIP
     annotations:
-      prometheus.io/scrape: "true"
-      prometheus.io/port: "8900"
-      prometheus.io/path: "/_/monitoring/metrics"
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '8900'
+      prometheus.io/path: /_/monitoring/metrics
   autoscaling:
     enabled: false
     config:
@@ -96,7 +96,7 @@ ingestion:
 
 lifecycle:
   conductor:
-    cronRule: "0 */6 * * *"
+    cronRule: 0 */6 * * *
     resources: {}
     nodeSelector: {}
     tolerations: []
@@ -119,15 +119,15 @@ lifecycle:
     affinity: {}
 
   zookeeper:
-    path: "/lifecycle"
+    path: /lifecycle
 
   rules:
     expiration:
-      enabled: True
+      enabled: true
     noncurrentVersionExpiration:
-      enabled: True
+      enabled: true
     abortIncompleteMPU:
-      enabled: True
+      enabled: true
 
 replication:
   dataProcessor:

--- a/kubernetes/zenko/charts/cloudserver/Chart.yaml
+++ b/kubernetes/zenko/charts/cloudserver/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "8.2.1"
+appVersion: 8.2.2
 description: A Helm chart for Kubernetes
 name: cloudserver
-version: 1.2.0
+version: 1.2.0-rc.1

--- a/kubernetes/zenko/charts/cloudserver/values.yaml
+++ b/kubernetes/zenko/charts/cloudserver/values.yaml
@@ -57,12 +57,12 @@ externalBackends:
     keepAlive: false
     keepAliveMsecs: 1000
     maxFreeSockets: 256
-    maxSockets: null
+    maxSockets:
   gcp:
     keepAlive: true
     keepAliveMsecs: 1000
     maxFreeSockets: 256
-    maxSockets: null
+    maxSockets:
 
 endpoint: zenko.local
 
@@ -73,9 +73,9 @@ users: {}
 
 logging:
    # Options: info, debug, trace
-   level: info
+  level: info
 
-allowHealthchecksFrom: '0.0.0.0/0'
+allowHealthchecksFrom: 0.0.0.0/0
 
 # enables prometheus metrics and service discovery
 metrics:
@@ -114,10 +114,10 @@ proxy:
   # Note: To avoid unexpected behavior, only specify one of "http" or "https"
   # proxy options.
   # If you have exceptions to proxification you can use the no_proxy variable.
-  http: ""
-  https: ""
+  http: ''
+  https: ''
   caCert: false
-  no_proxy: ""
+  no_proxy: ''
 
 service:
   type: ClusterIP
@@ -132,7 +132,7 @@ ingress:
   # This must match 'endpoint', unless your client supports different
   # hostnames.
   hosts:
-    - zenko.local
+  - zenko.local
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
@@ -148,7 +148,7 @@ kmip:
 
 vault:
   enabled: false
-  host: "zenko-vault"
+  host: zenko-vault
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/kubernetes/zenko/charts/s3-data/Chart.yaml
+++ b/kubernetes/zenko/charts/s3-data/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "8.2.2"
+appVersion: 8.2.2
 description: A Helm chart for Kubernetes
 name: s3-data
-version: 1.2.0
+version: 1.2.0-rc.1

--- a/kubernetes/zenko/charts/s3-data/values.yaml
+++ b/kubernetes/zenko/charts/s3-data/values.yaml
@@ -26,12 +26,12 @@ noCache: true
 persistentVolume:
   enabled: true
   accessModes:
-    - ReadWriteOnce
+  - ReadWriteOnce
   annotations: {}
-  existingClaim: ""
+  existingClaim: ''
   size: 90Gi
   # storageClass: "-"
-allowHealthchecksFrom: '0.0.0.0/0'
+allowHealthchecksFrom: 0.0.0.0/0
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
- The first commit adds a script that takes the intended release version as an argument and optional path to the zenko folder (otherwise assumes it is being ran relative to `eve/scripts`). It will then look for the latest CloudServer and Backbeat images based off the corresponding minor version (1.2.x release will look for latest CloudServer/Backbeat 8.2.x).
Usage example: `./release 1.2.0-rc.1 [path to zenko]`

- The second commit makes the `values.yaml` and `Chart.yaml` follow a uniform spec. While there is a visual diff, functionally it is the same.

