### PR TITLE
documentation: ZENKO-2228_cosmos_deletion

### DIFF
--- a/docs/docsource/installation/uninstall/index.rst
+++ b/docs/docsource/installation/uninstall/index.rst
@@ -1,11 +1,19 @@
 Uninstall
 =========
 
-To uninstall/delete the “my-zenko” deployment:
+To uninstall/delete the “my-zenko” deployment, run:
 
-.. code:: bash
+::
 
-   $ helm delete my-zenko
+  $ kubectl delete cosmos --all --purge
 
-The command removes all Kubernetes components associated with the
-chart and deletes the deployed instance.
+This deletes all Cosmos objects from Kubernetes. 
+   
+Then, run:
+
+::
+  
+  $ helm delete my-zenko --purge
+
+The Helm command removes all Kubernetes components associated with the chart and
+deletes the deployed Zenko instance.


### PR DESCRIPTION
This PR adds Cosmos deletion information to the Zenko documentation, fixing ZENKO-2228.
