### PR TITLE
documentation: ZENKOIO-117 2nd fix parameter that breaks PDF output

### DIFF
--- a/docs/docsource/Makefile
+++ b/docs/docsource/Makefile
@@ -32,4 +32,7 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -t $@ -t install
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -t $@ -t operation
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -t $@ -t reference
+

--- a/docs/docsource/conf.py
+++ b/docs/docsource/conf.py
@@ -199,7 +199,7 @@ latex_elements = {
     'preamble': scaldoc.resources.get_latex_preamble(
         cover=os.path.basename(latex_cover),
         logo=os.path.basename(latex_logo),
-        title='latex_title',
+        title=latex_title,
         title_voffset='85pt',
         version=release,
         copyright=copyright
@@ -216,30 +216,30 @@ latex_additional_files.extend(scaldoc.resources.get_fonts())
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 
-# if tags.has('install'):
-#    latex_documents = [(
-#       'installation/index_pdf',
-#       'Zenko_Installation.tex',
-#       'Zenko Installation Documentation',
-#       'Scality Technical Publications',
-#       'manual'
-#    )]
-# elif tags.has('operation'):
-#    latex_documents = [(
-#       'operation/index_pdf',
-#       'Zenko_Operation.tex',
-#       'Zenko Operation Documentation',
-#       'Scality Technical Publications',
-#       'manual'
-#    )]
-# elif tags.has('reference'):
-#    latex_documents = [(
-#       'reference/index_pdf',
-#       'Zenko_Reference.tex',
-#       'Zenko Reference Documentation',
-#       'Scality Technical Publications',
-#       'manual'
-#    )]
+if tags.has('install'):
+   latex_documents = [(
+      'installation/index',
+      'Zenko_Installation.tex',
+      'Zenko Installation Documentation',
+      'Scality Technical Publications',
+      'manual'
+   )]
+elif tags.has('operation'):
+   latex_documents = [(
+      'operation/index',
+      'Zenko_Operation.tex',
+      'Zenko Operation Documentation',
+      'Scality Technical Publications',
+      'manual'
+   )]
+elif tags.has('reference'):
+   latex_documents = [(
+      'reference/index',
+      'Zenko_Reference.tex',
+      'Zenko Reference Documentation',
+      'Scality Technical Publications',
+      'manual'
+   )]
 
 # Override the default formatter with our custom one.
 

--- a/docs/docsource/templates/preamble.tex
+++ b/docs/docsource/templates/preamble.tex
@@ -63,7 +63,7 @@
 \addto\captionsenglish{\renewcommand{\contentsname}{Contents}}
 
 % Redefine the \maketitle command to customize the front page.
-\renewcommand{\maketitle}{
+\renewcommand{\sphinxmaketitle}{
     \begin{titlepage}
 
         % Redefine the margins for the title page.


### PR DESCRIPTION
This PR fixes a LaTeX template parameter that was breaking PDF output. Also made changes to Makefile and conf.py.

This PR fixes #ZENKOIO-117 