### PR TITLE
INTEGRATION [PR#885 > development/1.2] documentation: ZENKOIO-117 2nd fixed parameter that broke PDF output

### DIFF
--- a/docs/docsource/Makefile
+++ b/docs/docsource/Makefile
@@ -32,4 +32,7 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -t $@ -t install
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -t $@ -t operation
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -t $@ -t reference
+

--- a/docs/docsource/conf.py
+++ b/docs/docsource/conf.py
@@ -199,7 +199,7 @@ latex_elements = {
     'preamble': scaldoc.resources.get_latex_preamble(
         cover=os.path.basename(latex_cover),
         logo=os.path.basename(latex_logo),
-        title='latex_title',
+        title=latex_title,
         title_voffset='85pt',
         version=release,
         copyright=copyright
@@ -216,30 +216,30 @@ latex_additional_files.extend(scaldoc.resources.get_fonts())
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 
-# if tags.has('install'):
-#    latex_documents = [(
-#       'installation/index_pdf',
-#       'Zenko_Installation.tex',
-#       'Zenko Installation Documentation',
-#       'Scality Technical Publications',
-#       'manual'
-#    )]
-# elif tags.has('operation'):
-#    latex_documents = [(
-#       'operation/index_pdf',
-#       'Zenko_Operation.tex',
-#       'Zenko Operation Documentation',
-#       'Scality Technical Publications',
-#       'manual'
-#    )]
-# elif tags.has('reference'):
-#    latex_documents = [(
-#       'reference/index_pdf',
-#       'Zenko_Reference.tex',
-#       'Zenko Reference Documentation',
-#       'Scality Technical Publications',
-#       'manual'
-#    )]
+if tags.has('install'):
+   latex_documents = [(
+      'installation/index',
+      'Zenko_Installation.tex',
+      'Zenko Installation Documentation',
+      'Scality Technical Publications',
+      'manual'
+   )]
+elif tags.has('operation'):
+   latex_documents = [(
+      'operation/index',
+      'Zenko_Operation.tex',
+      'Zenko Operation Documentation',
+      'Scality Technical Publications',
+      'manual'
+   )]
+elif tags.has('reference'):
+   latex_documents = [(
+      'reference/index',
+      'Zenko_Reference.tex',
+      'Zenko Reference Documentation',
+      'Scality Technical Publications',
+      'manual'
+   )]
 
 # Override the default formatter with our custom one.
 

--- a/docs/docsource/templates/preamble.tex
+++ b/docs/docsource/templates/preamble.tex
@@ -63,7 +63,7 @@
 \addto\captionsenglish{\renewcommand{\contentsname}{Contents}}
 
 % Redefine the \maketitle command to customize the front page.
-\renewcommand{\maketitle}{
+\renewcommand{\sphinxmaketitle}{
     \begin{titlepage}
 
         % Redefine the margins for the title page.


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #885.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/1.2/documentation/ZENKOIO-117_2nd_fix_broken_latexpdf_covers`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/1.2/documentation/ZENKOIO-117_2nd_fix_broken_latexpdf_covers
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/1.2/documentation/ZENKOIO-117_2nd_fix_broken_latexpdf_covers
```

Please always comment pull request #885 instead of this one.