### PR TITLE
documentation: ZENKO-2251_remove_Connector_references

### DIFF
--- a/docs/docsource/reference/bucket_operations/bucket_ingestion_metrics/get_all_metrics.rst
+++ b/docs/docsource/reference/bucket_operations/bucket_ingestion_metrics/get_all_metrics.rst
@@ -1,12 +1,11 @@
 GET All Metrics	
 ===============	
 
-This request retrieves all metrics for all S3 Connector metadata	
-ingestion locations. Zenko returns three categories of information	
-(metrics) about system operations: completions, throughput, and 	
-pending operations. Completions are returned for the preceding 24	
-hours, throughput for the preceding 15 minutes, and pending    
-transactions are returned as a simple aggregate.    
+This request retrieves all metrics for all S3 Connector metadata ingestion
+locations. Zenko returns three categories of information (metrics) about system
+operations: completions, throughput, and pending operations. Completions are
+returned for the preceding 24 hours, throughput for the preceding 15 minutes,
+and pending transactions are returned as a simple aggregate.
 
 **Endpoint**	 
 

--- a/docs/docsource/reference/bucket_operations/delete_bucket.rst
+++ b/docs/docsource/reference/bucket_operations/delete_bucket.rst
@@ -8,7 +8,7 @@ empty.
 
 .. note::
 
-  Before a bucket can be deleted, all object must be deleted from the
+  Before a bucket can be deleted, all objects must be deleted from the
   bucket and all ongoing multipart uploads must be aborted.
 
 Requests
@@ -20,7 +20,7 @@ Syntax
 .. code::
 
    DELETE / HTTP/1.1
