### PR TITLE
documentation: ZENKOIO-122_backups_feature

### DIFF
--- a/docs/docsource/operation/Orbit_UI/Setting_Up_Orbit/Setting_Up_a_Full_Orbit_Installation.rst
+++ b/docs/docsource/operation/Orbit_UI/Setting_Up_Orbit/Setting_Up_a_Full_Orbit_Installation.rst
@@ -48,7 +48,7 @@ Orbit.
 .. |image0| image:: ../../Resources/Images/Orbit_Screencaps/google_login.png
    :scale: 75%
 .. |image1| image:: ../../Resources/Images/Orbit_Screencaps/Orbit_setup_Privacy.png
-   :scale: 75%
+   :width: 75%
 .. |image2| image:: ../../Resources/Images/Orbit_Screencaps/Orbit_register_my_Instance_detail.png
 .. |image3| image:: ../../Resources/Images/Orbit_Screencaps/Orbit_setup_Instance_ID.png
-   :scale: 75%
+   :width: 75%

--- a/docs/docsource/operation/Services/backups/burry.rst
+++ b/docs/docsource/operation/Services/backups/burry.rst
@@ -1,0 +1,36 @@
+.. _Burry:
+
+Burry
+=====
+
+Burry is a **B**\ack\ **u**\ p and **r**\ecove\ **ry** tool for cloud-native
+infrastructure services. Zenko uses Burry to back up and restore critical
+base infrastructure services such as ZooKeeper and the Kafka configurations and
+topics it contains.
+
+Install
+-------
+
+Burry is installed with Zenko as a cronjob in suspended mode. To enable it, edit
+the options.yaml file; then update Zenko with Helm. It is toggled off by default
+with the ``suspend:`` parameter set to ``true``. Setting this parameter to ``false``
+activates the feature when pushed to a Zenko server.
+
+.. code:: sh
+
+   burry:
+     cronjob:
+       suspend: false
+       schedule: "5 * * * *"
+     configMap:
+       destType: "s3"
+       destEndpoint: "{{zenko-server-name}}"
+       accessKey: "accessKey"
+       secretKey: "secretKey"
+       bucket: "bucketName"
+       ssl: "false
+
+When you've completed your reconfiguration, push the new configuration to your
+Zenko server with a Helm command::
+
+  $ helm upgrade {{zenko-server-name}} ./zenko -f options.yaml

--- a/docs/docsource/operation/Services/backups/index.rst
+++ b/docs/docsource/operation/Services/backups/index.rst
@@ -1,0 +1,15 @@
+.. _Backup Services:
+
+Backup Services
+===============
+
+Zenko uses two scripted backup services, Burry and MGOB. Burry backs up
+Kubernetes data. MGOB backs up the namespace and other metadata that MongoDB
+generates and uses to track object stores. Both perform scheduled backups using
+a crontab-like configfuration.
+
+.. toctree::
+   :maxdepth: 1
+
+   Burry<burry>
+   MGOB<mgob>

