### PR TITLE
feat(ZENKO-1987): Add opal chart

### DIFF
--- a/eve/ci-values.yaml
+++ b/eve/ci-values.yaml
@@ -261,3 +261,9 @@ mgob:
 burry:
   persistentVolume:
     enabled: false
+
+opal:
+  blobserver:
+    enabled: True
+    imagePullSecret: registry
+  

--- a/kubernetes/cert-manager-crds/Chart.yaml
+++ b/kubernetes/cert-manager-crds/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "v0.11.0"
+description: CustomResourceDefinitions for cert-manager
+name: cert-manager-crds
+version: v0.11.0

--- a/kubernetes/cert-manager-crds/templates/cert-manager-crds-0.11.0.yaml
+++ b/kubernetes/cert-manager-crds/templates/cert-manager-crds-0.11.0.yaml
@@ -1,0 +1,5354 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: challenges.acme.cert-manager.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.state
+    name: State
+    type: string
+  - JSONPath: .spec.dnsName
+    name: Domain
+    type: string
+  - JSONPath: .status.reason
+    name: Reason
+    priority: 1
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC.
+    name: Age
+    type: date
+  group: acme.cert-manager.io
+  names:
+    kind: Challenge
+    listKind: ChallengeList
+    plural: challenges
+    singular: challenge
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Challenge is a type to represent a Challenge request with an ACME
+        server
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            authzURL:
+              description: AuthzURL is the URL to the ACME Authorization resource
+                that this challenge is a part of.
+              type: string
+            dnsName:
+              description: DNSName is the identifier that this challenge is for, e.g.
+                example.com.
+              type: string
+            issuerRef:
+              description: IssuerRef references a properly configured ACME-type Issuer
+                which should be used to create this Challenge. If the Issuer does
+                not exist, processing will be retried. If the Issuer is not an 'ACME'
+                Issuer, an error will be returned and the Challenge will be marked
+                as failed.
+              properties:
+                group:
+                  type: string
+                kind:
+                  type: string
+                name:
+                  type: string
+              required:
+              - name
+              type: object
+            key:
+              description: Key is the ACME challenge key for this challenge
+              type: string
+            solver:
+              description: Solver contains the domain solving configuration that should
+                be used to solve this challenge resource. Only **one** of 'config'
+                or 'solver' may be specified, and if both are specified then no action
+                will be performed on the Challenge resource.
+              properties:
+                dns01:
+                  properties:
+                    acmedns:
+                      description: ACMEIssuerDNS01ProviderAcmeDNS is a structure containing
+                        the configuration for ACME-DNS servers
+                      properties:
+                        accountSecretRef:
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        host:
+                          type: string
+                      required:
+                      - accountSecretRef
+                      - host
+                      type: object
+                    akamai:
+                      description: ACMEIssuerDNS01ProviderAkamai is a structure containing
+                        the DNS configuration for Akamai DNS—Zone Record Management
+                        API
+                      properties:
+                        accessTokenSecretRef:
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        clientSecretSecretRef:
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        clientTokenSecretRef:
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        serviceConsumerDomain:
+                          type: string
+                      required:
+                      - accessTokenSecretRef
+                      - clientSecretSecretRef
+                      - clientTokenSecretRef
+                      - serviceConsumerDomain
+                      type: object
+                    azuredns:
+                      description: ACMEIssuerDNS01ProviderAzureDNS is a structure
+                        containing the configuration for Azure DNS
+                      properties:
+                        clientID:
+                          type: string
+                        clientSecretSecretRef:
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        environment:
+                          enum:
+                          - AzurePublicCloud
+                          - AzureChinaCloud
+                          - AzureGermanCloud
+                          - AzureUSGovernmentCloud
+                          type: string
+                        hostedZoneName:
+                          type: string
+                        resourceGroupName:
+                          type: string
+                        subscriptionID:
+                          type: string
+                        tenantID:
+                          type: string
+                      required:
+                      - clientID
+                      - clientSecretSecretRef
+                      - resourceGroupName
+                      - subscriptionID
+                      - tenantID
+                      type: object
+                    clouddns:
+                      description: ACMEIssuerDNS01ProviderCloudDNS is a structure
+                        containing the DNS configuration for Google Cloud DNS
+                      properties:
+                        project:
+                          type: string
+                        serviceAccountSecretRef:
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - project
+                      - serviceAccountSecretRef
+                      type: object
+                    cloudflare:
+                      description: ACMEIssuerDNS01ProviderCloudflare is a structure
+                        containing the DNS configuration for Cloudflare
+                      properties:
+                        apiKeySecretRef:
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        email:
+                          type: string
+                      required:
+                      - apiKeySecretRef
+                      - email
+                      type: object
+                    cnameStrategy:
+                      description: CNAMEStrategy configures how the DNS01 provider
+                        should handle CNAME records when found in DNS zones.
+                      enum:
+                      - None
+                      - Follow
+                      type: string
+                    digitalocean:
+                      description: ACMEIssuerDNS01ProviderDigitalOcean is a structure
+                        containing the DNS configuration for DigitalOcean Domains
+                      properties:
+                        tokenSecretRef:
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - tokenSecretRef
+                      type: object
+                    rfc2136:
+                      description: ACMEIssuerDNS01ProviderRFC2136 is a structure containing
+                        the configuration for RFC2136 DNS
+                      properties:
+                        nameserver:
+                          description: 'The IP address of the DNS supporting RFC2136.
+                            Required. Note: FQDN is not a valid value, only IP.'
+                          type: string
+                        tsigAlgorithm:
+                          description: 'The TSIG Algorithm configured in the DNS supporting
+                            RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName``
+                            are defined. Supported values are (case-insensitive):
+                            ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or
+                            ``HMACSHA512``.'
+                          type: string
+                        tsigKeyName:
+                          description: The TSIG Key name configured in the DNS. If
+                            ``tsigSecretSecretRef`` is defined, this field is required.
+                          type: string
+                        tsigSecretSecretRef:
+                          description: The name of the secret containing the TSIG
+                            value. If ``tsigKeyName`` is defined, this field is required.
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - nameserver
+                      type: object
+                    route53:
+                      description: ACMEIssuerDNS01ProviderRoute53 is a structure containing
+                        the Route 53 configuration for AWS
+                      properties:
+                        accessKeyID:
+                          description: 'The AccessKeyID is used for authentication.
+                            If not set we fall-back to using env vars, shared credentials
+                            file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                          type: string
+                        hostedZoneID:
+                          description: If set, the provider will manage only this
+                            zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName
+                            api call.
+                          type: string
+                        region:
+                          description: Always set the region when using AccessKeyID
+                            and SecretAccessKey
+                          type: string
+                        role:
+                          description: Role is a Role ARN which the Route53 provider
+                            will assume using either the explicit credentials AccessKeyID/SecretAccessKey
+                            or the inferred credentials from environment variables,
+                            shared credentials file or AWS Instance metadata
+                          type: string
+                        secretAccessKeySecretRef:
+                          description: The SecretAccessKey is used for authentication.
+                            If not set we fall-back to using env vars, shared credentials
+                            file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - region
+                      type: object
+                    webhook:
+                      description: ACMEIssuerDNS01ProviderWebhook specifies configuration
+                        for a webhook DNS01 provider, including where to POST ChallengePayload
+                        resources.
+                      properties:
+                        config:
+                          description: Additional configuration that should be passed
+                            to the webhook apiserver when challenges are processed.
+                            This can contain arbitrary JSON data. Secret values should
+                            not be specified in this stanza. If secret values are
+                            needed (e.g. credentials for a DNS service), you should
+                            use a SecretKeySelector to reference a Secret resource.
+                            For details on the schema of this field, consult the webhook
+                            provider implementation's documentation.
+                          x-kubernetes-preserve-unknown-fields: true
+                        groupName:
+                          description: The API group name that should be used when
+                            POSTing ChallengePayload resources to the webhook apiserver.
+                            This should be the same as the GroupName specified in
+                            the webhook provider implementation.
+                          type: string
+                        solverName:
+                          description: The name of the solver to use, as defined in
+                            the webhook provider implementation. This will typically
+                            be the name of the provider, e.g. 'cloudflare'.
+                          type: string
+                      required:
+                      - groupName
+                      - solverName
+                      type: object
+                  type: object
+                http01:
+                  description: ACMEChallengeSolverHTTP01 contains configuration detailing
+                    how to solve HTTP01 challenges within a Kubernetes cluster. Typically
+                    this is accomplished through creating 'routes' of some description
+                    that configure ingress controllers to direct traffic to 'solver
+                    pods', which are responsible for responding to the ACME server's
+                    HTTP requests.
+                  properties:
+                    ingress:
+                      description: The ingress based HTTP01 challenge solver will
+                        solve challenges by creating or modifying Ingress resources
+                        in order to route requests for '/.well-known/acme-challenge/XYZ'
+                        to 'challenge solver' pods that are provisioned by cert-manager
+                        for each Challenge to be completed.
+                      properties:
+                        class:
+                          description: The ingress class to use when creating Ingress
+                            resources to solve ACME challenges that use this challenge
+                            solver. Only one of 'class' or 'name' may be specified.
+                          type: string
+                        name:
+                          description: The name of the ingress resource that should
+                            have ACME challenge solving routes inserted into it in
+                            order to solve HTTP01 challenges. This is typically used
+                            in conjunction with ingress controllers like ingress-gce,
+                            which maintains a 1:1 mapping between external IPs and
+                            ingress resources.
+                          type: string
+                        podTemplate:
+                          description: Optional pod template used to configure the
+                            ACME challenge solver pods used for HTTP01 challenges
+                          properties:
+                            metadata:
+                              description: ObjectMeta overrides for the pod used to
+                                solve HTTP01 challenges. Only the 'labels' and 'annotations'
+                                fields may be set. If labels or annotations overlap
+                                with in-built values, the values here will override
+                                the in-built values.
+                              type: object
+                            spec:
+                              description: PodSpec defines overrides for the HTTP01
+                                challenge solver pod. Only the 'nodeSelector', 'affinity'
+                                and 'tolerations' fields are supported currently.
+                                All other fields will be ignored.
+                              properties:
+                                affinity:
+                                  description: If specified, the pod's scheduling
+                                    constraints
+                                  properties:
+                                    nodeAffinity:
+                                      description: Describes node affinity scheduling
+                                        rules for the pod.
+                                      properties:
+                                        preferredDuringSchedulingIgnoredDuringExecution:
+                                          description: The scheduler will prefer to
+                                            schedule pods to nodes that satisfy the
+                                            affinity expressions specified by this
+                                            field, but it may choose a node that violates
+                                            one or more of the expressions. The node
+                                            that is most preferred is the one with
+                                            the greatest sum of weights, i.e. for
+                                            each node that meets all of the scheduling
+                                            requirements (resource request, requiredDuringScheduling
+                                            affinity expressions, etc.), compute a
+                                            sum by iterating through the elements
+                                            of this field and adding "weight" to the
+                                            sum if the node matches the corresponding
+                                            matchExpressions; the node(s) with the
+                                            highest sum are the most preferred.
+                                          items:
+                                            description: An empty preferred scheduling
+                                              term matches all objects with implicit
+                                              weight 0 (i.e. it's a no-op). A null
+                                              preferred scheduling term matches no
+                                              objects (i.e. is also a no-op).
+                                            properties:
+                                              preference:
+                                                description: A node selector term,
+                                                  associated with the corresponding
+                                                  weight.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: A list of node selector
+                                                      requirements by node's labels.
+                                                    items:
+                                                      description: A node selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: The label key
+                                                            that the selector applies
+                                                            to.
+                                                          type: string
+                                                        operator:
+                                                          description: Represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists, DoesNotExist.
+                                                            Gt, and Lt.
+                                                          type: string
+                                                        values:
+                                                          description: An array of
+                                                            string values. If the
+                                                            operator is In or NotIn,
+                                                            the values array must
+                                                            be non-empty. If the operator
+                                                            is Exists or DoesNotExist,
+                                                            the values array must
+                                                            be empty. If the operator
+                                                            is Gt or Lt, the values
+                                                            array must have a single
+                                                            element, which will be
+                                                            interpreted as an integer.
+                                                            This array is replaced
+                                                            during a strategic merge
+                                                            patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchFields:
+                                                    description: A list of node selector
+                                                      requirements by node's fields.
+                                                    items:
+                                                      description: A node selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: The label key
+                                                            that the selector applies
+                                                            to.
+                                                          type: string
+                                                        operator:
+                                                          description: Represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists, DoesNotExist.
+                                                            Gt, and Lt.
+                                                          type: string
+                                                        values:
+                                                          description: An array of
+                                                            string values. If the
+                                                            operator is In or NotIn,
+                                                            the values array must
+                                                            be non-empty. If the operator
+                                                            is Exists or DoesNotExist,
+                                                            the values array must
+                                                            be empty. If the operator
+                                                            is Gt or Lt, the values
+                                                            array must have a single
+                                                            element, which will be
+                                                            interpreted as an integer.
+                                                            This array is replaced
+                                                            during a strategic merge
+                                                            patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              weight:
+                                                description: Weight associated with
+                                                  matching the corresponding nodeSelectorTerm,
+                                                  in the range 1-100.
+                                                format: int32
+                                                type: integer
+                                            required:
+                                            - preference
+                                            - weight
+                                            type: object
+                                          type: array
+                                        requiredDuringSchedulingIgnoredDuringExecution:
+                                          description: If the affinity requirements
+                                            specified by this field are not met at
+                                            scheduling time, the pod will not be scheduled
+                                            onto the node. If the affinity requirements
+                                            specified by this field cease to be met
+                                            at some point during pod execution (e.g.
+                                            due to an update), the system may or may
+                                            not try to eventually evict the pod from
+                                            its node.
+                                          properties:
+                                            nodeSelectorTerms:
+                                              description: Required. A list of node
+                                                selector terms. The terms are ORed.
+                                              items:
+                                                description: A null or empty node
+                                                  selector term matches no objects.
+                                                  The requirements of them are ANDed.
+                                                  The TopologySelectorTerm type implements
+                                                  a subset of the NodeSelectorTerm.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: A list of node selector
+                                                      requirements by node's labels.
+                                                    items:
+                                                      description: A node selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: The label key
+                                                            that the selector applies
+                                                            to.
+                                                          type: string
+                                                        operator:
+                                                          description: Represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists, DoesNotExist.
+                                                            Gt, and Lt.
+                                                          type: string
+                                                        values:
+                                                          description: An array of
+                                                            string values. If the
+                                                            operator is In or NotIn,
+                                                            the values array must
+                                                            be non-empty. If the operator
+                                                            is Exists or DoesNotExist,
+                                                            the values array must
+                                                            be empty. If the operator
+                                                            is Gt or Lt, the values
+                                                            array must have a single
+                                                            element, which will be
+                                                            interpreted as an integer.
+                                                            This array is replaced
+                                                            during a strategic merge
+                                                            patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchFields:
+                                                    description: A list of node selector
+                                                      requirements by node's fields.
+                                                    items:
+                                                      description: A node selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: The label key
+                                                            that the selector applies
+                                                            to.
+                                                          type: string
+                                                        operator:
+                                                          description: Represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists, DoesNotExist.
+                                                            Gt, and Lt.
+                                                          type: string
+                                                        values:
+                                                          description: An array of
+                                                            string values. If the
+                                                            operator is In or NotIn,
+                                                            the values array must
+                                                            be non-empty. If the operator
+                                                            is Exists or DoesNotExist,
+                                                            the values array must
+                                                            be empty. If the operator
+                                                            is Gt or Lt, the values
+                                                            array must have a single
+                                                            element, which will be
+                                                            interpreted as an integer.
+                                                            This array is replaced
+                                                            during a strategic merge
+                                                            patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              type: array
+                                          required:
+                                          - nodeSelectorTerms
+                                          type: object
+                                      type: object
+                                    podAffinity:
+                                      description: Describes pod affinity scheduling
+                                        rules (e.g. co-locate this pod in the same
+                                        node, zone, etc. as some other pod(s)).
+                                      properties:
+                                        preferredDuringSchedulingIgnoredDuringExecution:
+                                          description: The scheduler will prefer to
+                                            schedule pods to nodes that satisfy the
+                                            affinity expressions specified by this
+                                            field, but it may choose a node that violates
+                                            one or more of the expressions. The node
+                                            that is most preferred is the one with
+                                            the greatest sum of weights, i.e. for
+                                            each node that meets all of the scheduling
+                                            requirements (resource request, requiredDuringScheduling
+                                            affinity expressions, etc.), compute a
+                                            sum by iterating through the elements
+                                            of this field and adding "weight" to the
+                                            sum if the node has pods which matches
+                                            the corresponding podAffinityTerm; the
+                                            node(s) with the highest sum are the most
+                                            preferred.
+                                          items:
+                                            description: The weights of all of the
+                                              matched WeightedPodAffinityTerm fields
+                                              are added per-node to find the most
+                                              preferred node(s)
+                                            properties:
+                                              podAffinityTerm:
+                                                description: Required. A pod affinity
+                                                  term, associated with the corresponding
+                                                  weight.
+                                                properties:
+                                                  labelSelector:
+                                                    description: A label query over
+                                                      a set of resources, in this
+                                                      case pods.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions
+                                                          is a list of label selector
+                                                          requirements. The requirements
+                                                          are ANDed.
+                                                        items:
+                                                          description: A label selector
+                                                            requirement is a selector
+                                                            that contains values,
+                                                            a key, and an operator
+                                                            that relates the key and
+                                                            values.
+                                                          properties:
+                                                            key:
+                                                              description: key is
+                                                                the label key that
+                                                                the selector applies
+                                                                to.
+                                                              type: string
+                                                            operator:
+                                                              description: operator
+                                                                represents a key's
+                                                                relationship to a
+                                                                set of values. Valid
+                                                                operators are In,
+                                                                NotIn, Exists and
+                                                                DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: values
+                                                                is an array of string
+                                                                values. If the operator
+                                                                is In or NotIn, the
+                                                                values array must
+                                                                be non-empty. If the
+                                                                operator is Exists
+                                                                or DoesNotExist, the
+                                                                values array must
+                                                                be empty. This array
+                                                                is replaced during
+                                                                a strategic merge
+                                                                patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          required:
+                                                          - key
+                                                          - operator
+                                                          type: object
+                                                        type: array
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: matchLabels is
+                                                          a map of {key,value} pairs.
+                                                          A single {key,value} in
+                                                          the matchLabels map is equivalent
+                                                          to an element of matchExpressions,
+                                                          whose key field is "key",
+                                                          the operator is "In", and
+                                                          the values array contains
+                                                          only "value". The requirements
+                                                          are ANDed.
+                                                        type: object
+                                                    type: object
+                                                  namespaces:
+                                                    description: namespaces specifies
+                                                      which namespaces the labelSelector
+                                                      applies to (matches against);
+                                                      null or empty list means "this
+                                                      pod's namespace"
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  topologyKey:
+                                                    description: This pod should be
+                                                      co-located (affinity) or not
+                                                      co-located (anti-affinity) with
+                                                      the pods matching the labelSelector
+                                                      in the specified namespaces,
+                                                      where co-located is defined
+                                                      as running on a node whose value
+                                                      of the label with key topologyKey
+                                                      matches that of any node on
+                                                      which any of the selected pods
+                                                      is running. Empty topologyKey
+                                                      is not allowed.
+                                                    type: string
+                                                required:
+                                                - topologyKey
+                                                type: object
+                                              weight:
+                                                description: weight associated with
+                                                  matching the corresponding podAffinityTerm,
+                                                  in the range 1-100.
+                                                format: int32
+                                                type: integer
+                                            required:
+                                            - podAffinityTerm
+                                            - weight
+                                            type: object
+                                          type: array
+                                        requiredDuringSchedulingIgnoredDuringExecution:
+                                          description: If the affinity requirements
+                                            specified by this field are not met at
+                                            scheduling time, the pod will not be scheduled
+                                            onto the node. If the affinity requirements
+                                            specified by this field cease to be met
+                                            at some point during pod execution (e.g.
+                                            due to a pod label update), the system
+                                            may or may not try to eventually evict
+                                            the pod from its node. When there are
+                                            multiple elements, the lists of nodes
+                                            corresponding to each podAffinityTerm
+                                            are intersected, i.e. all terms must be
+                                            satisfied.
+                                          items:
+                                            description: Defines a set of pods (namely
+                                              those matching the labelSelector relative
+                                              to the given namespace(s)) that this
+                                              pod should be co-located (affinity)
+                                              or not co-located (anti-affinity) with,
+                                              where co-located is defined as running
+                                              on a node whose value of the label with
+                                              key <topologyKey> matches that of any
+                                              node on which a pod of the set of pods
+                                              is running
+                                            properties:
+                                              labelSelector:
+                                                description: A label query over a
+                                                  set of resources, in this case pods.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: A label selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: values is an
+                                                            array of string values.
+                                                            If the operator is In
+                                                            or NotIn, the values array
+                                                            must be non-empty. If
+                                                            the operator is Exists
+                                                            or DoesNotExist, the values
+                                                            array must be empty. This
+                                                            array is replaced during
+                                                            a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: matchLabels is a
+                                                      map of {key,value} pairs. A
+                                                      single {key,value} in the matchLabels
+                                                      map is equivalent to an element
+                                                      of matchExpressions, whose key
+                                                      field is "key", the operator
+                                                      is "In", and the values array
+                                                      contains only "value". The requirements
+                                                      are ANDed.
+                                                    type: object
+                                                type: object
+                                              namespaces:
+                                                description: namespaces specifies
+                                                  which namespaces the labelSelector
+                                                  applies to (matches against); null
+                                                  or empty list means "this pod's
+                                                  namespace"
+                                                items:
+                                                  type: string
+                                                type: array
+                                              topologyKey:
+                                                description: This pod should be co-located
+                                                  (affinity) or not co-located (anti-affinity)
+                                                  with the pods matching the labelSelector
+                                                  in the specified namespaces, where
+                                                  co-located is defined as running
+                                                  on a node whose value of the label
+                                                  with key topologyKey matches that
+                                                  of any node on which any of the
+                                                  selected pods is running. Empty
+                                                  topologyKey is not allowed.
+                                                type: string
+                                            required:
+                                            - topologyKey
+                                            type: object
+                                          type: array
+                                      type: object
+                                    podAntiAffinity:
+                                      description: Describes pod anti-affinity scheduling
+                                        rules (e.g. avoid putting this pod in the
+                                        same node, zone, etc. as some other pod(s)).
+                                      properties:
+                                        preferredDuringSchedulingIgnoredDuringExecution:
+                                          description: The scheduler will prefer to
+                                            schedule pods to nodes that satisfy the
+                                            anti-affinity expressions specified by
+                                            this field, but it may choose a node that
+                                            violates one or more of the expressions.
+                                            The node that is most preferred is the
+                                            one with the greatest sum of weights,
+                                            i.e. for each node that meets all of the
+                                            scheduling requirements (resource request,
+                                            requiredDuringScheduling anti-affinity
+                                            expressions, etc.), compute a sum by iterating
+                                            through the elements of this field and
+                                            adding "weight" to the sum if the node
+                                            has pods which matches the corresponding
+                                            podAffinityTerm; the node(s) with the
+                                            highest sum are the most preferred.
+                                          items:
+                                            description: The weights of all of the
+                                              matched WeightedPodAffinityTerm fields
+                                              are added per-node to find the most
+                                              preferred node(s)
+                                            properties:
+                                              podAffinityTerm:
+                                                description: Required. A pod affinity
+                                                  term, associated with the corresponding
+                                                  weight.
+                                                properties:
+                                                  labelSelector:
+                                                    description: A label query over
+                                                      a set of resources, in this
+                                                      case pods.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions
+                                                          is a list of label selector
+                                                          requirements. The requirements
+                                                          are ANDed.
+                                                        items:
+                                                          description: A label selector
+                                                            requirement is a selector
+                                                            that contains values,
+                                                            a key, and an operator
+                                                            that relates the key and
+                                                            values.
+                                                          properties:
+                                                            key:
+                                                              description: key is
+                                                                the label key that
+                                                                the selector applies
+                                                                to.
+                                                              type: string
+                                                            operator:
+                                                              description: operator
+                                                                represents a key's
+                                                                relationship to a
+                                                                set of values. Valid
+                                                                operators are In,
+                                                                NotIn, Exists and
+                                                                DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: values
+                                                                is an array of string
+                                                                values. If the operator
+                                                                is In or NotIn, the
+                                                                values array must
+                                                                be non-empty. If the
+                                                                operator is Exists
+                                                                or DoesNotExist, the
+                                                                values array must
+                                                                be empty. This array
+                                                                is replaced during
+                                                                a strategic merge
+                                                                patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          required:
+                                                          - key
+                                                          - operator
+                                                          type: object
+                                                        type: array
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: matchLabels is
+                                                          a map of {key,value} pairs.
+                                                          A single {key,value} in
+                                                          the matchLabels map is equivalent
+                                                          to an element of matchExpressions,
+                                                          whose key field is "key",
+                                                          the operator is "In", and
+                                                          the values array contains
+                                                          only "value". The requirements
+                                                          are ANDed.
+                                                        type: object
+                                                    type: object
+                                                  namespaces:
+                                                    description: namespaces specifies
+                                                      which namespaces the labelSelector
+                                                      applies to (matches against);
+                                                      null or empty list means "this
+                                                      pod's namespace"
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  topologyKey:
+                                                    description: This pod should be
+                                                      co-located (affinity) or not
+                                                      co-located (anti-affinity) with
+                                                      the pods matching the labelSelector
+                                                      in the specified namespaces,
+                                                      where co-located is defined
+                                                      as running on a node whose value
+                                                      of the label with key topologyKey
+                                                      matches that of any node on
+                                                      which any of the selected pods
+                                                      is running. Empty topologyKey
+                                                      is not allowed.
+                                                    type: string
+                                                required:
+                                                - topologyKey
+                                                type: object
+                                              weight:
+                                                description: weight associated with
+                                                  matching the corresponding podAffinityTerm,
+                                                  in the range 1-100.
+                                                format: int32
+                                                type: integer
+                                            required:
+                                            - podAffinityTerm
+                                            - weight
+                                            type: object
+                                          type: array
+                                        requiredDuringSchedulingIgnoredDuringExecution:
+                                          description: If the anti-affinity requirements
+                                            specified by this field are not met at
+                                            scheduling time, the pod will not be scheduled
+                                            onto the node. If the anti-affinity requirements
+                                            specified by this field cease to be met
+                                            at some point during pod execution (e.g.
+                                            due to a pod label update), the system
+                                            may or may not try to eventually evict
+                                            the pod from its node. When there are
+                                            multiple elements, the lists of nodes
+                                            corresponding to each podAffinityTerm
+                                            are intersected, i.e. all terms must be
+                                            satisfied.
+                                          items:
+                                            description: Defines a set of pods (namely
+                                              those matching the labelSelector relative
+                                              to the given namespace(s)) that this
+                                              pod should be co-located (affinity)
+                                              or not co-located (anti-affinity) with,
+                                              where co-located is defined as running
+                                              on a node whose value of the label with
+                                              key <topologyKey> matches that of any
+                                              node on which a pod of the set of pods
+                                              is running
+                                            properties:
+                                              labelSelector:
+                                                description: A label query over a
+                                                  set of resources, in this case pods.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: A label selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: values is an
+                                                            array of string values.
+                                                            If the operator is In
+                                                            or NotIn, the values array
+                                                            must be non-empty. If
+                                                            the operator is Exists
+                                                            or DoesNotExist, the values
+                                                            array must be empty. This
+                                                            array is replaced during
+                                                            a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: matchLabels is a
+                                                      map of {key,value} pairs. A
+                                                      single {key,value} in the matchLabels
+                                                      map is equivalent to an element
+                                                      of matchExpressions, whose key
+                                                      field is "key", the operator
+                                                      is "In", and the values array
+                                                      contains only "value". The requirements
+                                                      are ANDed.
+                                                    type: object
+                                                type: object
+                                              namespaces:
+                                                description: namespaces specifies
+                                                  which namespaces the labelSelector
+                                                  applies to (matches against); null
+                                                  or empty list means "this pod's
+                                                  namespace"
+                                                items:
+                                                  type: string
+                                                type: array
+                                              topologyKey:
+                                                description: This pod should be co-located
+                                                  (affinity) or not co-located (anti-affinity)
+                                                  with the pods matching the labelSelector
+                                                  in the specified namespaces, where
+                                                  co-located is defined as running
+                                                  on a node whose value of the label
+                                                  with key topologyKey matches that
+                                                  of any node on which any of the
+                                                  selected pods is running. Empty
+                                                  topologyKey is not allowed.
+                                                type: string
+                                            required:
+                                            - topologyKey
+                                            type: object
+                                          type: array
+                                      type: object
+                                  type: object
+                                nodeSelector:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'NodeSelector is a selector which must
+                                    be true for the pod to fit on a node. Selector
+                                    which must match a node''s labels for the pod
+                                    to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                  type: object
+                                tolerations:
+                                  description: If specified, the pod's tolerations.
+                                  items:
+                                    description: The pod this Toleration is attached
+                                      to tolerates any taint that matches the triple
+                                      <key,value,effect> using the matching operator
+                                      <operator>.
+                                    properties:
+                                      effect:
+                                        description: Effect indicates the taint effect
+                                          to match. Empty means match all taint effects.
+                                          When specified, allowed values are NoSchedule,
+                                          PreferNoSchedule and NoExecute.
+                                        type: string
+                                      key:
+                                        description: Key is the taint key that the
+                                          toleration applies to. Empty means match
+                                          all taint keys. If the key is empty, operator
+                                          must be Exists; this combination means to
+                                          match all values and all keys.
+                                        type: string
+                                      operator:
+                                        description: Operator represents a key's relationship
+                                          to the value. Valid operators are Exists
+                                          and Equal. Defaults to Equal. Exists is
+                                          equivalent to wildcard for value, so that
+                                          a pod can tolerate all taints of a particular
+                                          category.
+                                        type: string
+                                      tolerationSeconds:
+                                        description: TolerationSeconds represents
+                                          the period of time the toleration (which
+                                          must be of effect NoExecute, otherwise this
+                                          field is ignored) tolerates the taint. By
+                                          default, it is not set, which means tolerate
+                                          the taint forever (do not evict). Zero and
+                                          negative values will be treated as 0 (evict
+                                          immediately) by the system.
+                                        format: int64
+                                        type: integer
+                                      value:
+                                        description: Value is the taint value the
+                                          toleration matches to. If the operator is
+                                          Exists, the value should be empty, otherwise
+                                          just a regular string.
+                                        type: string
+                                    type: object
+                                  type: array
+                              type: object
+                          type: object
+                        serviceType:
+                          description: Optional service type for Kubernetes solver
+                            service
+                          type: string
+                      type: object
+                  type: object
+                selector:
+                  description: Selector selects a set of DNSNames on the Certificate
+                    resource that should be solved using this challenge solver.
+                  properties:
+                    dnsNames:
+                      description: List of DNSNames that this solver will be used
+                        to solve. If specified and a match is found, a dnsNames selector
+                        will take precedence over a dnsZones selector. If multiple
+                        solvers match with the same dnsNames value, the solver with
+                        the most matching labels in matchLabels will be selected.
+                        If neither has more matches, the solver defined earlier in
+                        the list will be selected.
+                      items:
+                        type: string
+                      type: array
+                    dnsZones:
+                      description: List of DNSZones that this solver will be used
+                        to solve. The most specific DNS zone match specified here
+                        will take precedence over other DNS zone matches, so a solver
+                        specifying sys.example.com will be selected over one specifying
+                        example.com for the domain www.sys.example.com. If multiple
+                        solvers match with the same dnsZones value, the solver with
+                        the most matching labels in matchLabels will be selected.
+                        If neither has more matches, the solver defined earlier in
+                        the list will be selected.
+                      items:
+                        type: string
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: A label selector that is used to refine the set
+                        of certificate's that this challenge solver will apply to.
+                      type: object
+                  type: object
+              type: object
+            token:
+              description: Token is the ACME challenge token for this challenge.
+              type: string
+            type:
+              description: Type is the type of ACME challenge this resource represents,
+                e.g. "dns01" or "http01"
+              type: string
+            url:
+              description: URL is the URL of the ACME Challenge resource for this
+                challenge. This can be used to lookup details about the status of
+                this challenge.
+              type: string
+            wildcard:
+              description: Wildcard will be true if this challenge is for a wildcard
+                identifier, for example '*.example.com'
+              type: boolean
+          required:
+          - authzURL
+          - dnsName
+          - issuerRef
+          - key
+          - token
+          - type
+          - url
+          type: object
+        status:
+          properties:
+            presented:
+              description: Presented will be set to true if the challenge values for
+                this challenge are currently 'presented'. This *does not* imply the
+                self check is passing. Only that the values have been 'submitted'
+                for the appropriate challenge mechanism (i.e. the DNS01 TXT record
+                has been presented, or the HTTP01 configuration has been configured).
+              type: boolean
+            processing:
+              description: Processing is used to denote whether this challenge should
+                be processed or not. This field will only be set to true by the 'scheduling'
+                component. It will only be set to false by the 'challenges' controller,
+                after the challenge has reached a final state or timed out. If this
+                field is set to false, the challenge controller will not take any
+                more action.
+              type: boolean
+            reason:
+              description: Reason contains human readable information on why the Challenge
+                is in the current state.
+              type: string
+            state:
+              description: State contains the current 'state' of the challenge. If
+                not set, the state of the challenge is unknown.
+              enum:
+              - valid
+              - ready
+              - pending
+              - processing
+              - invalid
+              - expired
+              - errored
+              type: string
+          type: object
+      required:
+      - metadata
+      type: object
+  version: v1alpha2
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: orders.acme.cert-manager.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.state
+    name: State
+    type: string
+  - JSONPath: .spec.issuerRef.name
+    name: Issuer
+    priority: 1
+    type: string
+  - JSONPath: .status.reason
+    name: Reason
+    priority: 1
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC.
+    name: Age
+    type: date
+  group: acme.cert-manager.io
+  names:
+    kind: Order
+    listKind: OrderList
+    plural: orders
+    singular: order
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Order is a type to represent an Order with an ACME server
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            commonName:
+              description: CommonName is the common name as specified on the DER encoded
+                CSR. If CommonName is not specified, the first DNSName specified will
+                be used as the CommonName. At least one of CommonName or a DNSNames
+                must be set. This field must match the corresponding field on the
+                DER encoded CSR.
+              type: string
+            csr:
+              description: Certificate signing request bytes in DER encoding. This
+                will be used when finalizing the order. This field must be set on
+                the order.
+              format: byte
+              type: string
+            dnsNames:
+              description: DNSNames is a list of DNS names that should be included
+                as part of the Order validation process. If CommonName is not specified,
+                the first DNSName specified will be used as the CommonName. At least
+                one of CommonName or a DNSNames must be set. This field must match
+                the corresponding field on the DER encoded CSR.
+              items:
+                type: string
+              type: array
+            issuerRef:
+              description: IssuerRef references a properly configured ACME-type Issuer
+                which should be used to create this Order. If the Issuer does not
+                exist, processing will be retried. If the Issuer is not an 'ACME'
+                Issuer, an error will be returned and the Order will be marked as
+                failed.
+              properties:
+                group:
+                  type: string
+                kind:
+                  type: string
+                name:
+                  type: string
+              required:
+              - name
+              type: object
+          required:
+          - csr
+          - issuerRef
+          type: object
+        status:
+          properties:
+            authorizations:
+              description: Authorizations contains data returned from the ACME server
+                on what authoriations must be completed in order to validate the DNS
+                names specified on the Order.
+              items:
+                description: ACMEAuthorization contains data returned from the ACME
+                  server on an authorization that must be completed in order validate
+                  a DNS name on an ACME Order resource.
+                properties:
+                  challenges:
+                    description: Challenges specifies the challenge types offered
+                      by the ACME server. One of these challenge types will be selected
+                      when validating the DNS name and an appropriate Challenge resource
+                      will be created to perform the ACME challenge process.
+                    items:
+                      description: Challenge specifies a challenge offered by the
+                        ACME server for an Order. An appropriate Challenge resource
+                        can be created to perform the ACME challenge process.
+                      properties:
+                        token:
+                          description: Token is the token that must be presented for
+                            this challenge. This is used to compute the 'key' that
+                            must also be presented.
+                          type: string
+                        type:
+                          description: Type is the type of challenge being offered,
+                            e.g. http-01, dns-01
+                          type: string
+                        url:
+                          description: URL is the URL of this challenge. It can be
+                            used to retrieve additional metadata about the Challenge
+                            from the ACME server.
+                          type: string
+                      required:
+                      - token
+                      - type
+                      - url
+                      type: object
+                    type: array
+                  identifier:
+                    description: Identifier is the DNS name to be validated as part
+                      of this authorization
+                    type: string
+                  url:
+                    description: URL is the URL of the Authorization that must be
+                      completed
+                    type: string
+                  wildcard:
+                    description: Wildcard will be true if this authorization is for
+                      a wildcard DNS name. If this is true, the identifier will be
+                      the *non-wildcard* version of the DNS name. For example, if
+                      '*.example.com' is the DNS name being validated, this field
+                      will be 'true' and the 'identifier' field will be 'example.com'.
+                    type: boolean
+                required:
+                - url
+                type: object
+              type: array
+            certificate:
+              description: Certificate is a copy of the PEM encoded certificate for
+                this Order. This field will be populated after the order has been
+                successfully finalized with the ACME server, and the order has transitioned
+                to the 'valid' state.
+              format: byte
+              type: string
+            failureTime:
+              description: FailureTime stores the time that this order failed. This
+                is used to influence garbage collection and back-off.
+              format: date-time
+              type: string
+            finalizeURL:
+              description: FinalizeURL of the Order. This is used to obtain certificates
+                for this order once it has been completed.
+              type: string
+            reason:
+              description: Reason optionally provides more information about a why
+                the order is in the current state.
+              type: string
+            state:
+              description: State contains the current state of this Order resource.
+                States 'success' and 'expired' are 'final'
+              enum:
+              - valid
+              - ready
+              - pending
+              - processing
+              - invalid
+              - expired
+              - errored
+              type: string
+            url:
+              description: URL of the Order. This will initially be empty when the
+                resource is first created. The Order controller will populate this
+                field when the Order is first processed. This field will be immutable
+                after it is initially set.
+              type: string
+          type: object
+      required:
+      - metadata
+      type: object
+  version: v1alpha2
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: certificaterequests.cert-manager.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=="Ready")].status
+    name: Ready
+    type: string
+  - JSONPath: .spec.issuerRef.name
+    name: Issuer
+    priority: 1
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Ready")].message
+    name: Status
+    priority: 1
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC.
+    name: Age
+    type: date
+  group: cert-manager.io
+  names:
+    kind: CertificateRequest
+    listKind: CertificateRequestList
+    plural: certificaterequests
+    shortNames:
+    - cr
+    - crs
+    singular: certificaterequest
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: CertificateRequest is a type to represent a Certificate Signing
+        Request
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CertificateRequestSpec defines the desired state of CertificateRequest
+          properties:
+            csr:
+              description: Byte slice containing the PEM encoded CertificateSigningRequest
+              format: byte
+              type: string
+            duration:
+              description: Requested certificate default Duration
+              type: string
+            isCA:
+              description: IsCA will mark the resulting certificate as valid for signing.
+                This implies that the 'cert sign' usage is set
+              type: boolean
+            issuerRef:
+              description: IssuerRef is a reference to the issuer for this CertificateRequest.  If
+                the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                with the given name in the same namespace as the CertificateRequest
+                will be used.  If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
+                with the provided name will be used. The 'name' field in this stanza
+                is required at all times. The group field refers to the API group
+                of the issuer which defaults to 'cert-manager.io' if empty.
+              properties:
+                group:
+                  type: string
+                kind:
+                  type: string
+                name:
+                  type: string
+              required:
+              - name
+              type: object
+            usages:
+              description: Usages is the set of x509 actions that are enabled for
+                a given key. Defaults are ('digital signature', 'key encipherment')
+                if empty
+              items:
+                description: 'KeyUsage specifies valid usage contexts for keys. See:
+                  https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12'
+                enum:
+                - signing
+                - digital signature
+                - content commitment
+                - key encipherment
+                - key agreement
+                - data encipherment
+                - cert sign
+                - crl sign
+                - encipher only
+                - decipher only
+                - any
+                - server auth
+                - client auth
+                - code signing
+                - email protection
+                - s/mime
+                - ipsec end system
+                - ipsec tunnel
+                - ipsec user
+                - timestamping
+                - ocsp signing
+                - microsoft sgc
+                - netscape sgc
+                type: string
+              type: array
+          required:
+          - issuerRef
+          type: object
+        status:
+          description: CertificateStatus defines the observed state of CertificateRequest
+            and resulting signed certificate.
+          properties:
+            ca:
+              description: Byte slice containing the PEM encoded certificate authority
+                of the signed certificate.
+              format: byte
+              type: string
+            certificate:
+              description: Byte slice containing a PEM encoded signed certificate
+                resulting from the given certificate signing request.
+              format: byte
+              type: string
+            conditions:
+              items:
+                description: CertificateRequestCondition contains condition information
+                  for a CertificateRequest.
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the timestamp corresponding
+                      to the last status change of this condition.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message is a human readable description of the details
+                      of the last transition, complementing reason.
+                    type: string
+                  reason:
+                    description: Reason is a brief machine readable explanation for
+                      the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of ('True', 'False',
+                      'Unknown').
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
+                    type: string
+                  type:
+                    description: Type of the condition, currently ('Ready').
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            failureTime:
+              description: FailureTime stores the time that this CertificateRequest
+                failed. This is used to influence garbage collection and back-off.
+              format: date-time
+              type: string
+          type: object
+      type: object
+  version: v1alpha2
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: certificates.cert-manager.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=="Ready")].status
+    name: Ready
+    type: string
+  - JSONPath: .spec.secretName
+    name: Secret
+    type: string
+  - JSONPath: .spec.issuerRef.name
+    name: Issuer
+    priority: 1
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Ready")].message
+    name: Status
+    priority: 1
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC.
+    name: Age
+    type: date
+  group: cert-manager.io
+  names:
+    kind: Certificate
+    listKind: CertificateList
+    plural: certificates
+    shortNames:
+    - cert
+    - certs
+    singular: certificate
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Certificate is a type to represent a Certificate from ACME
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CertificateSpec defines the desired state of Certificate. A
+            valid Certificate requires at least one of a CommonName, DNSName, or URISAN
+            to be valid.
+          properties:
+            commonName:
+              description: CommonName is a common name to be used on the Certificate.
+                The CommonName should have a length of 64 characters or fewer to avoid
+                generating invalid CSRs.
+              type: string
+            dnsNames:
+              description: DNSNames is a list of subject alt names to be used on the
+                Certificate.
+              items:
+                type: string
+              type: array
+            duration:
+              description: Certificate default Duration
+              type: string
+            ipAddresses:
+              description: IPAddresses is a list of IP addresses to be used on the
+                Certificate
+              items:
+                type: string
+              type: array
+            isCA:
+              description: IsCA will mark this Certificate as valid for signing. This
+                implies that the 'cert sign' usage is set
+              type: boolean
+            issuerRef:
+              description: IssuerRef is a reference to the issuer for this certificate.
+                If the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                with the given name in the same namespace as the Certificate will
+                be used. If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
+                with the provided name will be used. The 'name' field in this stanza
+                is required at all times.
+              properties:
+                group:
+                  type: string
+                kind:
+                  type: string
+                name:
+                  type: string
+              required:
+              - name
+              type: object
+            keyAlgorithm:
+              description: KeyAlgorithm is the private key algorithm of the corresponding
+                private key for this certificate. If provided, allowed values are
+                either "rsa" or "ecdsa" If KeyAlgorithm is specified and KeySize is
+                not provided, key size of 256 will be used for "ecdsa" key algorithm
+                and key size of 2048 will be used for "rsa" key algorithm.
+              enum:
+              - rsa
+              - ecdsa
+              type: string
+            keyEncoding:
+              description: KeyEncoding is the private key cryptography standards (PKCS)
+                for this certificate's private key to be encoded in. If provided,
+                allowed values are "pkcs1" and "pkcs8" standing for PKCS#1 and PKCS#8,
+                respectively. If KeyEncoding is not specified, then PKCS#1 will be
+                used by default.
+              enum:
+              - pkcs1
+              - pkcs8
+              type: string
+            keySize:
+              description: KeySize is the key bit size of the corresponding private
+                key for this certificate. If provided, value must be between 2048
+                and 8192 inclusive when KeyAlgorithm is empty or is set to "rsa",
+                and value must be one of (256, 384, 521) when KeyAlgorithm is set
+                to "ecdsa".
+              type: integer
+            organization:
+              description: Organization is the organization to be used on the Certificate
+              items:
+                type: string
+              type: array
+            renewBefore:
+              description: Certificate renew before expiration duration
+              type: string
+            secretName:
+              description: SecretName is the name of the secret resource to store
+                this secret in
+              type: string
+            uriSANs:
+              description: URISANs is a list of URI Subject Alternative Names to be
+                set on this Certificate.
+              items:
+                type: string
+              type: array
+            usages:
+              description: Usages is the set of x509 actions that are enabled for
+                a given key. Defaults are ('digital signature', 'key encipherment')
+                if empty
+              items:
+                description: 'KeyUsage specifies valid usage contexts for keys. See:
+                  https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12'
+                enum:
+                - signing
+                - digital signature
+                - content commitment
+                - key encipherment
+                - key agreement
+                - data encipherment
+                - cert sign
+                - crl sign
+                - encipher only
+                - decipher only
+                - any
+                - server auth
+                - client auth
+                - code signing
+                - email protection
+                - s/mime
+                - ipsec end system
+                - ipsec tunnel
+                - ipsec user
+                - timestamping
+                - ocsp signing
+                - microsoft sgc
+                - netscape sgc
+                type: string
+              type: array
+          required:
+          - issuerRef
+          - secretName
+          type: object
+        status:
+          description: CertificateStatus defines the observed state of Certificate
+          properties:
+            conditions:
+              items:
+                description: CertificateCondition contains condition information for
+                  an Certificate.
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the timestamp corresponding
+                      to the last status change of this condition.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message is a human readable description of the details
+                      of the last transition, complementing reason.
+                    type: string
+                  reason:
+                    description: Reason is a brief machine readable explanation for
+                      the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of ('True', 'False',
+                      'Unknown').
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
+                    type: string
+                  type:
+                    description: Type of the condition, currently ('Ready').
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            lastFailureTime:
+              format: date-time
+              type: string
+            notAfter:
+              description: The expiration time of the certificate stored in the secret
+                named by this resource in spec.secretName.
+              format: date-time
+              type: string
+          type: object
+      type: object
+  version: v1alpha2
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: clusterissuers.cert-manager.io
+spec:
+  group: cert-manager.io
+  names:
+    kind: ClusterIssuer
+    listKind: ClusterIssuerList
+    plural: clusterissuers
+    singular: clusterissuer
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: IssuerSpec is the specification of an Issuer. This includes
+            any configuration required for the issuer.
+          properties:
+            acme:
+              description: ACMEIssuer contains the specification for an ACME issuer
+              properties:
+                email:
+                  description: Email is the email for this account
+                  type: string
+                privateKeySecretRef:
+                  description: PrivateKey is the name of a secret containing the private
+                    key for this user account.
+                  properties:
+                    key:
+                      description: The key of the secret to select from. Must be a
+                        valid secret key.
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  required:
+                  - name
+                  type: object
+                server:
+                  description: Server is the ACME server URL
+                  type: string
+                skipTLSVerify:
+                  description: If true, skip verifying the ACME server TLS certificate
+                  type: boolean
+                solvers:
+                  description: Solvers is a list of challenge solvers that will be
+                    used to solve ACME challenges for the matching domains.
+                  items:
+                    properties:
+                      dns01:
+                        properties:
+                          acmedns:
+                            description: ACMEIssuerDNS01ProviderAcmeDNS is a structure
+                              containing the configuration for ACME-DNS servers
+                            properties:
+                              accountSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              host:
+                                type: string
+                            required:
+                            - accountSecretRef
+                            - host
+                            type: object
+                          akamai:
+                            description: ACMEIssuerDNS01ProviderAkamai is a structure
+                              containing the DNS configuration for Akamai DNS—Zone
+                              Record Management API
+                            properties:
+                              accessTokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              clientSecretSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              clientTokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              serviceConsumerDomain:
+                                type: string
+                            required:
+                            - accessTokenSecretRef
+                            - clientSecretSecretRef
+                            - clientTokenSecretRef
+                            - serviceConsumerDomain
+                            type: object
+                          azuredns:
+                            description: ACMEIssuerDNS01ProviderAzureDNS is a structure
+                              containing the configuration for Azure DNS
+                            properties:
+                              clientID:
+                                type: string
+                              clientSecretSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              environment:
+                                enum:
+                                - AzurePublicCloud
+                                - AzureChinaCloud
+                                - AzureGermanCloud
+                                - AzureUSGovernmentCloud
+                                type: string
+                              hostedZoneName:
+                                type: string
+                              resourceGroupName:
+                                type: string
+                              subscriptionID:
+                                type: string
+                              tenantID:
+                                type: string
+                            required:
+                            - clientID
+                            - clientSecretSecretRef
+                            - resourceGroupName
+                            - subscriptionID
+                            - tenantID
+                            type: object
+                          clouddns:
+                            description: ACMEIssuerDNS01ProviderCloudDNS is a structure
+                              containing the DNS configuration for Google Cloud DNS
+                            properties:
+                              project:
+                                type: string
+                              serviceAccountSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - project
+                            - serviceAccountSecretRef
+                            type: object
+                          cloudflare:
+                            description: ACMEIssuerDNS01ProviderCloudflare is a structure
+                              containing the DNS configuration for Cloudflare
+                            properties:
+                              apiKeySecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              email:
+                                type: string
+                            required:
+                            - apiKeySecretRef
+                            - email
+                            type: object
+                          cnameStrategy:
+                            description: CNAMEStrategy configures how the DNS01 provider
+                              should handle CNAME records when found in DNS zones.
+                            enum:
+                            - None
+                            - Follow
+                            type: string
+                          digitalocean:
+                            description: ACMEIssuerDNS01ProviderDigitalOcean is a
+                              structure containing the DNS configuration for DigitalOcean
+                              Domains
+                            properties:
+                              tokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - tokenSecretRef
+                            type: object
+                          rfc2136:
+                            description: ACMEIssuerDNS01ProviderRFC2136 is a structure
+                              containing the configuration for RFC2136 DNS
+                            properties:
+                              nameserver:
+                                description: 'The IP address of the DNS supporting
+                                  RFC2136. Required. Note: FQDN is not a valid value,
+                                  only IP.'
+                                type: string
+                              tsigAlgorithm:
+                                description: 'The TSIG Algorithm configured in the
+                                  DNS supporting RFC2136. Used only when ``tsigSecretSecretRef``
+                                  and ``tsigKeyName`` are defined. Supported values
+                                  are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``,
+                                  ``HMACSHA256`` or ``HMACSHA512``.'
+                                type: string
+                              tsigKeyName:
+                                description: The TSIG Key name configured in the DNS.
+                                  If ``tsigSecretSecretRef`` is defined, this field
+                                  is required.
+                                type: string
+                              tsigSecretSecretRef:
+                                description: The name of the secret containing the
+                                  TSIG value. If ``tsigKeyName`` is defined, this
+                                  field is required.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - nameserver
+                            type: object
+                          route53:
+                            description: ACMEIssuerDNS01ProviderRoute53 is a structure
+                              containing the Route 53 configuration for AWS
+                            properties:
+                              accessKeyID:
+                                description: 'The AccessKeyID is used for authentication.
+                                  If not set we fall-back to using env vars, shared
+                                  credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                type: string
+                              hostedZoneID:
+                                description: If set, the provider will manage only
+                                  this zone in Route53 and will not do an lookup using
+                                  the route53:ListHostedZonesByName api call.
+                                type: string
+                              region:
+                                description: Always set the region when using AccessKeyID
+                                  and SecretAccessKey
+                                type: string
+                              role:
+                                description: Role is a Role ARN which the Route53
+                                  provider will assume using either the explicit credentials
+                                  AccessKeyID/SecretAccessKey or the inferred credentials
+                                  from environment variables, shared credentials file
+                                  or AWS Instance metadata
+                                type: string
+                              secretAccessKeySecretRef:
+                                description: The SecretAccessKey is used for authentication.
+                                  If not set we fall-back to using env vars, shared
+                                  credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - region
+                            type: object
+                          webhook:
+                            description: ACMEIssuerDNS01ProviderWebhook specifies
+                              configuration for a webhook DNS01 provider, including
+                              where to POST ChallengePayload resources.
+                            properties:
+                              config:
+                                description: Additional configuration that should
+                                  be passed to the webhook apiserver when challenges
+                                  are processed. This can contain arbitrary JSON data.
+                                  Secret values should not be specified in this stanza.
+                                  If secret values are needed (e.g. credentials for
+                                  a DNS service), you should use a SecretKeySelector
+                                  to reference a Secret resource. For details on the
+                                  schema of this field, consult the webhook provider
+                                  implementation's documentation.
+                                x-kubernetes-preserve-unknown-fields: true
+                              groupName:
+                                description: The API group name that should be used
+                                  when POSTing ChallengePayload resources to the webhook
+                                  apiserver. This should be the same as the GroupName
+                                  specified in the webhook provider implementation.
+                                type: string
+                              solverName:
+                                description: The name of the solver to use, as defined
+                                  in the webhook provider implementation. This will
+                                  typically be the name of the provider, e.g. 'cloudflare'.
+                                type: string
+                            required:
+                            - groupName
+                            - solverName
+                            type: object
+                        type: object
+                      http01:
+                        description: ACMEChallengeSolverHTTP01 contains configuration
+                          detailing how to solve HTTP01 challenges within a Kubernetes
+                          cluster. Typically this is accomplished through creating
+                          'routes' of some description that configure ingress controllers
+                          to direct traffic to 'solver pods', which are responsible
+                          for responding to the ACME server's HTTP requests.
+                        properties:
+                          ingress:
+                            description: The ingress based HTTP01 challenge solver
+                              will solve challenges by creating or modifying Ingress
+                              resources in order to route requests for '/.well-known/acme-challenge/XYZ'
+                              to 'challenge solver' pods that are provisioned by cert-manager
+                              for each Challenge to be completed.
+                            properties:
+                              class:
+                                description: The ingress class to use when creating
+                                  Ingress resources to solve ACME challenges that
+                                  use this challenge solver. Only one of 'class' or
+                                  'name' may be specified.
+                                type: string
+                              name:
+                                description: The name of the ingress resource that
+                                  should have ACME challenge solving routes inserted
+                                  into it in order to solve HTTP01 challenges. This
+                                  is typically used in conjunction with ingress controllers
+                                  like ingress-gce, which maintains a 1:1 mapping
+                                  between external IPs and ingress resources.
+                                type: string
+                              podTemplate:
+                                description: Optional pod template used to configure
+                                  the ACME challenge solver pods used for HTTP01 challenges
+                                properties:
+                                  metadata:
+                                    description: ObjectMeta overrides for the pod
+                                      used to solve HTTP01 challenges. Only the 'labels'
+                                      and 'annotations' fields may be set. If labels
+                                      or annotations overlap with in-built values,
+                                      the values here will override the in-built values.
+                                    type: object
+                                  spec:
+                                    description: PodSpec defines overrides for the
+                                      HTTP01 challenge solver pod. Only the 'nodeSelector',
+                                      'affinity' and 'tolerations' fields are supported
+                                      currently. All other fields will be ignored.
+                                    properties:
+                                      affinity:
+                                        description: If specified, the pod's scheduling
+                                          constraints
+                                        properties:
+                                          nodeAffinity:
+                                            description: Describes node affinity scheduling
+                                              rules for the pod.
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                description: The scheduler will prefer
+                                                  to schedule pods to nodes that satisfy
+                                                  the affinity expressions specified
+                                                  by this field, but it may choose
+                                                  a node that violates one or more
+                                                  of the expressions. The node that
+                                                  is most preferred is the one with
+                                                  the greatest sum of weights, i.e.
+                                                  for each node that meets all of
+                                                  the scheduling requirements (resource
+                                                  request, requiredDuringScheduling
+                                                  affinity expressions, etc.), compute
+                                                  a sum by iterating through the elements
+                                                  of this field and adding "weight"
+                                                  to the sum if the node matches the
+                                                  corresponding matchExpressions;
+                                                  the node(s) with the highest sum
+                                                  are the most preferred.
+                                                items:
+                                                  description: An empty preferred
+                                                    scheduling term matches all objects
+                                                    with implicit weight 0 (i.e. it's
+                                                    a no-op). A null preferred scheduling
+                                                    term matches no objects (i.e.
+                                                    is also a no-op).
+                                                  properties:
+                                                    preference:
+                                                      description: A node selector
+                                                        term, associated with the
+                                                        corresponding weight.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's labels.
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchFields:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's fields.
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                      type: object
+                                                    weight:
+                                                      description: Weight associated
+                                                        with matching the corresponding
+                                                        nodeSelectorTerm, in the range
+                                                        1-100.
+                                                      format: int32
+                                                      type: integer
+                                                  required:
+                                                  - preference
+                                                  - weight
+                                                  type: object
+                                                type: array
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                description: If the affinity requirements
+                                                  specified by this field are not
+                                                  met at scheduling time, the pod
+                                                  will not be scheduled onto the node.
+                                                  If the affinity requirements specified
+                                                  by this field cease to be met at
+                                                  some point during pod execution
+                                                  (e.g. due to an update), the system
+                                                  may or may not try to eventually
+                                                  evict the pod from its node.
+                                                properties:
+                                                  nodeSelectorTerms:
+                                                    description: Required. A list
+                                                      of node selector terms. The
+                                                      terms are ORed.
+                                                    items:
+                                                      description: A null or empty
+                                                        node selector term matches
+                                                        no objects. The requirements
+                                                        of them are ANDed. The TopologySelectorTerm
+                                                        type implements a subset of
+                                                        the NodeSelectorTerm.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's labels.
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchFields:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's fields.
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                required:
+                                                - nodeSelectorTerms
+                                                type: object
+                                            type: object
+                                          podAffinity:
+                                            description: Describes pod affinity scheduling
+                                              rules (e.g. co-locate this pod in the
+                                              same node, zone, etc. as some other
+                                              pod(s)).
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                description: The scheduler will prefer
+                                                  to schedule pods to nodes that satisfy
+                                                  the affinity expressions specified
+                                                  by this field, but it may choose
+                                                  a node that violates one or more
+                                                  of the expressions. The node that
+                                                  is most preferred is the one with
+                                                  the greatest sum of weights, i.e.
+                                                  for each node that meets all of
+                                                  the scheduling requirements (resource
+                                                  request, requiredDuringScheduling
+                                                  affinity expressions, etc.), compute
+                                                  a sum by iterating through the elements
+                                                  of this field and adding "weight"
+                                                  to the sum if the node has pods
+                                                  which matches the corresponding
+                                                  podAffinityTerm; the node(s) with
+                                                  the highest sum are the most preferred.
+                                                items:
+                                                  description: The weights of all
+                                                    of the matched WeightedPodAffinityTerm
+                                                    fields are added per-node to find
+                                                    the most preferred node(s)
+                                                  properties:
+                                                    podAffinityTerm:
+                                                      description: Required. A pod
+                                                        affinity term, associated
+                                                        with the corresponding weight.
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query
+                                                            over a set of resources,
+                                                            in this case pods.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions
+                                                                is a list of label
+                                                                selector requirements.
+                                                                The requirements are
+                                                                ANDed.
+                                                              items:
+                                                                description: A label
+                                                                  selector requirement
+                                                                  is a selector that
+                                                                  contains values,
+                                                                  a key, and an operator
+                                                                  that relates the
+                                                                  key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key
+                                                                      is the label
+                                                                      key that the
+                                                                      selector applies
+                                                                      to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator
+                                                                      represents a
+                                                                      key's relationship
+                                                                      to a set of
+                                                                      values. Valid
+                                                                      operators are
+                                                                      In, NotIn, Exists
+                                                                      and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values
+                                                                      is an array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or
+                                                                      DoesNotExist,
+                                                                      the values array
+                                                                      must be empty.
+                                                                      This array is
+                                                                      replaced during
+                                                                      a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: matchLabels
+                                                                is a map of {key,value}
+                                                                pairs. A single {key,value}
+                                                                in the matchLabels
+                                                                map is equivalent
+                                                                to an element of matchExpressions,
+                                                                whose key field is
+                                                                "key", the operator
+                                                                is "In", and the values
+                                                                array contains only
+                                                                "value". The requirements
+                                                                are ANDed.
+                                                              type: object
+                                                          type: object
+                                                        namespaces:
+                                                          description: namespaces
+                                                            specifies which namespaces
+                                                            the labelSelector applies
+                                                            to (matches against);
+                                                            null or empty list means
+                                                            "this pod's namespace"
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                        topologyKey:
+                                                          description: This pod should
+                                                            be co-located (affinity)
+                                                            or not co-located (anti-affinity)
+                                                            with the pods matching
+                                                            the labelSelector in the
+                                                            specified namespaces,
+                                                            where co-located is defined
+                                                            as running on a node whose
+                                                            value of the label with
+                                                            key topologyKey matches
+                                                            that of any node on which
+                                                            any of the selected pods
+                                                            is running. Empty topologyKey
+                                                            is not allowed.
+                                                          type: string
+                                                      required:
+                                                      - topologyKey
+                                                      type: object
+                                                    weight:
+                                                      description: weight associated
+                                                        with matching the corresponding
+                                                        podAffinityTerm, in the range
+                                                        1-100.
+                                                      format: int32
+                                                      type: integer
+                                                  required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                  type: object
+                                                type: array
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                description: If the affinity requirements
+                                                  specified by this field are not
+                                                  met at scheduling time, the pod
+                                                  will not be scheduled onto the node.
+                                                  If the affinity requirements specified
+                                                  by this field cease to be met at
+                                                  some point during pod execution
+                                                  (e.g. due to a pod label update),
+                                                  the system may or may not try to
+                                                  eventually evict the pod from its
+                                                  node. When there are multiple elements,
+                                                  the lists of nodes corresponding
+                                                  to each podAffinityTerm are intersected,
+                                                  i.e. all terms must be satisfied.
+                                                items:
+                                                  description: Defines a set of pods
+                                                    (namely those matching the labelSelector
+                                                    relative to the given namespace(s))
+                                                    that this pod should be co-located
+                                                    (affinity) or not co-located (anti-affinity)
+                                                    with, where co-located is defined
+                                                    as running on a node whose value
+                                                    of the label with key <topologyKey>
+                                                    matches that of any node on which
+                                                    a pod of the set of pods is running
+                                                  properties:
+                                                    labelSelector:
+                                                      description: A label query over
+                                                        a set of resources, in this
+                                                        case pods.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                      type: object
+                                                    namespaces:
+                                                      description: namespaces specifies
+                                                        which namespaces the labelSelector
+                                                        applies to (matches against);
+                                                        null or empty list means "this
+                                                        pod's namespace"
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    topologyKey:
+                                                      description: This pod should
+                                                        be co-located (affinity) or
+                                                        not co-located (anti-affinity)
+                                                        with the pods matching the
+                                                        labelSelector in the specified
+                                                        namespaces, where co-located
+                                                        is defined as running on a
+                                                        node whose value of the label
+                                                        with key topologyKey matches
+                                                        that of any node on which
+                                                        any of the selected pods is
+                                                        running. Empty topologyKey
+                                                        is not allowed.
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          podAntiAffinity:
+                                            description: Describes pod anti-affinity
+                                              scheduling rules (e.g. avoid putting
+                                              this pod in the same node, zone, etc.
+                                              as some other pod(s)).
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                description: The scheduler will prefer
+                                                  to schedule pods to nodes that satisfy
+                                                  the anti-affinity expressions specified
+                                                  by this field, but it may choose
+                                                  a node that violates one or more
+                                                  of the expressions. The node that
+                                                  is most preferred is the one with
+                                                  the greatest sum of weights, i.e.
+                                                  for each node that meets all of
+                                                  the scheduling requirements (resource
+                                                  request, requiredDuringScheduling
+                                                  anti-affinity expressions, etc.),
+                                                  compute a sum by iterating through
+                                                  the elements of this field and adding
+                                                  "weight" to the sum if the node
+                                                  has pods which matches the corresponding
+                                                  podAffinityTerm; the node(s) with
+                                                  the highest sum are the most preferred.
+                                                items:
+                                                  description: The weights of all
+                                                    of the matched WeightedPodAffinityTerm
+                                                    fields are added per-node to find
+                                                    the most preferred node(s)
+                                                  properties:
+                                                    podAffinityTerm:
+                                                      description: Required. A pod
+                                                        affinity term, associated
+                                                        with the corresponding weight.
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query
+                                                            over a set of resources,
+                                                            in this case pods.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions
+                                                                is a list of label
+                                                                selector requirements.
+                                                                The requirements are
+                                                                ANDed.
+                                                              items:
+                                                                description: A label
+                                                                  selector requirement
+                                                                  is a selector that
+                                                                  contains values,
+                                                                  a key, and an operator
+                                                                  that relates the
+                                                                  key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key
+                                                                      is the label
+                                                                      key that the
+                                                                      selector applies
+                                                                      to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator
+                                                                      represents a
+                                                                      key's relationship
+                                                                      to a set of
+                                                                      values. Valid
+                                                                      operators are
+                                                                      In, NotIn, Exists
+                                                                      and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values
+                                                                      is an array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or
+                                                                      DoesNotExist,
+                                                                      the values array
+                                                                      must be empty.
+                                                                      This array is
+                                                                      replaced during
+                                                                      a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: matchLabels
+                                                                is a map of {key,value}
+                                                                pairs. A single {key,value}
+                                                                in the matchLabels
+                                                                map is equivalent
+                                                                to an element of matchExpressions,
+                                                                whose key field is
+                                                                "key", the operator
+                                                                is "In", and the values
+                                                                array contains only
+                                                                "value". The requirements
+                                                                are ANDed.
+                                                              type: object
+                                                          type: object
+                                                        namespaces:
+                                                          description: namespaces
+                                                            specifies which namespaces
+                                                            the labelSelector applies
+                                                            to (matches against);
+                                                            null or empty list means
+                                                            "this pod's namespace"
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                        topologyKey:
+                                                          description: This pod should
+                                                            be co-located (affinity)
+                                                            or not co-located (anti-affinity)
+                                                            with the pods matching
+                                                            the labelSelector in the
+                                                            specified namespaces,
+                                                            where co-located is defined
+                                                            as running on a node whose
+                                                            value of the label with
+                                                            key topologyKey matches
+                                                            that of any node on which
+                                                            any of the selected pods
+                                                            is running. Empty topologyKey
+                                                            is not allowed.
+                                                          type: string
+                                                      required:
+                                                      - topologyKey
+                                                      type: object
+                                                    weight:
+                                                      description: weight associated
+                                                        with matching the corresponding
+                                                        podAffinityTerm, in the range
+                                                        1-100.
+                                                      format: int32
+                                                      type: integer
+                                                  required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                  type: object
+                                                type: array
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                description: If the anti-affinity
+                                                  requirements specified by this field
+                                                  are not met at scheduling time,
+                                                  the pod will not be scheduled onto
+                                                  the node. If the anti-affinity requirements
+                                                  specified by this field cease to
+                                                  be met at some point during pod
+                                                  execution (e.g. due to a pod label
+                                                  update), the system may or may not
+                                                  try to eventually evict the pod
+                                                  from its node. When there are multiple
+                                                  elements, the lists of nodes corresponding
+                                                  to each podAffinityTerm are intersected,
+                                                  i.e. all terms must be satisfied.
+                                                items:
+                                                  description: Defines a set of pods
+                                                    (namely those matching the labelSelector
+                                                    relative to the given namespace(s))
+                                                    that this pod should be co-located
+                                                    (affinity) or not co-located (anti-affinity)
+                                                    with, where co-located is defined
+                                                    as running on a node whose value
+                                                    of the label with key <topologyKey>
+                                                    matches that of any node on which
+                                                    a pod of the set of pods is running
+                                                  properties:
+                                                    labelSelector:
+                                                      description: A label query over
+                                                        a set of resources, in this
+                                                        case pods.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                      type: object
+                                                    namespaces:
+                                                      description: namespaces specifies
+                                                        which namespaces the labelSelector
+                                                        applies to (matches against);
+                                                        null or empty list means "this
+                                                        pod's namespace"
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    topologyKey:
+                                                      description: This pod should
+                                                        be co-located (affinity) or
+                                                        not co-located (anti-affinity)
+                                                        with the pods matching the
+                                                        labelSelector in the specified
+                                                        namespaces, where co-located
+                                                        is defined as running on a
+                                                        node whose value of the label
+                                                        with key topologyKey matches
+                                                        that of any node on which
+                                                        any of the selected pods is
+                                                        running. Empty topologyKey
+                                                        is not allowed.
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                type: array
+                                            type: object
+                                        type: object
+                                      nodeSelector:
+                                        additionalProperties:
+                                          type: string
+                                        description: 'NodeSelector is a selector which
+                                          must be true for the pod to fit on a node.
+                                          Selector which must match a node''s labels
+                                          for the pod to be scheduled on that node.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                        type: object
+                                      tolerations:
+                                        description: If specified, the pod's tolerations.
+                                        items:
+                                          description: The pod this Toleration is
+                                            attached to tolerates any taint that matches
+                                            the triple <key,value,effect> using the
+                                            matching operator <operator>.
+                                          properties:
+                                            effect:
+                                              description: Effect indicates the taint
+                                                effect to match. Empty means match
+                                                all taint effects. When specified,
+                                                allowed values are NoSchedule, PreferNoSchedule
+                                                and NoExecute.
+                                              type: string
+                                            key:
+                                              description: Key is the taint key that
+                                                the toleration applies to. Empty means
+                                                match all taint keys. If the key is
+                                                empty, operator must be Exists; this
+                                                combination means to match all values
+                                                and all keys.
+                                              type: string
+                                            operator:
+                                              description: Operator represents a key's
+                                                relationship to the value. Valid operators
+                                                are Exists and Equal. Defaults to
+                                                Equal. Exists is equivalent to wildcard
+                                                for value, so that a pod can tolerate
+                                                all taints of a particular category.
+                                              type: string
+                                            tolerationSeconds:
+                                              description: TolerationSeconds represents
+                                                the period of time the toleration
+                                                (which must be of effect NoExecute,
+                                                otherwise this field is ignored) tolerates
+                                                the taint. By default, it is not set,
+                                                which means tolerate the taint forever
+                                                (do not evict). Zero and negative
+                                                values will be treated as 0 (evict
+                                                immediately) by the system.
+                                              format: int64
+                                              type: integer
+                                            value:
+                                              description: Value is the taint value
+                                                the toleration matches to. If the
+                                                operator is Exists, the value should
+                                                be empty, otherwise just a regular
+                                                string.
+                                              type: string
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              serviceType:
+                                description: Optional service type for Kubernetes
+                                  solver service
+                                type: string
+                            type: object
+                        type: object
+                      selector:
+                        description: Selector selects a set of DNSNames on the Certificate
+                          resource that should be solved using this challenge solver.
+                        properties:
+                          dnsNames:
+                            description: List of DNSNames that this solver will be
+                              used to solve. If specified and a match is found, a
+                              dnsNames selector will take precedence over a dnsZones
+                              selector. If multiple solvers match with the same dnsNames
+                              value, the solver with the most matching labels in matchLabels
+                              will be selected. If neither has more matches, the solver
+                              defined earlier in the list will be selected.
+                            items:
+                              type: string
+                            type: array
+                          dnsZones:
+                            description: List of DNSZones that this solver will be
+                              used to solve. The most specific DNS zone match specified
+                              here will take precedence over other DNS zone matches,
+                              so a solver specifying sys.example.com will be selected
+                              over one specifying example.com for the domain www.sys.example.com.
+                              If multiple solvers match with the same dnsZones value,
+                              the solver with the most matching labels in matchLabels
+                              will be selected. If neither has more matches, the solver
+                              defined earlier in the list will be selected.
+                            items:
+                              type: string
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: A label selector that is used to refine the
+                              set of certificate's that this challenge solver will
+                              apply to.
+                            type: object
+                        type: object
+                    type: object
+                  type: array
+              required:
+              - privateKeySecretRef
+              - server
+              type: object
+            ca:
+              properties:
+                secretName:
+                  description: SecretName is the name of the secret used to sign Certificates
+                    issued by this Issuer.
+                  type: string
+              required:
+              - secretName
+              type: object
+            selfSigned:
+              type: object
+            vault:
+              properties:
+                auth:
+                  description: Vault authentication
+                  properties:
+                    appRole:
+                      description: This Secret contains a AppRole and Secret
+                      properties:
+                        path:
+                          description: Where the authentication path is mounted in
+                            Vault.
+                          type: string
+                        roleId:
+                          type: string
+                        secretRef:
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - path
+                      - roleId
+                      - secretRef
+                      type: object
+                    kubernetes:
+                      description: This contains a Role and Secret with a ServiceAccount
+                        token to authenticate with vault.
+                      properties:
+                        mountPath:
+                          description: The value here will be used as part of the
+                            path used when authenticating with vault, for example
+                            if you set a value of "foo", the path used will be `/v1/auth/foo/login`.
+                            If unspecified, the default value "kubernetes" will be
+                            used.
+                          type: string
+                        role:
+                          description: A required field containing the Vault Role
+                            to assume. A Role binds a Kubernetes ServiceAccount with
+                            a set of Vault policies.
+                          type: string
+                        secretRef:
+                          description: The required Secret field containing a Kubernetes
+                            ServiceAccount JWT used for authenticating with Vault.
+                            Use of 'ambient credentials' is not supported.
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - role
+                      - secretRef
+                      type: object
+                    tokenSecretRef:
+                      description: This Secret contains the Vault token key
+                      properties:
+                        key:
+                          description: The key of the secret to select from. Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  type: object
+                caBundle:
+                  description: Base64 encoded CA bundle to validate Vault server certificate.
+                    Only used if the Server URL is using HTTPS protocol. This parameter
+                    is ignored for plain HTTP protocol connection. If not set the
+                    system root certificates are used to validate the TLS connection.
+                  format: byte
+                  type: string
+                path:
+                  description: Vault URL path to the certificate role
+                  type: string
+                server:
+                  description: Server is the vault connection address
+                  type: string
+              required:
+              - auth
+              - path
+              - server
+              type: object
+            venafi:
+              description: VenafiIssuer describes issuer configuration details for
+                Venafi Cloud.
+              properties:
+                cloud:
+                  description: Cloud specifies the Venafi cloud configuration settings.
+                    Only one of TPP or Cloud may be specified.
+                  properties:
+                    apiTokenSecretRef:
+                      description: APITokenSecretRef is a secret key selector for
+                        the Venafi Cloud API token.
+                      properties:
+                        key:
+                          description: The key of the secret to select from. Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    url:
+                      description: URL is the base URL for Venafi Cloud
+                      type: string
+                  required:
+                  - apiTokenSecretRef
+                  - url
+                  type: object
+                tpp:
+                  description: TPP specifies Trust Protection Platform configuration
+                    settings. Only one of TPP or Cloud may be specified.
+                  properties:
+                    caBundle:
+                      description: CABundle is a PEM encoded TLS certifiate to use
+                        to verify connections to the TPP instance. If specified, system
+                        roots will not be used and the issuing CA for the TPP instance
+                        must be verifiable using the provided root. If not specified,
+                        the connection will be verified using the cert-manager system
+                        root certificates.
+                      format: byte
+                      type: string
+                    credentialsRef:
+                      description: CredentialsRef is a reference to a Secret containing
+                        the username and password for the TPP server. The secret must
+                        contain two keys, 'username' and 'password'.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    url:
+                      description: URL is the base URL for the Venafi TPP instance
+                      type: string
+                  required:
+                  - credentialsRef
+                  - url
+                  type: object
+                zone:
+                  description: Zone is the Venafi Policy Zone to use for this issuer.
+                    All requests made to the Venafi platform will be restricted by
+                    the named zone policy. This field is required.
+                  type: string
+              required:
+              - zone
+              type: object
+          type: object
+        status:
+          description: IssuerStatus contains status information about an Issuer
+          properties:
+            acme:
+              properties:
+                lastRegisteredEmail:
+                  description: LastRegisteredEmail is the email associated with the
+                    latest registered ACME account, in order to track changes made
+                    to registered account associated with the  Issuer
+                  type: string
+                uri:
+                  description: URI is the unique account identifier, which can also
+                    be used to retrieve account details from the CA
+                  type: string
+              type: object
+            conditions:
+              items:
+                description: IssuerCondition contains condition information for an
+                  Issuer.
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the timestamp corresponding
+                      to the last status change of this condition.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message is a human readable description of the details
+                      of the last transition, complementing reason.
+                    type: string
+                  reason:
+                    description: Reason is a brief machine readable explanation for
+                      the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of ('True', 'False',
+                      'Unknown').
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
+                    type: string
+                  type:
+                    description: Type of the condition, currently ('Ready').
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1alpha2
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: issuers.cert-manager.io
+spec:
+  group: cert-manager.io
+  names:
+    kind: Issuer
+    listKind: IssuerList
+    plural: issuers
+    singular: issuer
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: IssuerSpec is the specification of an Issuer. This includes
+            any configuration required for the issuer.
+          properties:
+            acme:
+              description: ACMEIssuer contains the specification for an ACME issuer
+              properties:
+                email:
+                  description: Email is the email for this account
+                  type: string
+                privateKeySecretRef:
+                  description: PrivateKey is the name of a secret containing the private
+                    key for this user account.
+                  properties:
+                    key:
+                      description: The key of the secret to select from. Must be a
+                        valid secret key.
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  required:
+                  - name
+                  type: object
+                server:
+                  description: Server is the ACME server URL
+                  type: string
+                skipTLSVerify:
+                  description: If true, skip verifying the ACME server TLS certificate
+                  type: boolean
+                solvers:
+                  description: Solvers is a list of challenge solvers that will be
+                    used to solve ACME challenges for the matching domains.
+                  items:
+                    properties:
+                      dns01:
+                        properties:
+                          acmedns:
+                            description: ACMEIssuerDNS01ProviderAcmeDNS is a structure
+                              containing the configuration for ACME-DNS servers
+                            properties:
+                              accountSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              host:
+                                type: string
+                            required:
+                            - accountSecretRef
+                            - host
+                            type: object
+                          akamai:
+                            description: ACMEIssuerDNS01ProviderAkamai is a structure
+                              containing the DNS configuration for Akamai DNS—Zone
+                              Record Management API
+                            properties:
+                              accessTokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              clientSecretSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              clientTokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              serviceConsumerDomain:
+                                type: string
+                            required:
+                            - accessTokenSecretRef
+                            - clientSecretSecretRef
+                            - clientTokenSecretRef
+                            - serviceConsumerDomain
+                            type: object
+                          azuredns:
+                            description: ACMEIssuerDNS01ProviderAzureDNS is a structure
+                              containing the configuration for Azure DNS
+                            properties:
+                              clientID:
+                                type: string
+                              clientSecretSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              environment:
+                                enum:
+                                - AzurePublicCloud
+                                - AzureChinaCloud
+                                - AzureGermanCloud
+                                - AzureUSGovernmentCloud
+                                type: string
+                              hostedZoneName:
+                                type: string
+                              resourceGroupName:
+                                type: string
+                              subscriptionID:
+                                type: string
+                              tenantID:
+                                type: string
+                            required:
+                            - clientID
+                            - clientSecretSecretRef
+                            - resourceGroupName
+                            - subscriptionID
+                            - tenantID
+                            type: object
+                          clouddns:
+                            description: ACMEIssuerDNS01ProviderCloudDNS is a structure
+                              containing the DNS configuration for Google Cloud DNS
+                            properties:
+                              project:
+                                type: string
+                              serviceAccountSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - project
+                            - serviceAccountSecretRef
+                            type: object
+                          cloudflare:
+                            description: ACMEIssuerDNS01ProviderCloudflare is a structure
+                              containing the DNS configuration for Cloudflare
+                            properties:
+                              apiKeySecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              email:
+                                type: string
+                            required:
+                            - apiKeySecretRef
+                            - email
+                            type: object
+                          cnameStrategy:
+                            description: CNAMEStrategy configures how the DNS01 provider
+                              should handle CNAME records when found in DNS zones.
+                            enum:
+                            - None
+                            - Follow
+                            type: string
+                          digitalocean:
+                            description: ACMEIssuerDNS01ProviderDigitalOcean is a
+                              structure containing the DNS configuration for DigitalOcean
+                              Domains
+                            properties:
+                              tokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - tokenSecretRef
+                            type: object
+                          rfc2136:
+                            description: ACMEIssuerDNS01ProviderRFC2136 is a structure
+                              containing the configuration for RFC2136 DNS
+                            properties:
+                              nameserver:
+                                description: 'The IP address of the DNS supporting
+                                  RFC2136. Required. Note: FQDN is not a valid value,
+                                  only IP.'
+                                type: string
+                              tsigAlgorithm:
+                                description: 'The TSIG Algorithm configured in the
+                                  DNS supporting RFC2136. Used only when ``tsigSecretSecretRef``
+                                  and ``tsigKeyName`` are defined. Supported values
+                                  are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``,
+                                  ``HMACSHA256`` or ``HMACSHA512``.'
+                                type: string
+                              tsigKeyName:
+                                description: The TSIG Key name configured in the DNS.
+                                  If ``tsigSecretSecretRef`` is defined, this field
+                                  is required.
+                                type: string
+                              tsigSecretSecretRef:
+                                description: The name of the secret containing the
+                                  TSIG value. If ``tsigKeyName`` is defined, this
+                                  field is required.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - nameserver
+                            type: object
+                          route53:
+                            description: ACMEIssuerDNS01ProviderRoute53 is a structure
+                              containing the Route 53 configuration for AWS
+                            properties:
+                              accessKeyID:
+                                description: 'The AccessKeyID is used for authentication.
+                                  If not set we fall-back to using env vars, shared
+                                  credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                type: string
+                              hostedZoneID:
+                                description: If set, the provider will manage only
+                                  this zone in Route53 and will not do an lookup using
+                                  the route53:ListHostedZonesByName api call.
+                                type: string
+                              region:
+                                description: Always set the region when using AccessKeyID
+                                  and SecretAccessKey
+                                type: string
+                              role:
+                                description: Role is a Role ARN which the Route53
+                                  provider will assume using either the explicit credentials
+                                  AccessKeyID/SecretAccessKey or the inferred credentials
+                                  from environment variables, shared credentials file
+                                  or AWS Instance metadata
+                                type: string
+                              secretAccessKeySecretRef:
+                                description: The SecretAccessKey is used for authentication.
+                                  If not set we fall-back to using env vars, shared
+                                  credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - region
+                            type: object
+                          webhook:
+                            description: ACMEIssuerDNS01ProviderWebhook specifies
+                              configuration for a webhook DNS01 provider, including
+                              where to POST ChallengePayload resources.
+                            properties:
+                              config:
+                                description: Additional configuration that should
+                                  be passed to the webhook apiserver when challenges
+                                  are processed. This can contain arbitrary JSON data.
+                                  Secret values should not be specified in this stanza.
+                                  If secret values are needed (e.g. credentials for
+                                  a DNS service), you should use a SecretKeySelector
+                                  to reference a Secret resource. For details on the
+                                  schema of this field, consult the webhook provider
+                                  implementation's documentation.
+                                x-kubernetes-preserve-unknown-fields: true
+                              groupName:
+                                description: The API group name that should be used
+                                  when POSTing ChallengePayload resources to the webhook
+                                  apiserver. This should be the same as the GroupName
+                                  specified in the webhook provider implementation.
+                                type: string
+                              solverName:
+                                description: The name of the solver to use, as defined
+                                  in the webhook provider implementation. This will
+                                  typically be the name of the provider, e.g. 'cloudflare'.
+                                type: string
+                            required:
+                            - groupName
+                            - solverName
+                            type: object
+                        type: object
+                      http01:
+                        description: ACMEChallengeSolverHTTP01 contains configuration
+                          detailing how to solve HTTP01 challenges within a Kubernetes
+                          cluster. Typically this is accomplished through creating
+                          'routes' of some description that configure ingress controllers
+                          to direct traffic to 'solver pods', which are responsible
+                          for responding to the ACME server's HTTP requests.
+                        properties:
+                          ingress:
+                            description: The ingress based HTTP01 challenge solver
+                              will solve challenges by creating or modifying Ingress
+                              resources in order to route requests for '/.well-known/acme-challenge/XYZ'
+                              to 'challenge solver' pods that are provisioned by cert-manager
+                              for each Challenge to be completed.
+                            properties:
+                              class:
+                                description: The ingress class to use when creating
+                                  Ingress resources to solve ACME challenges that
+                                  use this challenge solver. Only one of 'class' or
+                                  'name' may be specified.
+                                type: string
+                              name:
+                                description: The name of the ingress resource that
+                                  should have ACME challenge solving routes inserted
+                                  into it in order to solve HTTP01 challenges. This
+                                  is typically used in conjunction with ingress controllers
+                                  like ingress-gce, which maintains a 1:1 mapping
+                                  between external IPs and ingress resources.
+                                type: string
+                              podTemplate:
+                                description: Optional pod template used to configure
+                                  the ACME challenge solver pods used for HTTP01 challenges
+                                properties:
+                                  metadata:
+                                    description: ObjectMeta overrides for the pod
+                                      used to solve HTTP01 challenges. Only the 'labels'
+                                      and 'annotations' fields may be set. If labels
+                                      or annotations overlap with in-built values,
+                                      the values here will override the in-built values.
+                                    type: object
+                                  spec:
+                                    description: PodSpec defines overrides for the
+                                      HTTP01 challenge solver pod. Only the 'nodeSelector',
+                                      'affinity' and 'tolerations' fields are supported
+                                      currently. All other fields will be ignored.
+                                    properties:
+                                      affinity:
+                                        description: If specified, the pod's scheduling
+                                          constraints
+                                        properties:
+                                          nodeAffinity:
+                                            description: Describes node affinity scheduling
+                                              rules for the pod.
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                description: The scheduler will prefer
+                                                  to schedule pods to nodes that satisfy
+                                                  the affinity expressions specified
+                                                  by this field, but it may choose
+                                                  a node that violates one or more
+                                                  of the expressions. The node that
+                                                  is most preferred is the one with
+                                                  the greatest sum of weights, i.e.
+                                                  for each node that meets all of
+                                                  the scheduling requirements (resource
+                                                  request, requiredDuringScheduling
+                                                  affinity expressions, etc.), compute
+                                                  a sum by iterating through the elements
+                                                  of this field and adding "weight"
+                                                  to the sum if the node matches the
+                                                  corresponding matchExpressions;
+                                                  the node(s) with the highest sum
+                                                  are the most preferred.
+                                                items:
+                                                  description: An empty preferred
+                                                    scheduling term matches all objects
+                                                    with implicit weight 0 (i.e. it's
+                                                    a no-op). A null preferred scheduling
+                                                    term matches no objects (i.e.
+                                                    is also a no-op).
+                                                  properties:
+                                                    preference:
+                                                      description: A node selector
+                                                        term, associated with the
+                                                        corresponding weight.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's labels.
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchFields:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's fields.
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                      type: object
+                                                    weight:
+                                                      description: Weight associated
+                                                        with matching the corresponding
+                                                        nodeSelectorTerm, in the range
+                                                        1-100.
+                                                      format: int32
+                                                      type: integer
+                                                  required:
+                                                  - preference
+                                                  - weight
+                                                  type: object
+                                                type: array
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                description: If the affinity requirements
+                                                  specified by this field are not
+                                                  met at scheduling time, the pod
+                                                  will not be scheduled onto the node.
+                                                  If the affinity requirements specified
+                                                  by this field cease to be met at
+                                                  some point during pod execution
+                                                  (e.g. due to an update), the system
+                                                  may or may not try to eventually
+                                                  evict the pod from its node.
+                                                properties:
+                                                  nodeSelectorTerms:
+                                                    description: Required. A list
+                                                      of node selector terms. The
+                                                      terms are ORed.
+                                                    items:
+                                                      description: A null or empty
+                                                        node selector term matches
+                                                        no objects. The requirements
+                                                        of them are ANDed. The TopologySelectorTerm
+                                                        type implements a subset of
+                                                        the NodeSelectorTerm.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's labels.
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchFields:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's fields.
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                required:
+                                                - nodeSelectorTerms
+                                                type: object
+                                            type: object
+                                          podAffinity:
+                                            description: Describes pod affinity scheduling
+                                              rules (e.g. co-locate this pod in the
+                                              same node, zone, etc. as some other
+                                              pod(s)).
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                description: The scheduler will prefer
+                                                  to schedule pods to nodes that satisfy
+                                                  the affinity expressions specified
+                                                  by this field, but it may choose
+                                                  a node that violates one or more
+                                                  of the expressions. The node that
+                                                  is most preferred is the one with
+                                                  the greatest sum of weights, i.e.
+                                                  for each node that meets all of
+                                                  the scheduling requirements (resource
+                                                  request, requiredDuringScheduling
+                                                  affinity expressions, etc.), compute
+                                                  a sum by iterating through the elements
+                                                  of this field and adding "weight"
+                                                  to the sum if the node has pods
+                                                  which matches the corresponding
+                                                  podAffinityTerm; the node(s) with
+                                                  the highest sum are the most preferred.
+                                                items:
+                                                  description: The weights of all
+                                                    of the matched WeightedPodAffinityTerm
+                                                    fields are added per-node to find
+                                                    the most preferred node(s)
+                                                  properties:
+                                                    podAffinityTerm:
+                                                      description: Required. A pod
+                                                        affinity term, associated
+                                                        with the corresponding weight.
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query
+                                                            over a set of resources,
+                                                            in this case pods.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions
+                                                                is a list of label
+                                                                selector requirements.
+                                                                The requirements are
+                                                                ANDed.
+                                                              items:
+                                                                description: A label
+                                                                  selector requirement
+                                                                  is a selector that
+                                                                  contains values,
+                                                                  a key, and an operator
+                                                                  that relates the
+                                                                  key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key
+                                                                      is the label
+                                                                      key that the
+                                                                      selector applies
+                                                                      to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator
+                                                                      represents a
+                                                                      key's relationship
+                                                                      to a set of
+                                                                      values. Valid
+                                                                      operators are
+                                                                      In, NotIn, Exists
+                                                                      and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values
+                                                                      is an array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or
+                                                                      DoesNotExist,
+                                                                      the values array
+                                                                      must be empty.
+                                                                      This array is
+                                                                      replaced during
+                                                                      a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: matchLabels
+                                                                is a map of {key,value}
+                                                                pairs. A single {key,value}
+                                                                in the matchLabels
+                                                                map is equivalent
+                                                                to an element of matchExpressions,
+                                                                whose key field is
+                                                                "key", the operator
+                                                                is "In", and the values
+                                                                array contains only
+                                                                "value". The requirements
+                                                                are ANDed.
+                                                              type: object
+                                                          type: object
+                                                        namespaces:
+                                                          description: namespaces
+                                                            specifies which namespaces
+                                                            the labelSelector applies
+                                                            to (matches against);
+                                                            null or empty list means
+                                                            "this pod's namespace"
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                        topologyKey:
+                                                          description: This pod should
+                                                            be co-located (affinity)
+                                                            or not co-located (anti-affinity)
+                                                            with the pods matching
+                                                            the labelSelector in the
+                                                            specified namespaces,
+                                                            where co-located is defined
+                                                            as running on a node whose
+                                                            value of the label with
+                                                            key topologyKey matches
+                                                            that of any node on which
+                                                            any of the selected pods
+                                                            is running. Empty topologyKey
+                                                            is not allowed.
+                                                          type: string
+                                                      required:
+                                                      - topologyKey
+                                                      type: object
+                                                    weight:
+                                                      description: weight associated
+                                                        with matching the corresponding
+                                                        podAffinityTerm, in the range
+                                                        1-100.
+                                                      format: int32
+                                                      type: integer
+                                                  required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                  type: object
+                                                type: array
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                description: If the affinity requirements
+                                                  specified by this field are not
+                                                  met at scheduling time, the pod
+                                                  will not be scheduled onto the node.
+                                                  If the affinity requirements specified
+                                                  by this field cease to be met at
+                                                  some point during pod execution
+                                                  (e.g. due to a pod label update),
+                                                  the system may or may not try to
+                                                  eventually evict the pod from its
+                                                  node. When there are multiple elements,
+                                                  the lists of nodes corresponding
+                                                  to each podAffinityTerm are intersected,
+                                                  i.e. all terms must be satisfied.
+                                                items:
+                                                  description: Defines a set of pods
+                                                    (namely those matching the labelSelector
+                                                    relative to the given namespace(s))
+                                                    that this pod should be co-located
+                                                    (affinity) or not co-located (anti-affinity)
+                                                    with, where co-located is defined
+                                                    as running on a node whose value
+                                                    of the label with key <topologyKey>
+                                                    matches that of any node on which
+                                                    a pod of the set of pods is running
+                                                  properties:
+                                                    labelSelector:
+                                                      description: A label query over
+                                                        a set of resources, in this
+                                                        case pods.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                      type: object
+                                                    namespaces:
+                                                      description: namespaces specifies
+                                                        which namespaces the labelSelector
+                                                        applies to (matches against);
+                                                        null or empty list means "this
+                                                        pod's namespace"
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    topologyKey:
+                                                      description: This pod should
+                                                        be co-located (affinity) or
+                                                        not co-located (anti-affinity)
+                                                        with the pods matching the
+                                                        labelSelector in the specified
+                                                        namespaces, where co-located
+                                                        is defined as running on a
+                                                        node whose value of the label
+                                                        with key topologyKey matches
+                                                        that of any node on which
+                                                        any of the selected pods is
+                                                        running. Empty topologyKey
+                                                        is not allowed.
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          podAntiAffinity:
+                                            description: Describes pod anti-affinity
+                                              scheduling rules (e.g. avoid putting
+                                              this pod in the same node, zone, etc.
+                                              as some other pod(s)).
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                description: The scheduler will prefer
+                                                  to schedule pods to nodes that satisfy
+                                                  the anti-affinity expressions specified
+                                                  by this field, but it may choose
+                                                  a node that violates one or more
+                                                  of the expressions. The node that
+                                                  is most preferred is the one with
+                                                  the greatest sum of weights, i.e.
+                                                  for each node that meets all of
+                                                  the scheduling requirements (resource
+                                                  request, requiredDuringScheduling
+                                                  anti-affinity expressions, etc.),
+                                                  compute a sum by iterating through
+                                                  the elements of this field and adding
+                                                  "weight" to the sum if the node
+                                                  has pods which matches the corresponding
+                                                  podAffinityTerm; the node(s) with
+                                                  the highest sum are the most preferred.
+                                                items:
+                                                  description: The weights of all
+                                                    of the matched WeightedPodAffinityTerm
+                                                    fields are added per-node to find
+                                                    the most preferred node(s)
+                                                  properties:
+                                                    podAffinityTerm:
+                                                      description: Required. A pod
+                                                        affinity term, associated
+                                                        with the corresponding weight.
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query
+                                                            over a set of resources,
+                                                            in this case pods.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions
+                                                                is a list of label
+                                                                selector requirements.
+                                                                The requirements are
+                                                                ANDed.
+                                                              items:
+                                                                description: A label
+                                                                  selector requirement
+                                                                  is a selector that
+                                                                  contains values,
+                                                                  a key, and an operator
+                                                                  that relates the
+                                                                  key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key
+                                                                      is the label
+                                                                      key that the
+                                                                      selector applies
+                                                                      to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator
+                                                                      represents a
+                                                                      key's relationship
+                                                                      to a set of
+                                                                      values. Valid
+                                                                      operators are
+                                                                      In, NotIn, Exists
+                                                                      and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values
+                                                                      is an array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or
+                                                                      DoesNotExist,
+                                                                      the values array
+                                                                      must be empty.
+                                                                      This array is
+                                                                      replaced during
+                                                                      a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: matchLabels
+                                                                is a map of {key,value}
+                                                                pairs. A single {key,value}
+                                                                in the matchLabels
+                                                                map is equivalent
+                                                                to an element of matchExpressions,
+                                                                whose key field is
+                                                                "key", the operator
+                                                                is "In", and the values
+                                                                array contains only
+                                                                "value". The requirements
+                                                                are ANDed.
+                                                              type: object
+                                                          type: object
+                                                        namespaces:
+                                                          description: namespaces
+                                                            specifies which namespaces
+                                                            the labelSelector applies
+                                                            to (matches against);
+                                                            null or empty list means
+                                                            "this pod's namespace"
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                        topologyKey:
+                                                          description: This pod should
+                                                            be co-located (affinity)
+                                                            or not co-located (anti-affinity)
+                                                            with the pods matching
+                                                            the labelSelector in the
+                                                            specified namespaces,
+                                                            where co-located is defined
+                                                            as running on a node whose
+                                                            value of the label with
+                                                            key topologyKey matches
+                                                            that of any node on which
+                                                            any of the selected pods
+                                                            is running. Empty topologyKey
+                                                            is not allowed.
+                                                          type: string
+                                                      required:
+                                                      - topologyKey
+                                                      type: object
+                                                    weight:
+                                                      description: weight associated
+                                                        with matching the corresponding
+                                                        podAffinityTerm, in the range
+                                                        1-100.
+                                                      format: int32
+                                                      type: integer
+                                                  required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                  type: object
+                                                type: array
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                description: If the anti-affinity
+                                                  requirements specified by this field
+                                                  are not met at scheduling time,
+                                                  the pod will not be scheduled onto
+                                                  the node. If the anti-affinity requirements
+                                                  specified by this field cease to
+                                                  be met at some point during pod
+                                                  execution (e.g. due to a pod label
+                                                  update), the system may or may not
+                                                  try to eventually evict the pod
+                                                  from its node. When there are multiple
+                                                  elements, the lists of nodes corresponding
+                                                  to each podAffinityTerm are intersected,
+                                                  i.e. all terms must be satisfied.
+                                                items:
+                                                  description: Defines a set of pods
+                                                    (namely those matching the labelSelector
+                                                    relative to the given namespace(s))
+                                                    that this pod should be co-located
+                                                    (affinity) or not co-located (anti-affinity)
+                                                    with, where co-located is defined
+                                                    as running on a node whose value
+                                                    of the label with key <topologyKey>
+                                                    matches that of any node on which
+                                                    a pod of the set of pods is running
+                                                  properties:
+                                                    labelSelector:
+                                                      description: A label query over
+                                                        a set of resources, in this
+                                                        case pods.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                      type: object
+                                                    namespaces:
+                                                      description: namespaces specifies
+                                                        which namespaces the labelSelector
+                                                        applies to (matches against);
+                                                        null or empty list means "this
+                                                        pod's namespace"
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    topologyKey:
+                                                      description: This pod should
+                                                        be co-located (affinity) or
+                                                        not co-located (anti-affinity)
+                                                        with the pods matching the
+                                                        labelSelector in the specified
+                                                        namespaces, where co-located
+                                                        is defined as running on a
+                                                        node whose value of the label
+                                                        with key topologyKey matches
+                                                        that of any node on which
+                                                        any of the selected pods is
+                                                        running. Empty topologyKey
+                                                        is not allowed.
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                type: array
+                                            type: object
+                                        type: object
+                                      nodeSelector:
+                                        additionalProperties:
+                                          type: string
+                                        description: 'NodeSelector is a selector which
+                                          must be true for the pod to fit on a node.
+                                          Selector which must match a node''s labels
+                                          for the pod to be scheduled on that node.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                        type: object
+                                      tolerations:
+                                        description: If specified, the pod's tolerations.
+                                        items:
+                                          description: The pod this Toleration is
+                                            attached to tolerates any taint that matches
+                                            the triple <key,value,effect> using the
+                                            matching operator <operator>.
+                                          properties:
+                                            effect:
+                                              description: Effect indicates the taint
+                                                effect to match. Empty means match
+                                                all taint effects. When specified,
+                                                allowed values are NoSchedule, PreferNoSchedule
+                                                and NoExecute.
+                                              type: string
+                                            key:
+                                              description: Key is the taint key that
+                                                the toleration applies to. Empty means
+                                                match all taint keys. If the key is
+                                                empty, operator must be Exists; this
+                                                combination means to match all values
+                                                and all keys.
+                                              type: string
+                                            operator:
+                                              description: Operator represents a key's
+                                                relationship to the value. Valid operators
+                                                are Exists and Equal. Defaults to
+                                                Equal. Exists is equivalent to wildcard
+                                                for value, so that a pod can tolerate
+                                                all taints of a particular category.
+                                              type: string
+                                            tolerationSeconds:
+                                              description: TolerationSeconds represents
+                                                the period of time the toleration
+                                                (which must be of effect NoExecute,
+                                                otherwise this field is ignored) tolerates
+                                                the taint. By default, it is not set,
+                                                which means tolerate the taint forever
+                                                (do not evict). Zero and negative
+                                                values will be treated as 0 (evict
+                                                immediately) by the system.
+                                              format: int64
+                                              type: integer
+                                            value:
+                                              description: Value is the taint value
+                                                the toleration matches to. If the
+                                                operator is Exists, the value should
+                                                be empty, otherwise just a regular
+                                                string.
+                                              type: string
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              serviceType:
+                                description: Optional service type for Kubernetes
+                                  solver service
+                                type: string
+                            type: object
+                        type: object
+                      selector:
+                        description: Selector selects a set of DNSNames on the Certificate
+                          resource that should be solved using this challenge solver.
+                        properties:
+                          dnsNames:
+                            description: List of DNSNames that this solver will be
+                              used to solve. If specified and a match is found, a
+                              dnsNames selector will take precedence over a dnsZones
+                              selector. If multiple solvers match with the same dnsNames
+                              value, the solver with the most matching labels in matchLabels
+                              will be selected. If neither has more matches, the solver
+                              defined earlier in the list will be selected.
+                            items:
+                              type: string
+                            type: array
+                          dnsZones:
+                            description: List of DNSZones that this solver will be
+                              used to solve. The most specific DNS zone match specified
+                              here will take precedence over other DNS zone matches,
+                              so a solver specifying sys.example.com will be selected
+                              over one specifying example.com for the domain www.sys.example.com.
+                              If multiple solvers match with the same dnsZones value,
+                              the solver with the most matching labels in matchLabels
+                              will be selected. If neither has more matches, the solver
+                              defined earlier in the list will be selected.
+                            items:
+                              type: string
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: A label selector that is used to refine the
+                              set of certificate's that this challenge solver will
+                              apply to.
+                            type: object
+                        type: object
+                    type: object
+                  type: array
+              required:
+              - privateKeySecretRef
+              - server
+              type: object
+            ca:
+              properties:
+                secretName:
+                  description: SecretName is the name of the secret used to sign Certificates
+                    issued by this Issuer.
+                  type: string
+              required:
+              - secretName
+              type: object
+            selfSigned:
+              type: object
+            vault:
+              properties:
+                auth:
+                  description: Vault authentication
+                  properties:
+                    appRole:
+                      description: This Secret contains a AppRole and Secret
+                      properties:
+                        path:
+                          description: Where the authentication path is mounted in
+                            Vault.
+                          type: string
+                        roleId:
+                          type: string
+                        secretRef:
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - path
+                      - roleId
+                      - secretRef
+                      type: object
+                    kubernetes:
+                      description: This contains a Role and Secret with a ServiceAccount
+                        token to authenticate with vault.
+                      properties:
+                        mountPath:
+                          description: The value here will be used as part of the
+                            path used when authenticating with vault, for example
+                            if you set a value of "foo", the path used will be `/v1/auth/foo/login`.
+                            If unspecified, the default value "kubernetes" will be
+                            used.
+                          type: string
+                        role:
+                          description: A required field containing the Vault Role
+                            to assume. A Role binds a Kubernetes ServiceAccount with
+                            a set of Vault policies.
+                          type: string
+                        secretRef:
+                          description: The required Secret field containing a Kubernetes
+                            ServiceAccount JWT used for authenticating with Vault.
+                            Use of 'ambient credentials' is not supported.
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - role
+                      - secretRef
+                      type: object
+                    tokenSecretRef:
+                      description: This Secret contains the Vault token key
+                      properties:
+                        key:
+                          description: The key of the secret to select from. Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  type: object
+                caBundle:
+                  description: Base64 encoded CA bundle to validate Vault server certificate.
+                    Only used if the Server URL is using HTTPS protocol. This parameter
+                    is ignored for plain HTTP protocol connection. If not set the
+                    system root certificates are used to validate the TLS connection.
+                  format: byte
+                  type: string
+                path:
+                  description: Vault URL path to the certificate role
+                  type: string
+                server:
+                  description: Server is the vault connection address
+                  type: string
+              required:
+              - auth
+              - path
+              - server
+              type: object
+            venafi:
+              description: VenafiIssuer describes issuer configuration details for
+                Venafi Cloud.
+              properties:
+                cloud:
+                  description: Cloud specifies the Venafi cloud configuration settings.
+                    Only one of TPP or Cloud may be specified.
+                  properties:
+                    apiTokenSecretRef:
+                      description: APITokenSecretRef is a secret key selector for
+                        the Venafi Cloud API token.
+                      properties:
+                        key:
+                          description: The key of the secret to select from. Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    url:
+                      description: URL is the base URL for Venafi Cloud
+                      type: string
+                  required:
+                  - apiTokenSecretRef
+                  - url
+                  type: object
+                tpp:
+                  description: TPP specifies Trust Protection Platform configuration
+                    settings. Only one of TPP or Cloud may be specified.
+                  properties:
+                    caBundle:
+                      description: CABundle is a PEM encoded TLS certifiate to use
+                        to verify connections to the TPP instance. If specified, system
+                        roots will not be used and the issuing CA for the TPP instance
+                        must be verifiable using the provided root. If not specified,
+                        the connection will be verified using the cert-manager system
+                        root certificates.
+                      format: byte
+                      type: string
+                    credentialsRef:
+                      description: CredentialsRef is a reference to a Secret containing
+                        the username and password for the TPP server. The secret must
+                        contain two keys, 'username' and 'password'.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    url:
+                      description: URL is the base URL for the Venafi TPP instance
+                      type: string
+                  required:
+                  - credentialsRef
+                  - url
+                  type: object
+                zone:
+                  description: Zone is the Venafi Policy Zone to use for this issuer.
+                    All requests made to the Venafi platform will be restricted by
+                    the named zone policy. This field is required.
+                  type: string
+              required:
+              - zone
+              type: object
+          type: object
+        status:
+          description: IssuerStatus contains status information about an Issuer
+          properties:
+            acme:
+              properties:
+                lastRegisteredEmail:
+                  description: LastRegisteredEmail is the email associated with the
+                    latest registered ACME account, in order to track changes made
+                    to registered account associated with the  Issuer
+                  type: string
+                uri:
+                  description: URI is the unique account identifier, which can also
+                    be used to retrieve account details from the CA
+                  type: string
+              type: object
+            conditions:
+              items:
+                description: IssuerCondition contains condition information for an
+                  Issuer.
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the timestamp corresponding
+                      to the last status change of this condition.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message is a human readable description of the details
+                      of the last transition, complementing reason.
+                    type: string
+                  reason:
+                    description: Reason is a brief machine readable explanation for
+                      the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of ('True', 'False',
+                      'Unknown').
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
+                    type: string
+                  type:
+                    description: Type of the condition, currently ('Ready').
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1alpha2
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---