-   Host: {{BucketName}}.{{ConnectorName}}.{{StorageService}}.com
+   Host: {{BucketName}}.{{StorageService}}.com
    Date: {{date}}
    Authorization: {{authenticationInformation}
 

--- a/docs/docsource/reference/bucket_operations/delete_bucket_policy.rst
+++ b/docs/docsource/reference/bucket_operations/delete_bucket_policy.rst
@@ -8,10 +8,10 @@ policy. For any identity other than the root user of the account that owns the
 bucket, the identity must have the DeleteBucketPolicy permissions on the
 specified bucket and belong to the bucket owner's account to use this operation.
 
-In the absence of DeleteBucketPolicy permissions, S3 Connector returns a ``403
-Access Denied`` error. If the permissions are correct, but you are not using an
-identity that belongs to the bucket owner's account, S3 Connector returns a
-``405 Method Not Allowed`` error.
+In the absence of DeleteBucketPolicy permissions, Zenko returns a ``403 Access
+Denied`` error. If the permissions are correct, but you are not using an
+identity that belongs to the bucket owner's account, Zenko returns a ``405
+Method Not Allowed`` error.
 
 .. important::
 
@@ -98,5 +98,5 @@ Sample Response
    x-amz-request-id: 656c76696e672SAMPLE5657374  
    Date: Fri, 27 Sep 2019 20:22:01 GMT  
    Connection: keep-alive  
-   Server: S3Connector
+   Server: my-zenko
 

--- a/docs/docsource/reference/bucket_operations/get_bucket_list_objects.rst
+++ b/docs/docsource/reference/bucket_operations/get_bucket_list_objects.rst
@@ -23,7 +23,7 @@ Syntax
 .. code::
 
    GET / HTTP/1.1
-   Host: {{BucketName}}.{{ConnectorName}}.{{StorageService}}.com
+   Host: {{BucketName}}.{{StorageService}}.com
    Date: {{date}}
    Authorization: {{authenticationInformation}}
 

--- a/docs/docsource/reference/bucket_operations/get_bucket_list_objects_v2.rst
+++ b/docs/docsource/reference/bucket_operations/get_bucket_list_objects_v2.rst
@@ -461,7 +461,7 @@ Response
 
   <?xml version="1.0" encoding="UTF-8"?>
   <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-  Server: S3Connector
+  Server: my-zenko
     <Name>quotes</Name>
     <Prefix>E</Prefix>
     <StartAfter>ExampleGuide.pdf</StartAfter>
@@ -497,7 +497,7 @@ The following GET request specifies the delimiter parameter with value /.
 .. code::
 
   GET /?list-type=2&delimiter=/ HTTP/1.1
-  Host: s3connector.scality.com
+  Host: my-zenko.example.com
   x-amz-date: 20181108T235931Z
   Authorization: authorization string
 
@@ -542,7 +542,7 @@ the prefix parameter with valuephotos/2006/.
 .. code::
 
   GET /?list-type=2&prefix=photos/2006/&delimiter=/ HTTP/1.1
-  Host: s3connector.scality.com
+  Host: my-zenko.example.com
   x-amz-date: 20181108T000433Z
   Authorization: authorization string
 
@@ -596,7 +596,7 @@ Request
 .. code::
 
   GET /?list-type=2 HTTP/1.1
-  Host: s3connector.scality.com
+  Host: my-zenko.example.com
   Date: Thu, 08 Nov 2018 23:17:07 GMT
   Authorization: authorization string
 
@@ -645,7 +645,7 @@ response.
   GET /?list-type=2 HTTP/1.1
   GET /?list-type=2&continuation-token=1ueGcxLPRx1Tr/XYExHnhbYLgveDs2J/wm36Hy4vbOwM= HTTP/1.1
 
-  Host: s3connector.scality.com
+  Host: my-zenko.example.com
   Date: Thu, 08 Nov 2018 23:17:07 GMT
   Authorization: authorization string
 

--- a/docs/docsource/reference/bucket_operations/get_bucket_location.rst
+++ b/docs/docsource/reference/bucket_operations/get_bucket_location.rst
@@ -22,7 +22,7 @@ Syntax
 .. code::
 
    GET /?location HTTP/1.1
-   Host: {{BucketName}}.{{ConnectorName}}.{{StorageService}}.com
+   Host: {{BucketName}}.{{StorageService}}.com
    Date: {{date}}
    Authorization: {{authenticationInformation}}
 

--- a/docs/docsource/reference/bucket_operations/get_bucket_object_versions.rst
+++ b/docs/docsource/reference/bucket_operations/get_bucket_object_versions.rst
@@ -24,7 +24,7 @@ Syntax
 .. code::
 
    GET /?versions HTTP/1.1
-   Host: {{BucketName}}.{{ConnectorName}}.{{StorageService}}.com
+   Host: {{BucketName}}.{{StorageService}}.com
    Date: {{date}}
    Authorization: {{authenticationInformation}}
 
@@ -152,8 +152,8 @@ XML elements in the response:
    |                         |           | response.                           |
    |                         |           |                                     |
    |                         |           | If encoding-type request parameter  |
-   |                         |           | is specified, S3 Connector includes |
-   |                         |           | this element in the response, and   |
+   |                         |           | is specified, Zenko includes this   |
+   |                         |           | element in the response, and        |
    |                         |           | returns encoded key name values in  |
    |                         |           | the following response elements:    |
    |                         |           |                                     |

--- a/docs/docsource/reference/bucket_operations/get_bucket_policy.rst
+++ b/docs/docsource/reference/bucket_operations/get_bucket_policy.rst
@@ -8,10 +8,10 @@ policy. For any identity other than the root user of the account that owns the
 bucket, the identity must have GetBucketPolicy permissions on the specified
 bucket and belong to the bucket owner's account to use this operation.
 
-In the absence of GetBucketPolicy permissions, S3 Connector returns a ``403
-Access Denied`` error. If the permissions are correct, but you are not using an
-identity that belongs to the bucket owner's account, S3 Connector returns a
-``405 Method Not Allowed`` error.
+In the absence of GetBucketPolicy permissions, Zenko returns a ``403 Access
+Denied`` error. If the permissions are correct, but you are not using an
+identity that belongs to the bucket owner's account, Zenko returns a ``405
+Method Not Allowed`` error.
 
 .. important::
 

--- a/docs/docsource/reference/bucket_operations/list_multipart_uploads.rst
+++ b/docs/docsource/reference/bucket_operations/list_multipart_uploads.rst
@@ -202,9 +202,9 @@ its response (includes XML containers):
    |                                       |           |                           |
    |                                       |           | If the encoding-type      |
    |                                       |           | request parameter is      |
-   |                                       |           | specified, S3 Connector   |
-   |                                       |           | includes this element in  |
-   |                                       |           | the response, and returns |
+   |                                       |           | specified, Zenko includes |
+   |                                       |           | this element in the       |
+   |                                       |           | response, and returns     |
    |                                       |           | encoded key name values   |
    |                                       |           | in the following          |
    |                                       |           | elements: Delimiter,      |

--- a/docs/docsource/reference/bucket_operations/put_bucket_policy.rst
+++ b/docs/docsource/reference/bucket_operations/put_bucket_policy.rst
@@ -8,9 +8,9 @@ policy. For any identity other than the root user of the account that owns the
 bucket, the calling identity must have PutBucketPolicy permissions on the
 specified bucket and belong to the bucket owner's account to use this operation.
 
-In the absence of PutBucketPolicy permissions, S3 Connector returns a ``403
+In the absence of PutBucketPolicy permissions, Zenko returns a ``403
 Access Denied`` error. If the permissions are correct, but you are not using
-an identity that belongs to the bucket owner's account, S3 Connector returns a
+an identity that belongs to the bucket owner's account, Zenko returns a
 ``405 Method Not Allowed`` error.
 
 .. important::

--- a/docs/docsource/reference/object_operations/multi-object_delete.rst
+++ b/docs/docsource/reference/object_operations/multi-object_delete.rst
@@ -241,12 +241,11 @@ response:
    |                           |                   |    key is specified   |
    |                           |                   |    and not the        |
    |                           |                   |    version ID. In     |
-   |                           |                   |    this case, S3      |
-   |                           |                   |    Connector creates  |
-   |                           |                   |    a delete marker    |
-   |                           |                   |    and returns its    |
-   |                           |                   |    version ID in the  |
-   |                           |                   |    response.          |
+   |                           |                   |    this case, Zenko   |
+   |                           |                   |    creates a delete   |
+   |                           |                   |    marker and returns |
+   |                           |                   |    its version ID in  |
+   |                           |                   |    the response.      |
    |                           |                   | -  A versioned delete |
    |                           |                   |    request is sent;   |
    |                           |                   |    that is, an object |
@@ -257,12 +256,11 @@ response:
    |                           |                   |    version ID         |
    |                           |                   |    identifies a       |
    |                           |                   |    delete marker. In  |
-   |                           |                   |    this case, S3      |
-   |                           |                   |    Connector deletes  |
-   |                           |                   |    the delete marker  |
-   |                           |                   |    and returns the    |
-   |                           |                   |    specific version   |
-   |                           |                   |    ID in response.    |
+   |                           |                   |    this case, Zenko   |
+   |                           |                   |    deletes the delete |
+   |                           |                   |    marker and responds|
+   |                           |                   |    with the specific  |
+   |                           |                   |    version ID.        |
    |                           |                   |                       |
    |                           |                   | **Ancestor:** Deleted |
    +---------------------------+-------------------+-----------------------+

--- a/docs/docsource/reference/object_operations/put_object_copy.rst
+++ b/docs/docsource/reference/object_operations/put_object_copy.rst
@@ -148,9 +148,9 @@ Headers`).
    |                                           |        | adds this metadata to the resulting      |
    |                                           |        | object. If you specify headers in the    |
    |                                           |        | request specifying any user-defined      |
-   |                                           |        | metadata, the connector ignores these    |
-   |                                           |        | headers. To use new user-defined         |
-   |                                           |        | metadata, REPLACE must be selected.      |
+   |                                           |        | metadata, Zenko ignores these headers.   |
+   |                                           |        | To use new user-defined metadata,        |
+   |                                           |        | REPLACE must be selected.                |
    |                                           |        |                                          |
    |                                           |        | If replaced, all original metadata is    |
    |                                           |        | replaced by the specified metadata.      |

--- a/docs/docsource/reference/object_operations/upload_part_copy.rst
+++ b/docs/docsource/reference/object_operations/upload_part_copy.rst
@@ -96,17 +96,12 @@ x-amz-copy-source header.
    |                                           |        | returns an HTTP status code ``412         |
    |                                           |        | Precondition Failed`` error.              |
    |                                           |        |                                           |
-   |                                           |        | **Note**: If both the                     |
-   |                                           |        | x-amz-copy-source-if-match                |
-   |                                           |        | and x-amz-copy-source-if-unmodified-since |
-   |                                           |        | headers are present in the request as     |
-   |                                           |        | follows:                                  |
-   |                                           |        |                                           |
-   |                                           |        | x-amz-copy-source-if-match                |
-   |                                           |        | condition evaluates to true, and;         |
-   |                                           |        | x-amz-copy-source-if-unmodified-since     |
-   |                                           |        | condition evaluates to false; then, S3    |
-   |                                           |        | returns ``200 OK`` and copies the data.   |
+   |                                           |        | .. note:: If x-amz-copy-source-if-match   |
+   |                                           |        |    is requested and evaluates to true and |
+   |                                           |        |    x-amz-copy-source-if-unmodified-since  |
+   |                                           |        |    is present in the request and          |
+   |                                           |        |    evaluates to false, Zenko returns      |
+   |                                           |        |    ``200 OK`` and copies the data.        |
    |                                           |        |                                           |
    |                                           |        | **Default:** None                         |
    +-------------------------------------------+--------+-------------------------------------------+
@@ -117,37 +112,30 @@ x-amz-copy-source header.
    |                                           |        | status code ``412 Precondition Failed``   |
    |                                           |        | error.                                    |
    |                                           |        |                                           |
-   |                                           |        | **Note**: If both the x-amz-copy-source-\ |
-   |                                           |        | if-none-match and x-amz-copy-source-if-\  |
-   |                                           |        | unmodified-since headers are present in   |
-   |                                           |        | the request as follows:                   |
-   |                                           |        |                                           |
-   |                                           |        | x-amz-copy-source-if-none-match condition |
-   |                                           |        | evaluates to false, and                   |
-   |                                           |        | x-amz-copy-source-if-unmodified-since     |
-   |                                           |        | condition evaluates to true; then, S3     |
-   |                                           |        | returns ``412 Precondition Failed``       |
-   |                                           |        | response code.                            |
+   |                                           |        | .. note:: If                              |
+   |                                           |        |    x-amz-copy-source-if-none-match is     |
+   |                                           |        |    present in the request and evaluates   |
+   |                                           |        |    false and                              |
+   |                                           |        |    x-amz-copy-source-if-unmodified-since  |
+   |                                           |        |    is requested and evaluates to true     |
+   |                                           |        |    Zenko returns ``412 Precondition       |
+   |                                           |        |    Failed``.                              |
    |                                           |        |                                           |
    |                                           |        | **Default:** None                         |
    +-------------------------------------------+--------+-------------------------------------------+
    | ``x-amz-copy-source-if-unmodified-since`` | String | Perform a copy if the source object is    |
    |                                           |        | not modified after the time specified     |
    |                                           |        | using this header. If the source object   |
-   |                                           |        | is modified, S3Connector returns an HTTP  |
-   |                                           |        | status code, ``412 Precondition Failed``  |
-   |                                           |        | error.                                    |
+   |                                           |        | is modified, Zenko returns an HTTP status |
+   |                                           |        | code, ``412 Precondition Failed`` error.  |
    |                                           |        |                                           |
-   |                                           |        | **Note**: If both the x-amz-copy-source-\ |
-   |                                           |        | if-match and x-amz-copy-source-if-\       |
-   |                                           |        | unmodified-since headers are present in   |
-   |                                           |        | the request as follows:                   |
-   |                                           |        |                                           |
-   |                                           |        | x-amz-copy-source-if-match condition      |
-   |                                           |        | evaluates to true, and; x-amz-copy-\      |
-   |                                           |        | source-if-unmodified-since condition      |
-   |                                           |        | evaluates to false; then, S3 returns      |
-   |                                           |        | ``200 OK`` and copies the data.           |
+   |                                           |        | .. note:: If both the                     |
+   |                                           |        |    x-amz-copy-source-if-match header is   | 
+   |                                           |        |    present in the request and evaluates   |
+   |                                           |        |    to true, and                           |
+   |                                           |        |    x-amz-copy-source-if-unmodified-since  |
+   |                                           |        |    evaluates to false, Zenko returns      |
+   |                                           |        |    ``200 OK`` and copies the data.        |
    |                                           |        |                                           |
    |                                           |        | **Default:** None                         |
    +-------------------------------------------+--------+-------------------------------------------+
@@ -155,20 +143,17 @@ x-amz-copy-source header.
    |                                           |        | modified after the time specified using   |
    |                                           |        | the x-amz-copy-source-if-modified-since   |
    |                                           |        | header. If the source object is not       |
-   |                                           |        | modified, S3 Connector returns an HTTP    |
+   |                                           |        | modified, Zenko returns an HTTP           |
    |                                           |        | status code, ``412 precondition failed``  |
    |                                           |        | error.                                    |
    |                                           |        |                                           |
-   |                                           |        | **Note**: If both the x-amz-copy-source-\ |
-   |                                           |        | if-none-match and x-amz-copy-source-if-\  |
-   |                                           |        | unmodified-since headers are present in   |
-   |                                           |        | the request as follows:                   |
-   |                                           |        |                                           |
-   |                                           |        | x-amz-copy-source-if-none-match condition |
-   |                                           |        | evaluates to false, and x-amz-copy-\      |
-   |                                           |        | source-if-unmodified-since condition      |
-   |                                           |        | evaluates to true, then S3 returns        |
-   |                                           |        | ``412 Precondition Failed`` response code.|
+   |                                           |        | .. note:: If                              |
+   |                                           |        |    x-amz-copy-source-if-none-match is     |
+   |                                           |        |    requested and evaluates to false, and  |
+   |                                           |        |    x-amz-copy-source-if-unmodified-since  |
+   |                                           |        |    is requestred and evaluates to true,   |
+   |                                           |        |    Zenko returns a ``412 Precondition     |
+   |                                           |        |    Failed`` response code.                |
    |                                           |        |                                           |
    |                                           |        | **Default:** None                         |
    +-------------------------------------------+--------+-------------------------------------------+
@@ -201,11 +186,11 @@ encryption information for Zenko to decrypt the object for copying.
    +-----------------------------------+--------+--------------------------------------+
    | ``x-amz-copy-source-server-side-\ | string | Specifies the customer-provided      |
    | encryption-customer-key``         |        | base-64 encoded encryption key for   |
-   |                                   |        | S3 Connector to use to decrypt the   |
-   |                                   |        | source object. The encryption key    |
-   |                                   |        | provided in this header must be one  |
-   |                                   |        | that was used when the source object |
-   |                                   |        | was created.                         |
+   |                                   |        | Zenko to use to decrypt the source   |
+   |                                   |        | object. The encryption key provided  |
+   |                                   |        | in this header must be one that was  |
+   |                                   |        | used when the source object was      |
+   |                                   |        | created.                             |
    |                                   |        |                                      |
    |                                   |        | **Default:** None                    |
    |                                   |        |                                      |


### PR DESCRIPTION
This PR 
Removes four instances of holdover S3 Connector language in reference guide as requested.

Also removes several other instances of "Connector" and "S3 Connector" as (I hope)
appropriate.

fixes #ZENKO-2251