--- a/docs/docsource/operation/Services/backups/mgob.rst
+++ b/docs/docsource/operation/Services/backups/mgob.rst
@@ -1,0 +1,123 @@
+MGOB
+====
+
+MGOB is a MongoDB backup automation tool, deployed with Zenko 1.2 and later.
+
+MGOB runs as a Kubernetes pod with crontab scheduling to enable backups of
+Zenko's MongoDB assets, including object store metadata.
+
+MGOB enables your Zenko instance to:
+
+-  Schedule backups
+-  Retain (buffer) backups locally
+-  Upload backups to S3 object stores (such as AWS, RING/S3 Connector, Wasabi,
+   DigitalOcean Spaces, etc.)
+-  Upload backups to Google Cloud Platform and Azure Blob storage
+-  Upload to SFTP (under testing)
+-  Receive notifications using protocols such as email and Slack
+
+Installation
+------------
+
+MGOB is installed with Zenko 1.2 and later. It imposes no installation overhead.
+
+Configuration
+-------------
+
+MGOB runs as a Kubernetes pod operating under rules defined in a Helm chart. To
+configure MGOB, edit its configuration in values.yaml, and pass it to Zenko
+using a Helm command.
+
+Backup Plan
+~~~~~~~~~~~
+
+Define your backup plan under configMap in either the mgob values.yaml file or
+the vaules.yaml file for Zenko.
+
+For example:
+
+.. code:: yaml
+
+   scheduler:
+     # run every day at 6:00 and 18:00 UTC
+     cron: "0 6,18 */1 * *"
+     # number of backups to keep locally
+     retention: 14
+     # backup operation timeout in minutes
+     timeout: 60
+   target:
+     # mongod IP or host name
+     host: "<mongoDB replica set>"
+     # mongodb port
+     port: 27017
+     # mongodb database name, leave blank to backup all databases
+     database: "test"
+     # leave blank or comment out if auth is not enabled
+     username: "admin"
+     password: "secret"
+     # add custom params to mongodump (eg. Auth or SSL support), leave blank if not needed
+     params: "--ssl --authenticationDatabase admin"
+   # S3 upload (optional)
+   s3:
+     url: "https://s3.amazonaws.com"
+     bucket: "backup"
+     accessKey: "Q3AM3UQ867SPQQA43P2F"
+     secretKey: "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG"
+     # For Minio and AWS use S3v4 for GCP use S3v2
+     api: "S3v4"
+   # GCloud upload (optional)
+   gcloud:
+     bucket: "backup"
+     keyFilePath: /path/to/service-account.json
+   # Azure blob storage upload (optional)
+   azure:
+     containerName: "backup"
+     connectionString: "DefaultEndpointsProtocol=https;AccountName=...;AccountKey=...;EndpointSuffix=core.windows.net"
+   # SFTP upload (optional - under testing)
+   sftp:
+     host: sftp.company.com
+     port: 2022
+     username: user
+     password: secret
+     # dir must exist on the SFTP server
+     dir: backup
+   # Email notifications (optional - under testing)
+   smtp:
+     server: smtp.company.com
+     port: 465
+     username: user
+     password: secret
+     from: mgob@company.com
+     to:
+       - devops@company.com
+       - alerts@company.com
+   # Slack notifications (optional  - under testing)
+   slack:
+     url: https://hooks.slack.com/services/xxxx/xxx/xx
+     channel: devops-alerts
+     username: mgob
+     # 'true' to notify only on failures
+     warnOnly: false
+
+ReplicaSet Example
+~~~~~~~~~~~~~~~~~~
+
+.. code:: yaml
+
+   target:
+     host: "zenko-mongodb-replicaset-0.zenko-mongodb-replicaset,zenko-mongodb-replicaset-1.zenko-mongodb-replicaset,zenko-mongodb-replicaset-2.zenko-mongodb-replicaset"
+     port: 27017
+     database: "test"
+
+Sharded cluster with authentication and SSL example:
+
+.. code:: yaml
+
+   target:
+     host: "zenko-mongodb-replicaset-0.zenko-mongodb-replicaset,zenko-mongodb-replicaset-1.zenko-mongodb-replicaset,zenko-mongodb-replicaset-2.zenko-mongodb-replicaset"
+     port: 27017
+     database: "test"
+     username: "admin"
+     password: "secret"
+     params: "--ssl --authenticationDatabase admin"
+

--- a/docs/docsource/operation/Services/index.rst
+++ b/docs/docsource/operation/Services/index.rst
@@ -10,6 +10,7 @@ Zenko offers the following services as Backbeat extensions:
    Lifecycle Management Service<lifecycle_management/Lifecycle_Management_Service>
    Metadata Search<../Metadata_Search/Metadata_Search>
    Out-of-Band Updates<out-of-band_updates>
+   Backups<backups/index>
 
 More services are under development.
 

--- a/docs/docsource/reference/index.rst
+++ b/docs/docsource/reference/index.rst
@@ -12,5 +12,5 @@ Zenko Reference
    object_operations/index
    backbeat/index
    prometheus/index
-   
+
 


### PR DESCRIPTION
This PR documents the burry and MGOB backup tools in the Zenko context.

fixes #ZENKOIO-122

I am operating under the assumption that users only access these tools using the tools described here. I have some (bad) MGOB api stuff backed up, but don't think it's needed/useful here.  