--- a/kubernetes/zenko/charts/opal/.helmignore
+++ b/kubernetes/zenko/charts/opal/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/kubernetes/zenko/charts/opal/Chart.yaml
+++ b/kubernetes/zenko/charts/opal/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0.0"
+description: A Helm chart for Kubernetes
+name: opal
+version: 1.0.0

--- a/kubernetes/zenko/charts/opal/templates/_env.tpl
+++ b/kubernetes/zenko/charts/opal/templates/_env.tpl
@@ -1,0 +1,130 @@
+{{- define "blobserver.env" }}
+- name: DATA_HOST
+  value: "{{- printf "%s-%s" .Release.Name "s3-data" | trunc 63 | trimSuffix "-" -}}"
+- name: ENDPOINT
+  value: "{{ include "blobserver.fullname" . }}"
+- name: LOG_LEVEL
+  value: "{{ .Values.logging.level }}"
+- name: HEALTHCHECKS_ALLOWFROM
+  value: "{{ .Values.allowHealthchecksFrom }}"
+{{- if .Values.proxy.http }}
+- name: http_proxy
+  value: "{{ .Values.proxy.http }}"
+- name: HTTP_PROXY
+  value: "{{ .Values.proxy.http }}"
+- name: https_proxy
+  value: "{{- if .Values.proxy.https }}{{ .Values.proxy.https }}{{- else }}{{ .Values.proxy.http }}{{- end }}"
+- name: HTTPS_PROXY
+  value: "{{- if .Values.proxy.https }}{{ .Values.proxy.https }}{{- else }}{{ .Values.proxy.http }}{{- end }}"
+{{- else if .Values.proxy.https }}
+- name: https_proxy
+  value: "{{ .Values.proxy.https }}"
+- name: HTTPS_PROXY
+  value: "{{ .Values.proxy.https }}"
+{{- end }}
+{{- if .Values.proxy.caCert }}
+- name: NODE_EXTRA_CA_CERTS
+  value: "/ssl/ca.crt"
+{{- end }}
+{{- if .Values.proxy.no_proxy }}
+- name: no_proxy
+  value: "{{ .Values.proxy.no_proxy }}"
+- name: NO_PROXY
+  value: "{{ .Values.proxy.no_proxy }}"
+{{- end }}
+- name: BLOB_METADATA
+  value: "mongodb"
+- name: BLOB_DATA
+  value: "multiple"
+- name: BLOB_DATA_CLIENT_HOST
+  value: {{ include "opal.s3-data-host" . }}
+- name: MONGODB_HOSTS
+  value: "{{ include "opal.mongodb-hosts" . }}"
+- name: MONGODB_RS
+  value: "{{ default "rs0" .Values.mongodb.replicaSet }}"
+# force remote management
+- name: REMOTE_MANAGEMENT_DISABLE
+  value: "{{ ternary "0" "1" .Values.global.orbit.enabled }}"
+- name: MANAGEMENT_ENDPOINT
+  value: "{{ .Values.global.orbit.endpoint }}"
+- name: PUSH_ENDPOINT
+  value: "{{- .Values.global.orbit.pushEndpoint -}}"
+{{- if .Values.kmip.enabled }}
+- name: BLOB_KMS
+  value: kmip
+- name: BLOB_KMIP_PORT
+  value: "{{ .Values.kmip.port }}"
+- name: BLOB_KMIP_HOST
+  value: "{{ .Values.kmip.host }}"
+- name: BLOB_KMIP_COMPOUND_CREATE
+  value: "{{ .Values.kmip.compoundCreate }}"
+- name: BLOB_BUCKET_ATTRIBUTE_NAME
+  value: "{{ .Values.kmip.bucketAttributeName }}"
+- name: BLOB_KMIP_PIPELINE_DEPTH
+  value: "{{ .Values.kmip.pipelineDepth }}"
+- name: BLOB_KEY
+  value: /ssl-kmip/kmip-key.pem
+- name: BLOB_KMIP_CERT
+  value: /ssl-kmip/kmip-cert.pem
+- name: BLOB_KMIP_CA
+  value: /ssl-kmip/kmip-ca.pem
+{{- end }}
+{{- end }}
+
+{{- define "jabba.env" }}
+- name: JABBA_REST_ENDPOINTS
+  value: "{{ include "jabba.fullname" . }},{{ .Values.jabba.endpoint }}"
+- name: JABBA_HOSTNAME
+  value: "{{ .Values.jabba.endpoint }}"
+- name: JABBA_LOG_LEVEL
+  value: "{{ .Values.logging.level }}"
+- name: JABBA_ALLOW_HEALTHCHECK
+  value: "{{ .Values.allowHealthchecksFrom }}"
+- name: JABBA_HTTPS
+  value: ''
+{{- if .Values.proxy.http }}
+- name: http_proxy
+  value: "{{ .Values.proxy.http }}"
+- name: HTTP_PROXY
+  value: "{{ .Values.proxy.http }}"
+- name: https_proxy
+  value: "{{- if .Values.proxy.https }}{{ .Values.proxy.https }}{{- else }}{{ .Values.proxy.http }}{{- end }}"
+- name: HTTPS_PROXY
+  value: "{{- if .Values.proxy.https }}{{ .Values.proxy.https }}{{- else }}{{ .Values.proxy.http }}{{- end }}"
+{{- else if .Values.proxy.https }}
+- name: https_proxy
+  value: "{{ .Values.proxy.https }}"
+- name: HTTPS_PROXY
+  value: "{{ .Values.proxy.https }}"
+{{- end }}
+{{- if .Values.proxy.caCert }}
+- name: NODE_EXTRA_CA_CERTS
+  value: "/ssl/ca.crt"
+{{- end }}
+{{- if .Values.proxy.no_proxy }}
+- name: no_proxy
+  value: "{{ .Values.proxy.no_proxy }}"
+- name: NO_PROXY
+  value: "{{ .Values.proxy.no_proxy }}"
+{{- end }}
+- name: JABBA_METADATA_BACKEND
+  value: mongodb
+- name: JABBA_AUTH_BACKEND
+  value: mongodb
+- name: JABBA_TOKEN_BACKEND
+  value: redis
+- name: JABBA_MONGODB_HOSTS
+  value: "{{ include "opal.mongodb-hosts" . }}"
+- name: JABBA_MONGODB_RS
+  value: "{{ default "rs0" .Values.mongodb.replicaSet }}"
+- name: JABBA_MONGODB_WRITE_CONCERN
+  value: "{{ default "majority" .Values.mongodb.writeConcern }}"
+- name: JABBA_MONGODB_READ_PREFERENCE
+  value: "{{ default "primary" .Values.mongodb.readPreference }}"
+- name: JABBA_EXTERNAL_TLS
+  value: "true"
+- name: JABBA_REDIS_SENTINELS
+  value: "{{ include "opal.redis-hosts" . }}"
+- name: JABBA_REDIS_NAME
+  value: "{{ default "jabba" .Values.redis.sentinel.name }}"
+{{- end }}

