### PR TITLE
doc: give a default value for latex_title

### DIFF
--- a/docs/docsource/conf.py
+++ b/docs/docsource/conf.py
@@ -176,6 +176,7 @@ latex_contents = r"""
 latex_logo = scaldoc.resources.get_footer_logo()
 latex_cover = scaldoc.resources.get_cover('Zenko')
 
+latex_title = ''
 if tags.has('install'):
      latex_title = 'Installation'
 elif tags.has('operation'):


### PR DESCRIPTION
`latex_title` is only initialized when either `install`, `operation` or `reference` tag is given on the command line.
When building for RTD, none of those are given, and thus `latex_title` is not defined and we have an error.

To workaround this issue, we declare `latex_title` with a default value (this is harmless since RTD doesn't build the PDF documentation, only the HTML one).