### PR TITLE
docs: add-forum-comments-RTD

### DIFF
--- a/docs/docsource/_templates/page.html
+++ b/docs/docsource/_templates/page.html
@@ -1,0 +1,23 @@
+{% extends "!page.html" %}
+
+{% block body %}
+	{{ super() }}
+
+	<div id='discourse-comments'></div>
+
+	<script type="text/javascript">
+	  DiscourseEmbed = { discourseUrl: 'https://forum.zenko.io/',
+	                     topicId: 684 };
+	  (function() {
+	    var d = document.createElement('script'); d.type = 'text/javascript'; d.async = true;
+	    d.src = DiscourseEmbed.discourseUrl + 'javascripts/embed.js';
+	    (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(d);
+	  })();
+	</script>
+
+
+
+{% endblock %}
+
+<!-- Old configuration 
+discourseEmbedUrl: 'https://zenko.readthedocs.io/en/latest/{{ pagename }}.html -->

--- a/docs/docsource/conf.py
+++ b/docs/docsource/conf.py
@@ -176,6 +176,7 @@ latex_contents = r"""
 latex_logo = scaldoc.resources.get_footer_logo()
 latex_cover = scaldoc.resources.get_cover('Zenko')
 
+latex_title = ''
 if tags.has('install'):
      latex_title = 'Installation'
 elif tags.has('operation'):
@@ -199,7 +200,7 @@ latex_elements = {
     'preamble': scaldoc.resources.get_latex_preamble(
         cover=os.path.basename(latex_cover),
         logo=os.path.basename(latex_logo),
-        title='latex_title',
+        title=latex_title,
         title_voffset='85pt',
         version=release,
         copyright=copyright

--- a/docs/tox.ini
+++ b/docs/tox.ini
@@ -18,7 +18,7 @@ description = Render documentation
 skip_install = true
 deps =
 #     {[testenv]deps}
-    -r{toxinidir}/docsource/requirements.txt
+    -r{toxinidir}/requirements.txt
 commands =
     make -C docsource {posargs:html}
 setenv = 
@@ -31,7 +31,7 @@ whitelist_externals =
 description = Render Operations
 skip_install = true
 deps =
-    -r{toxinidir}/docsource/requirements.txt
+    -r{toxinidir}/requirements.txt
 commands =
     make -C ./docsource/operation {posargs:latexpdf} SPHINXOPTS="-j 4 -n -W"
 whitelist_externals =
@@ -41,7 +41,7 @@ whitelist_externals =
 description = Render Installation
 skip_install = true
 deps =
-    -r{toxinidir}/docsource/requirements.txt
+    -r{toxinidir}/requirements.txt
 commands =
     make -C ./docsource/installation {posargs:latexpdf} SPHINXOPTS="-j 4 -n -W"
 whitelist_externals =
@@ -51,7 +51,7 @@ whitelist_externals =
 description = Render Reference
 skip_install = true
 deps =
-    -r{toxinidir}/docsource/requirements.txt
+    -r{toxinidir}/requirements.txt
 commands =
     make -C ./docsource/reference {posargs:latexpdf} SPHINXOPTS="-j 4 -n -W"
 whitelist_externals =


### PR DESCRIPTION
This PR adds a comment box to all the pages of public documentation hosted on readthedocs.
Comment box embedded from Zenko forum and all discussions will be happening in a single topic created for this reason: https://forum.zenko.io/t/comments-to-zenko-official-documentation/684

fixes ZENKOIO-111

**Special notes for your reviewers**:
Additionally, I am pushing fix for RTD builds by specifying the correct path to `requirements.txt`
https://readthedocs.org/projects/zenko/builds/10060345/