### PR TITLE
docs: embed forum comments rtd

### DIFF
--- a/docs/docsource/_templates/page.html
+++ b/docs/docsource/_templates/page.html
@@ -1,0 +1,20 @@
+{% extends "!page.html" %}
+
+{% block body %}
+	{{ super() }}
+
+	<div id='discourse-comments'></div>
+
+	<script type="text/javascript">
+	  DiscourseEmbed = { discourseUrl: 'https://forum.zenko.io/',
+	                     topicId: 684 };
+	  (function() {
+	    var d = document.createElement('script'); d.type = 'text/javascript'; d.async = true;
+	    d.src = DiscourseEmbed.discourseUrl + 'javascripts/embed.js';
+	    (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(d);
+	  })();
+	</script>
+
+
+
+{% endblock %}


### PR DESCRIPTION
fixes ZENKOIO-139
Added a template `page.html` that embeds a comment box (from a dedicated topic on Zenko forum) on all pages of public Zenko documentation site (RTD)