### PR TITLE
feature: add pause/resume route

### DIFF
--- a/cosmos/api/types/v1alpha1/cosmos.go
+++ b/cosmos/api/types/v1alpha1/cosmos.go
@@ -31,7 +31,7 @@ type CosmosPfsdSpec struct {
 type CosmosRcloneSpec struct {
 	Schedule      string                       `json:"schedule"`
 	Suspend       bool                         `json:"suspend"`
-	TriggerIngest bool                         `json:"triggerIngestion"`
+	Trigger       bool                         `json:"triggerIngestion"`
 	Source        *CosmosRcloneSourceSpec      `json:"source"`
 	Destination   *CosmosRcloneDestinationSpec `json:"destination"`
 	Options       *CosmosRcloneOptionsSpec     `json:"options"`

--- a/cosmos/scheduler/Makefile
+++ b/cosmos/scheduler/Makefile
@@ -1,5 +1,5 @@
 COSMOS_IMAGE := zenko/cosmos-scheduler
-COSMOS_TAG := 0.5.2
+COSMOS_TAG := 0.5.3
 COSMOS_BINARY := ./scheduler
 
 .PHONY: setup

--- a/cosmos/scheduler/README.md
+++ b/cosmos/scheduler/README.md
@@ -39,6 +39,41 @@ The following environment variables can be set to customize the Scheduler's beha
 
 ## Development
 
+In a typical development environment running the schdeuler locally and
+controlling a remote Zenko is most likely. This setup is the easiest to iterate,
+develop, and debug with.
+
+```sh
+export RELEASE=<zenko release name>
+# Export your kube config otherwise the scheduler will try to run in-cluster mode
+export KUBECONFIG="/${HOME}/.kube/config"
+export CLOUDSERVER_ENDPOINT=${RELEASE}-cloudserver
+# Remove any scheduler pods in the cluster allowing the local process to take over
+kubectl scale --replicas=0 deploy ${RELEASE}-cosmos-scheduler
+# Port forward one of your mongodb pods
+kubectl port-forward ${RELEASE_NAME}-mongodb-replicaset-0
+# Compile and run
+go build && ./scheduler
+```
+
+### API cURL examples
+
+GET /healthcheck
+```sh
+curl localhost:8080/healthcheck
+```
+
+GET /suspend/<location-name>
+```sh
+curl localhost:8080/suspend/<location-name>
+{"suspend":true,"triggerIngestion":true}
+```
+POST /suspend/<location-name>
+```sh
+curl -d '{"suspend":true,"triggerIngestion":false}' -X POST -H "Content-Type: application/json" localhost:8080/suspend/<location-name>
+```
+
+Makefile help:
 ```sh
 make help
 ```

--- a/cosmos/scheduler/main.go
+++ b/cosmos/scheduler/main.go
@@ -37,7 +37,7 @@ func init() {
 	viper.BindEnv("mongodb_hosts")
 
 	viper.SetDefault("mongodb_database", "metadata")
-	viper.BindEnv("MONGODB_DATABASE")
+	viper.BindEnv("mongodb_database")
 
 	viper.SetDefault("cloudserver_endpoint", "http://localhost:8000")
 	viper.BindEnv("cloudserver_endpoint")
@@ -52,6 +52,8 @@ func init() {
 	viper.BindEnv("ingestion_secret_name")
 }
 
+// The main function esablishes the mongodb connection, validates kube api access,
+// and instanciates the scheduler run loop.
 func main() {
 	mongoOptions := options.Client()
 	mongoOptions.SetAppName("cosmos-scheduler")

--- a/kubernetes/zenko/templates/cosmos-scheduler/deployment.yaml
+++ b/kubernetes/zenko/templates/cosmos-scheduler/deployment.yaml
@@ -29,6 +29,9 @@ spec:
       - name: {{ template "cosmos-scheduler.fullname" . }}
         image: "{{ .Values.cosmos.scheduler.image.repository }}:{{ .Values.cosmos.scheduler.image.tag }}"
         imagePullPolicy: {{ .Values.cosmos.scheduler.image.pullPolicy }}
+        ports:
+        - name: cosmos
+          containerPort: 8080
         env:
         - name: NAMESPACE
           {{- if .Values.cosmos.scheduler.namespace }}

--- a/kubernetes/zenko/templates/cosmos-scheduler/service.yaml
+++ b/kubernetes/zenko/templates/cosmos-scheduler/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "cosmos-scheduler.fullname" . }}
+  labels:
+    app: {{ template "cosmos-scheduler.name" . }}
+    chart: {{ template "zenko.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: cosmos
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "cosmos-scheduler.name" . }}
+    release: {{ .Release.Name }}

--- a/kubernetes/zenko/values.yaml
+++ b/kubernetes/zenko/values.yaml
@@ -144,7 +144,7 @@ cosmos:
   scheduler:
     image:
       repository: zenko/cosmos-scheduler
-      tag: 0.5.2
+      tag: 0.5.3
       pullPolicy: IfNotPresent
 
     ## A namespace to watch can be specified otherwise will default to the


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
Adds a route that will return the current status of the location cron on GET. The state can be modified on POST. Included is a README update with the routes and example usage with curl.

**Which issue does this PR fix?**

fixes #<ISSUE>

**Special notes for your reviewers**:
