### PR TITLE
docs: set latex_title for RTD build

### DIFF
--- a/docs/docsource/conf.py
+++ b/docs/docsource/conf.py
@@ -176,6 +176,7 @@ latex_contents = r"""
 latex_logo = scaldoc.resources.get_footer_logo()
 latex_cover = scaldoc.resources.get_cover('Zenko')
 
+latex_title = ''
 if tags.has('install'):
      latex_title = 'Installation'
 elif tags.has('operation'):


### PR DESCRIPTION
This fixes ZENKIO-134

Why: RTD (readthedocs) fails to build Zenko documentation with the error:
` title=latex_title,
NameError: name 'latex_title' is not defined`

This PR sets a default value for `latex_title` in `docsource/conf.py` 