--- a/kubernetes/zenko/charts/opal/templates/_helpers.tpl
+++ b/kubernetes/zenko/charts/opal/templates/_helpers.tpl
@@ -1,0 +1,143 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "opal.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "opal.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "opal.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "opal.labels" -}}
+app.kubernetes.io/name: {{ include "opal.name" . }}
+helm.sh/chart: {{ include "opal.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+
+{{/*
+Create the blobserver variant of opal.name
+adds -blobserver by default
+*/}}
+{{- define "blobserver.name" -}}
+{{- if .Values.blobserverNameOverride -}}
+{{- .Values.blobserverNameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $chart_fullname := include "opal.name" . -}}
+{{- $name := default "blobserver" .Values.blobserverNameOverride -}}
+{{- printf "%s-%s" $chart_fullname $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the blobserver variant of opal.fullname
+adds -blobserver by default
+*/}}
+{{- define "blobserver.fullname" -}}
+{{- if .Values.blobserverFullnameOverride -}}
+{{- .Values.blobserverFullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $chart_fullname := include "opal.fullname" . -}}
+{{- $name := default "blobserver" .Values.blobserverNameOverride -}}
+{{- printf "%s-%s" $chart_fullname $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the blobserver variant of opal.name
+adds -blobserver by default
+*/}}
+{{- define "jabba.name" -}}
+{{- if .Values.jabbaNameOverride -}}
+{{- .Values.jabbaNameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $chart_fullname := include "opal.name" . -}}
+{{- $name := default "jabba" .Values.jabbaNameOverride -}}
+{{- printf "%s-%s" $chart_fullname $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the blobserver variant of fullname
+adds -jabba by default
+*/}}
+{{- define "jabba.fullname" -}}
+{{- if .Values.jabbaFullnameOverride -}}
+{{- .Values.jabbaFullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $chart_fullname := include "opal.fullname" . -}}
+{{- $name := default "jabba" .Values.jabbaNameOverride -}}
+{{- printf "%s-%s" $chart_fullname $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Increases the number of blobserver replicas by the replicaFactor value
+*/}}
+{{- define "blobserver.replicaFactor" -}}
+{{- $factor := mul .Values.blobserver.replicaFactor .Values.blobserver.replicaCount -}}
+{{- printf "%d" $factor }}
+{{- end -}}
+
+{{/*
+Increases the number of jabba replicas by the replicaFactor value
+*/}}
+{{- define "jabba.replicaFactor" -}}
+{{- $factor := mul .Values.jabba.replicaFactor .Values.jabba.replicaCount -}}
+{{- printf "%d" $factor }}
+{{- end -}}
+
+{{/*
+Create the default mongodb replicaset hosts string
+*/}}
+{{- define "opal.mongodb-hosts" -}}
+{{- $count := (atoi (printf "%d" (int64 .Values.mongodb.replicas))) -}}
+{{- $release := .Release.Name -}}
+{{- range $v := until $count }}{{ $release }}-mongodb-replicaset-{{ $v }}.{{ $release }}-mongodb-replicaset:27017{{ if ne $v (sub $count 1) }},{{- end -}}{{- end -}}
+{{- end -}}
+
+{{/*
+Create the default redis sentinels hosts string
+*/}}
+{{- define "opal.redis-hosts" -}}
+{{- $count := (int .Values.redis.replicas) -}}
+{{- $release := .Release.Name -}}
+{{- range $v := until $count }}{{ $release }}-redis-ha-server-{{ $v }}.{{ $release }}-redis-ha:26379{{ if ne $v (sub $count 1) }},{{- end -}}{{- end -}}
+{{- end -}}
+
+{{/*
+Create the s3-data host
+*/}}
+{{- define "opal.s3-data-host" -}}
+{{- printf "%s-s3-data" .Release.Name }}
+{{- end -}}

--- a/kubernetes/zenko/charts/opal/templates/blobserver/async-delete-cron.yaml
+++ b/kubernetes/zenko/charts/opal/templates/blobserver/async-delete-cron.yaml
@@ -1,0 +1,50 @@
+{{- $successfulJobsHistory :=  .Values.blobserver.asyncDeletes.successfulJobsHistory -}}
+{{- $failedJobsHistory :=  .Values.blobserver.asyncDeletes.failedJobsHistory -}}
+{{- $local := . -}}
+{{- range .Values.blobserver.asyncDeletes.jobs }}
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ template "opal.fullname" $local }}-async-delete-{{ .name }}
+  labels:
+    app: {{ template "opal.name" $local }}-async-delete-{{ .name }}
+    chart: {{ template "opal.chart" $local }}
+    release: {{ $local.Release.Name }}
+    heritage: {{ $local.Release.Service }}
+spec:
+  schedule: "{{ .schedule }}"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: {{ $successfulJobsHistory }}
+  failedJobsHistoryLimit: {{ $failedJobsHistory }}
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 120
+      template:
+        metadata:
+          labels:
+            app: {{ template "opal.name" $local }}-async-delete-{{ .name }}
+            chart: {{ template "opal.chart" $local }}-async-delete-{{ .name }}
+            release: {{ $local.Release.Name }}
+            heritage: {{ $local.Release.Service }}
+        spec:
+          restartPolicy: OnFailure
+          {{- if $local.Values.blobserver.image.imagePullSecret }}
+          imagePullSecrets:
+            - name: {{ $local.Values.blobserver.image.imagePullSecret }}
+          {{- end }}
+          containers:
+            - name: async-container-delete-{{ .name }}
+              image: "{{ $local.Values.blobserver.image.repository }}:{{ $local.Values.blobserver.image.tag }}"
+              imagePullPolicy: {{ $local.Values.blobserver.image.pullPolicy }}
+              command: {{ .command | toJson }}
+              env:
+                {{- include "blobserver.env" $local | indent 16 }}
+                - name: BLOB_MAX_RETRY
+                  value: "{{ .maxRetry }}"
+                - name: BLOB_CONCURRENT_OPS
+                  value: "{{ .maxConcurrentProcs }}"
+                - name: BLOB_CONCURRENT_DELETES
+                  value: "{{ .maxConcurrentDeletes }}"
+{{- end }}

--- a/kubernetes/zenko/charts/opal/templates/blobserver/deployment.yaml
+++ b/kubernetes/zenko/charts/opal/templates/blobserver/deployment.yaml
@@ -1,0 +1,105 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "blobserver.fullname" . }}
+  labels:
+    app: {{ template "blobserver.name" . }}
+    chart: {{ template "opal.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ template "blobserver.replicaFactor" . }}
+  selector:
+    matchLabels:
+      app: {{ template "blobserver.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      annotations:
+        {{- if .Values.proxy.https }}
+        checksum/config: {{ include (print $.Template.BasePath "/certificate.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not .Values.global.orbit.enabled }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/accounts.yaml") . | sha256sum }}
+        {{- end }}
+      labels:
+        app: {{ template "blobserver.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      # no offline mode
+      {{- if .Values.blobserver.image.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.blobserver.image.imagePullSecret }}
+      {{- end }}
+      containers:
+        - name: blobserver
+          image: "{{ .Values.blobserver.image.repository }}:{{ .Values.blobserver.image.tag }}"
+          imagePullPolicy: {{ .Values.blobserver.image.pullPolicy }}
+          terminationMessagePolicy: FallbackToLogsOnError
+          ports:
+            - name: http
+              containerPort: 8001
+          env:
+            {{- include "blobserver.env" . | indent 12 }}
+            {{- if .Values.global.orbit.enabled }}
+            - name: MANAGEMENT_MODE
+              value: "{{- .Values.global.orbit.workerMode -}}"
+            - name: PUSH_STATS
+              value: "false"
+            {{- end }}
+            {{- range $key, $value := .Values.blobserver.env }}
+            - name: {{ $key | upper | replace "." "_" }}
+              value: {{ $value | quote }}
+            {{- end }}
+          args: ['yarn', 'start']
+          livenessProbe:
+            tcpSocket:
+              port: http
+              initialDelaySeconds: 15
+              periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /_/healthcheck/deep
+              port: http
+          startupProbe:
+            tcpSocket:
+              port: http
+            failureThreshold: 30
+            periodSeconds: 20
+          volumeMounts:
+            {{- if .Values.proxy.caCert }}
+            - name: proxy-cert
+              mountPath: "/ssl"
+              readOnly: true
+            {{- end }}
+            {{- if .Values.kmip.enabled }}
+            - name:  kip-cert
+              mountPath: "/ssl-kmip"
+              readOnly: true
+            {{- end }}
+          resources:
+{{ toYaml .Values.blobserver.resources | indent 12 }}
+    {{- with .Values.blobserver.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+      affinity:
+{{ tpl .Values.blobserver.affinity . | indent 8 }}
+    {{- with .Values.blobserver.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+{{- if or .Values.proxy.caCert .Values.kmip.enabled -}}
+      volumes:
+        {{- if .Values.proxy.caCert }}
+        - name: proxy-cert
+          secret:
+            secretName: {{ template "opal.fullname" . }}-proxy-cert
+        {{- end }}
+        {{- if .Values.kmip.enabled }}
+        - name: kmip-cert
+          secret:
+            secretName: {{ template "opal.fullname" . }}-kmip-cert
+        {{- end }}
+{{- end }}

--- a/kubernetes/zenko/charts/opal/templates/blobserver/hpa.yaml
+++ b/kubernetes/zenko/charts/opal/templates/blobserver/hpa.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.blobserver.autoscaling.enabled -}}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "blobserver.fullname" . }}
+  labels:
+    app: {{ template "blobserver.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  scaleTargetRef:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: {{ template "blobserver.fullname" . }}
+{{ toYaml .Values.blobserver.autoscaling.config | indent 2 }}
+{{- end -}}

--- a/kubernetes/zenko/charts/opal/templates/blobserver/ingress.yaml
+++ b/kubernetes/zenko/charts/opal/templates/blobserver/ingress.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.blobserver.ingress.enabled -}}
+{{- $root := . -}}
+{{ $fullName := include "blobserver.fullname" . -}}
+{{- $servicePort := .Values.blobserver.service.port -}}
+{{- $ingressPath := .Values.blobserver.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ template "blobserver.name" . }}
+    chart: {{ template "opal.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.blobserver.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.blobserver.ingress.tls }}
+  tls:
+  {{- range .Values.blobserver.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range default ((list .Values.blobserver.endpoint) .Values.blobserver.ingress.hosts) }}
+  {{- if $root.Values.blobserver.enable_dns_storage_accounts }}
+    - host: '*.{{ . }}'
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+  {{- end }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+  {{- end }}
+{{- end }}

--- a/kubernetes/zenko/charts/opal/templates/blobserver/service.yaml
+++ b/kubernetes/zenko/charts/opal/templates/blobserver/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  {{- if .Values.blobserver.service.annotations }}
+  annotations:
+{{ toYaml .Values.blobserver.service.annotations | indent 4 }}
+  {{- end }}
+  name: {{ template "blobserver.fullname" . }}
+  labels:
+    app: {{ template "blobserver.name" . }}
+    chart: {{ template "opal.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.blobserver.service.type }}
+  ports:
+    - port: {{ .Values.blobserver.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "blobserver.name" . }}
+    release: {{ .Release.Name }}

--- a/kubernetes/zenko/charts/opal/templates/jabba/deployment.yaml
+++ b/kubernetes/zenko/charts/opal/templates/jabba/deployment.yaml
@@ -1,0 +1,103 @@
+{{- if .Values.jabba.enabled -}}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "jabba.fullname" . }}
+  labels:
+    app: {{ template "jabba.name" . }}
+    chart: {{ template "opal.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ template "jabba.replicaFactor" . }}
+  selector:
+    matchLabels:
+      app: {{ template "jabba.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      annotations:
+        {{- if .Values.proxy.https }}
+        checksum/config: {{ include (print $.Template.BasePath "/certificates.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if not .Values.global.orbit.enabled }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/accounts.yaml") . | sha256sum }}
+        {{- end }}
+      labels:
+        app: {{ template "jabba.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      # no offline mode
+      {{- if .Values.jabba.image.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.jabba.image.imagePullSecret }}
+      {{- end }}
+      containers:
+        - name: jabba
+          image: "{{ .Values.jabba.image.repository }}:{{ .Values.jabba.image.tag }}"
+          imagePullPolicy: {{ .Values.jabba.image.pullPolicy }}
+          terminationMessagePolicy: FallbackToLogsOnError
+          ports:
+            - name: http
+              containerPort: 443
+          env:
+  {{- include "jabba.env" . | indent 12 }}
+            {{- range $key, $value := .Values.jabba.env }}
+            - name: {{ $key | upper | replace "." "_" }}
+              value: {{ $value | quote }}
+            {{- end }}
+          args: ['yarn', 'start']
+          livenessProbe:
+            tcpSocket:
+              port: http
+              initialDelaySeconds: 15
+              periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /_/healthcheck
+              port: http
+              initialDelaySeconds: 15
+              periodSeconds: 20
+          startupProbe:
+            tcpSocket:
+              port: http
+            failureThreshold: 30
+            periodSeconds: 20
+          volumeMounts:
+            {{- if .Values.proxy.caCert }}
+            - name: proxy-cert
+              mountPath: "/ssl"
+              readOnly: true
+            {{- end }}
+            {{- if .Values.kmip.enabled }}
+            - name:  kmip-cert
+              mountPath: "/ssl-kmip"
+              readOnly: true
+            {{- end }}
+          resources:
+{{ toYaml .Values.jabba.resources | indent 12 }}
+    {{- with .Values.jabba.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+      affinity:
+{{ tpl .Values.jabba.affinity . | indent 8 }}
+    {{- with .Values.jabba.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+{{- if or .Values.proxy.caCert .Values.kmip.enabled -}}
+      volumes:
+        {{- if .Values.proxy.caCert }}
+        - name: proxy-cert
+          secret:
+            secretName: {{ template "opal.fullname" . }}-proxy-cert
+        {{- end }}
+        {{- if .Values.kmip.enabled }}
+        - name: kmip-cert
+          secret:
+            secretName: {{ template "opal.fullname" . }}-kmip-cert
+        {{- end }}
+{{- end }}
+{{- end }}

--- a/kubernetes/zenko/charts/opal/templates/jabba/hpa.yaml
+++ b/kubernetes/zenko/charts/opal/templates/jabba/hpa.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.jabba.autoscaling.enabled -}}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "jabba.fullname" . }}
+  labels:
+    app: {{ template "jabba.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  scaleTargetRef:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: {{ template "jabba.fullname" . }}
+{{ toYaml .Values.jabba.autoscaling.config | indent 2 }}
+{{- end -}}

--- a/kubernetes/zenko/charts/opal/templates/jabba/ingress.yaml
+++ b/kubernetes/zenko/charts/opal/templates/jabba/ingress.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.jabba.enabled -}}
+{{ if .Values.jabba.ingress.enabled -}}
+{{- $root := . -}}
+{{- $fullName := include "jabba.fullname" . -}}
+{{- $servicePort := .Values.jabba.service.port -}}
+{{- $ingressPath := .Values.jabba.ingress.path -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ template "jabba.name" . }}
+    chart: {{ template "opal.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.jabba.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.jabba.ingress.tls }}
+  tls:
+  {{- range .Values.jabba.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range default ((list .Values.jabba.endpoint) .Values.jabba.ingress.hosts) }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/kubernetes/zenko/charts/opal/templates/jabba/service.yaml
+++ b/kubernetes/zenko/charts/opal/templates/jabba/service.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.jabba.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  {{- if .Values.jabba.service.annotations }}
+  annotations:
+{{ toYaml .Values.jabba.service.annotations | indent 4 }}
+  {{- end }}
+  name: {{ template "jabba.fullname" . }}
+  labels:
+    app: {{ template "jabba.name" . }}
+    chart: {{ template "opal.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.jabba.service.type }}
+  ports:
+    - port: {{ .Values.jabba.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "jabba.name" . }}
+    release: {{ .Release.Name }}
+{{- end }}

--- a/kubernetes/zenko/charts/opal/values.yaml
+++ b/kubernetes/zenko/charts/opal/values.yaml
@@ -1,0 +1,161 @@
+global:
+  orbit:
+    enabled: true
+    endpoint: https://api.zenko.io
+    pushEndpoint: https://push.api.zenko.io
+    workerMode: poll
+
+  locationConstraints: {}
+
+users: {}
+logging:
+  level: info
+
+mongodb:
+  replicaSet: rs0
+  replicas: 3
+
+kmip:
+  enabled: false
+  port: 5696
+  hosts: []
+  compoundCreate: false
+  bucketAttributeName: ''
+  pipelineDepth: 8
+
+proxy:
+  http: ''
+  https: ''
+  caCert: false
+  no_proxy: ''
+
+redis:
+  sentinel:
+    name: zenko
+  replicas: 3
+
+allowHealthchecksFrom: '0.0.0.0/0'
+
+blobserver:
+  enabled: False
+  endpoint: blob.zenko.local
+  enable_dns_storage_accounts: True
+  replicaCount: 3
+  replicaFactor: 1
+
+  asyncDeletes:
+    successfulJobsHistory: 1
+    failedJobsHistory: 3
+    jobs:
+      - name: container
+        command: ['yarn', 'cron:delete_container']
+        maxRetry: 1
+        maxConcurrentProcs: 10
+        maxConcurrentDeletes: 100
+        schedule: '*/5 * * * *'
+      - name: bucket
+        command: ['yarn', 'cron:delete_bucket']
+        maxRetry: 1
+        maxConcurrentProcs: 10
+        maxConcurrentDeletes: 100
+        schedule: '*/5 * * * *'
+      - name: overview
+        command: ['yarn', 'cron:delete_overview']
+        maxRetry: 1
+        maxConcurrentProcs: 10
+        maxConcurrentDeletes: 100
+        schedule: '*/5 * * * *'
+      - name: gc
+        command: ['yarn', 'cron:gc']
+        maxRetry: 1
+        maxConcurrentProcs: 10
+        maxConcurrentDeletes: 100
+        schedule: '*/5 * * * *'
+
+  image:
+    repository: registry.scality.com/sf-eng/blobserver
+    tag: '1.0.0'
+    pullPolicy: IfNotPresent
+    imagePullSecret: ''
+
+  ingress:
+    enabled: false
+    annotations: {}
+    path: /
+    hosts: []
+    tls: []
+
+  service:
+    type: ClusterIP
+    port: 80
+
+  env: {}
+  resources: {}
+  nodeSelector: {}
+
+  affinity: |
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 5
+        podAffinityTerm:
+          topologyKey: 'kubernetes.io/hostname'
+          labelSelector:
+            matchLabels:
+              app: {{ include "blobserver.name" . }}
+              release: {{ .Release.Name | quote }}
+
+  autoscaling:
+    enabled: false
+    config:
+      minReplicas: 1
+      maxReplicas: 16
+      # Note: when setting this, a `resources.request.cpu` is required. You
+      # likely want to set it to `1` or some lower value.
+      targetCPUUtilizationPercentage: 80
+
+jabba:
+  enabled: False
+  endpoint: manage.zenko.local
+  replicaCount: 3
+  replicaFactor: 1
+
+  image:
+    repository: registry.scality.com/sf-eng/jabba
+    tag: '1.0.0'
+    pullPolicy: IfNotPresent
+    imagePullSecret: ''
+
+  ingress:
+    enabled: false
+    annotations: {}
+    path: /
+    hosts: []
+    tls: []
+
+  service:
+    type: ClusterIP
+    port: 80
+
+  env: {}
+  resources: {}
+  nodeSelector: {}
+
+  affinity: |
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 5
+        podAffinityTerm:
+          topologyKey: 'kubernetes.io/hostname'
+          labelSelector:
+            matchLabels:
+              app: {{ include 'jabba.name' . }}
+              release: {{ .Release.Name | quote }}
+
+  autoscaling:
+    enabled: false
+    config:
+      minReplicas: 1
+      maxReplicas: 16
+      # Note: when setting this, a `resources.request.cpu` is required. You
+      # likely want to set it to `1` or some lower value.
+      targetCPUUtilizationPercentage: 80

--- a/kubernetes/zenko/requirements.lock
+++ b/kubernetes/zenko/requirements.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: cert-manager-crds
+  repository: file://../cert-manager-crds
+  version: v0.11.0
+- name: cert-manager
+  repository: https://charts.jetstack.io
+  version: v0.11.0
+digest: sha256:58c2ce2f27109aded6f4557625c981ddf071a752de15155109e1447c4ecf6cfe
+generated: "2019-10-29T10:50:35.619373773-07:00"

--- a/kubernetes/zenko/requirements.yaml
+++ b/kubernetes/zenko/requirements.yaml
@@ -1,0 +1,9 @@
+dependencies:
+  - name: cert-manager-crds
+    version: v0.11.0
+    condition: ingress.auto_certificates
+    repository: 'file://../cert-manager-crds'
+  - name: cert-manager
+    version: v0.11.0
+    condition: ingress.auto_certificates
+    repository: https://charts.jetstack.io

--- a/kubernetes/zenko/templates/NOTES.txt
+++ b/kubernetes/zenko/templates/NOTES.txt
@@ -1,10 +1,26 @@
 {{- if .Values.ingress.enabled }}
-Access the Zenko endpoint from this URL:
+
+{{- if .Values.ingress.hosts }}
+The ingress.hosts option as been DEPRECATED.
+It is currently honored, but may be removed in future versions.
+{{- end }}
+
+Access the Zenko S3 endpoint from this URL:
+{{- if .Values.ingress.hosts }}
+The ingress.hosts option has been DEPRECATED.
+It is currently honored, but may be removed in future versions.
 {{- range .Values.ingress.hosts }}
-  {{- if not . }}
-  connect using your kubernetes host IP
-  {{- else }}
   http://{{ . }}
-  {{- end }}
+{{- end }}
+{{- end }}
+{{ printf "http://%s.%s" .Values.ingress.s3_subdomain .Values.ingress.root_domain }}
+{{- range .Values.ingress.s3_extra_hosts }}
+  http://{{ . }}
+{{- end }}
+
+Access the Zenko Blob endpoint from this URL:
+{{ printf "http://%s.%s" .Values.ingress.blob_subdomain .Values.ingress.root_domain }}
+{{- range .Values.ingress.blob_extra_hosts }}
+  http://{{ . }}
 {{- end }}
 {{- end }}

--- a/kubernetes/zenko/templates/_helpers.tpl
+++ b/kubernetes/zenko/templates/_helpers.tpl
@@ -81,3 +81,16 @@ Create the default mongodb replicaset hosts string
 {{- $release := .Release.Name -}}
 {{- range $v := until $count }}{{ $release }}-mongodb-replicaset-{{ $v }}.{{ $release }}-mongodb-replicaset:27017{{ if ne $v (sub $count 1) }},{{- end -}}{{- end -}}
 {{- end -}}
+
+{{/*
+Create a host entry suitable for ingress
+*/}}
+{{- define "zenko.ingress.host_entry" }}
+- host: {{ .domain }}
+  http:
+    paths:
+      - path: /
+        backend:
+          serviceName: {{ .service }}
+          servicePort: http
+{{- end }}

--- a/kubernetes/zenko/templates/ingress.yaml
+++ b/kubernetes/zenko/templates/ingress.yaml
@@ -1,5 +1,13 @@
 {{- if .Values.ingress.enabled -}}
-{{- $serviceName := printf "%s-%s" .Release.Name "cloudserver" | trunc 63 | trimSuffix "-" -}}
+{{- $cloudserverServiceName := printf "%s-%s" .Release.Name "cloudserver" | trunc 63 | trimSuffix "-" -}}
+{{- $cloudserverDomain := printf "%s.%s" .Values.ingress.s3_subdomain .Values.ingress.root_domain -}}
+{{- $cloudserverWildcardDomain := printf "*.%s.%s" .Values.ingress.s3_subdomain .Values.ingress.root_domain | quote -}}
+{{- $blobserverServiceName := printf "%s-%s-%s" .Release.Name "opal" "blobserver" | trunc 63 | trimSuffix "-" -}}
+{{- $blobserverDomain := printf "%s.%s" .Values.ingress.blob_subdomain .Values.ingress.root_domain -}}
+{{- $blobserverWildcardDomain := printf "*.%s.%s" .Values.ingress.blob_subdomain .Values.ingress.root_domain | quote -}}
+{{- $jabbaDomain := printf "%s.%s" .Values.ingress.blob_mgmt_subdomain .Values.ingress.root_domain -}}
+{{- $jabbaServiceName := printf "%s-%s-%s" .Release.Name "opal" "jabba" | trunc 63 | trimSuffix "-" -}}
+{{- $addIssuerAnnotation := and .Values.ingress.auto_certificates (or .Values.ingress.issuer .Values.ingress.cluster_issuer) -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -9,10 +17,18 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- if or .Values.ingress.max_body_size .Values.ingress.annotations }}
+{{- if or .Values.ingress.max_body_size .Values.ingress.annotations $addIssuerAnnotation }}
   annotations:
 {{- if .Values.ingress.max_body_size }}
     nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.ingress.max_body_size | quote }}
+{{- end }}
+{{- if and .Values.ingress.auto_certificates .Values.ingress.issuer }}
+    kubernetes.io/tls-acme: "true"
+    cert-manager.io/issuer: {{ .Values.ingress.issuer }}
+{{- end }}
+{{- if and .Values.ingress.auto_certificates .Values.ingress.cluster_issuer }}
+    kubernetes.io/tls-acme: "true"
+    cert-manager.io/cluster-issuer: {{ .Values.ingress.cluster_issuer }}
 {{- end }}
 {{- if .Values.ingress.annotations }}
     {{- range $key, $value := .Values.ingress.annotations }}
@@ -22,17 +38,46 @@ metadata:
 {{- end }}
 spec:
   rules:
-    {{- range $host := .Values.ingress.hosts }}
-    - host: {{ $host }}
-      http:
-        paths:
-          - path: /
-            backend:
-              serviceName: {{ $serviceName }}
-              servicePort: http
-    {{- end -}}
-  {{- if .Values.ingress.tls }}
+    {{- include "zenko.ingress.host_entry" (dict "domain" $cloudserverDomain "service" $cloudserverServiceName) | indent 4 }}
+    {{- include "zenko.ingress.host_entry" (dict "domain" $blobserverDomain "service" $blobserverServiceName) | indent 4 }}
+    {{- include "zenko.ingress.host_entry" (dict "domain" $jabbaDomain "service" $jabbaServiceName) | indent 4 }}
+{{/* For backwards compatibiltiy will Zenko <= 1.1 */}}
+{{- if .Values.ingress.hosts }}
+  {{- range $host := .Values.ingress.hosts }}
+    {{- include "zenko.ingress.host_entry" (dict "domain" $host "service" $cloudserverServiceName) | indent 4 }}
+  {{- end }}
+{{- end }}
+{{- if .Values.ingress.enable_dns_style_buckets }}
+    {{- include "zenko.ingress.host_entry" (dict "domain" $cloudserverWildcardDomain "service" $cloudserverServiceName) | indent 4 }}
+    {{- include "zenko.ingress.host_entry" (dict "domain" $blobserverWildcardDomain "service" $blobserverServiceName) | indent 4 }}
+{{- end }}
+{{- range $host := .Values.ingress.s3_extra_hosts }}
+    {{- include "zenko.ingress.host_entry" (dict "domain" $host "service" $cloudserverServiceName) | indent 4 }}
+{{- end }}
+{{- range $host := .Values.ingress.blob_extra_hosts }}
+    {{- include "zenko.ingress.host_entry" (dict "domain" $host "service" $blobserverServiceName) | indent 4 }}
+{{- end }}
+{{- if or .Values.ingress.tls .Values.ingress.auto_certificates }}
   tls:
-{{ toYaml .Values.ingress.tls | indent 4 }}
-  {{- end -}}
+{{- if .Values.ingress.tls }}
+    {{ toYaml .Values.ingress.tls | indent 4 }}
+{{- end -}}
+{{- if .Values.ingress.auto_certificates }}
+    - hosts:
+        - {{ $cloudserverDomain }}
+        - {{ $blobserverDomain }}
+        - {{ $jabbaDomain }}
+        {{- if .Values.ingress.enable_dns_style_buckets }}
+        - {{ $cloudserverWildcardDomain }}
+        - {{ $blobserverWildcardDomain }}
+        {{- end }}
+        {{- range .Values.ingress.s3_extra_hosts }}
+        - {{ . | quote }}
+        {{- end }}
+        {{- range .Values.ingress.blob_extra_hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ template "zenko.fullname" . }}-ingress-certificates
+{{- end -}}
+{{- end -}}
 {{- end -}}

--- a/kubernetes/zenko/values.yaml
+++ b/kubernetes/zenko/values.yaml
@@ -7,22 +7,54 @@
 # is equivalent to the number of nodes in a Kubernetes Cluster.
 nodeCount: &nodeCount 3
 
+
+
 ingress:
   enabled: false
+  
+  # ingress.hosts has been deprecated in favor of ingress.root_domain and 
+  # ingress.*_sudomain values and may be removed in future versions.
+  hosts:
+    - zenko.local
+  
   # Used to create an Ingress record.
   # This must match the 'cloudserver' 'endpoint', unless your client
   # supports different hostnames.
-  hosts:
-    - zenko.local
+  # The root domain for endpoints
+  root_domain: zenko.local
+
+  # Subdomain to serve cloudserver traffic
+  # Will be added as a prefix to root_domain
+  # eg s3.example.com
+  s3_subdomain: s3
+  s3_extra_hosts: []
+
+  # Subdomain to serve blobserver traffic
+  # Will be added as a prefix to root_domain
+  # eg blob.example.com
+  blob_subdomain: blob
+  blob_mgmt_subdomain: jabba
+  blob_extra_hosts: []
+
   max_body_size: 100m
   annotations:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  # Enable deployment of cert-manager for automatic certificate issuance
+  auto_certificates: False
+  # Set the issuer for the created ingress
+  # Has no effect if `auto_certificates` is false
+  issuer: ''
+  cluster_issuer: ''
   tls:
     # Secrets must be manually created in the namespace.
     # - secretName: zenko-tls
     #   hosts:
     #     - zenko.example.com
+
+  # Adds a wildcard subdomain to the ingress for s3 and blob
+  # Example: *.s3.zenko.local
+  enable_dns_style_buckets: False
 
 global:
   orbit:
@@ -84,6 +116,8 @@ cloudserver:
     # accountName:
       # access:
       # secret:
+      #
+      #
 
 backbeat:
   api:
@@ -235,6 +269,7 @@ mongodb-replicaset:
   persistentVolume:
     size: 50Gi
 
+
 zenko-queue:
 ## Extensive list of configurables can be found here:
 ## https://github.com/kubernetes/charts/blob/master/incubator/kafka/values.yaml
@@ -326,3 +361,9 @@ zenko-queue-manager:
   clusters:
     - name: "zenko-queue-cluster"
       tuning: {}
+
+opal:
+  blobserver:
+    replicaCount: *nodeCount
+  jabba:
+    replicaCount: *nodeCount

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -169,7 +169,14 @@ install-ceph:
 		--install ../eve/workers/ceph/chart
 .PHONY: install-ceph
 
-install-zenko: | install-tiller
+update-chart-dependencies:
+ifndef NO_INSTALL
+	$(HELM) repo add jetstack https://charts.jetstack.io
+	$(HELM) dependency update ../kubernetes/zenko
+endif
+.PHONY: update-chart-dependencies
+
+install-zenko: | install-tiller update-chart-dependencies
 ifndef NO_INSTALL
 	$(HELM) upgrade $(ZENKO_HELM_RELEASE) \
 		--namespace $(HELM_NAMESPACE) \
@@ -180,7 +187,7 @@ ifndef NO_INSTALL
 endif
 .PHONY: install-zenko
 
-install-latest-zenko: | build-latest
+install-latest-zenko: | build-latest update-chart-dependencies
 ifndef NO_INSTALL
 	$(HELM) upgrade $(ZENKO_HELM_RELEASE) \
 		--namespace $(HELM_NAMESPACE) \

--- a/tests/zenko_tests/create_buckets.py
+++ b/tests/zenko_tests/create_buckets.py
@@ -13,7 +13,7 @@ IGNORED_PODS = [
     'failed',
     'pending',
     'kafkaclient',
-    'utils'
+    'utils',
 ]
 
 IGNORED_PODS = [re.compile(x) for x in IGNORED_PODS]


### PR DESCRIPTION
<!--
Thank you for contributing to Zenko!

Please enter applicable information below.
-->

**What does this PR do, and why do we need it?**

**Which issue does this PR fix?**
Adds opal deployment
fixes #ZENKO-1987

**Special notes for your reviewers**:

Pay special attention to `kubernetes/zenko/templates/ingress.yaml` and the addition of the cert-manager charts as well as `kubernetes/zenko/values.yaml` changes
