### PR TITLE
ZENKO-2248 setup nightly release

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -433,3 +433,28 @@ stages:
             TESTRAIL_KEY: '%(secret:testrail_key)s'
           warnOnFailure: true
           flunkOnFailure: false
+
+  release-nightly:
+    worker:
+      type: kube_pod
+      path: eve/workers/release/pod.yaml
+      images:
+        release: eve/workers/release
+    steps:
+      - Git: *git_pull
+      - ShellCommand:
+          name: release nightly zenko
+          command: >-
+            ./release-nightly.sh
+            --backbeat-revision development/8.2
+            --cloudserver-revision development/8.2
+            --upload zenko-dev &&
+            ./release-nightly.sh
+            --backbeat-revision development/8.2
+            --cloudserver-revision development/8.2
+            --upload zenko-dev
+            --nightly-suffix "nightly-$(date -I)"
+          workdir: build/eve/scripts
+          env:
+            HARBOR_LOGIN: '%(secret:harbor_login)s'
+            HARBOR_PASSWORD: '%(secret:harbor_password)s'

--- a/eve/scripts/release-nightly.sh
+++ b/eve/scripts/release-nightly.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+
+set -e
+
+# This function check the commit ref on a specified branch
+# and returns a short commit revision
+get_short_rev() {
+  local url="$1"
+  local branch="$2"
+
+  echo $(git ls-remote $url --branch $branch | cut -c -7) 
+}
+
+usage() {
+  local exitcode=$1
+  cat <<HELP
+    Usage: $0 [options]
+
+      --cloudserver-revision <git revision>: The desired git revision of cloudserver.
+        i.e: development/8.1, or a commit sha1.
+      --backbeat-revision <git revision>: The desired git revision of backbeat.
+        i.e: development/8.1, or a commit sha1.
+      --dest <path>: The local path to save the chart.
+        default: /tmp
+      --upload <repo>: The name of the chart repository where we will upload the release.
+        i.e: zenko-dev
+      --nightly-suffix <name>: the suffix of the chart version.
+        default: nightly
+      --help: Display this message.
+HELP
+
+  exit ${exitcode}
+}
+
+parse_semver() {
+  local RE='[^0-9]*\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)[-+]\([0-9A-Za-z\-\.]*\)'
+  local major
+  local minor
+  local patch
+  local special
+
+  major=`echo $1 | sed -n "s/${RE}/\1/p"`
+  minor=`echo $1 | sed -n "s/${RE}/\2/p"`
+  patch=`echo $1 | sed -n "s/${RE}/\3/p"`
+  special=`echo $1 | sed -n "s/${RE}/\4/p"`
+
+  SEMVER=( ${major} ${minor} ${patch} ${special} )
+}
+
+check_requirements() {
+  HELM_VERSION=$(helm version --client --short)
+  echo "Checking helm version: ${HELM_VERSION}"
+  parse_semver "${HELM_VERSION}"
+  # As we're using the option --set on helm package
+  # which was only introduced in helm version >= 3.0.0
+  # we need to ensure that we're not using an old version of helm.
+  if [[ "${SEMVER[0]}" != "3" ]]; then
+    echo "Helm must be >= 3.0.0 due to required features to use this script"
+    exit 1
+  fi
+  if [ ${UPLOAD} ] && [[ ! -f /usr/bin/curl ]]; then
+    echo "You must install curl to be able to upload charts"
+    exit 1
+  fi
+  if [[ ! -f /usr/bin/git ]]; then
+    echo "Git must be installed"
+    exit 1
+  fi
+}
+
+parse_opts() {
+  local SCRIPT_FULL_PATH=$(readlink -f $0)
+
+  declare -r LONG_OPTS='
+    backbeat-revision:,
+    cloudserver-revision:,
+    dest:,
+    upload:,
+    nightly-suffix:,
+    help,'
+
+  OPTS=$(getopt -n "$0" -o "h" --long "$LONG_OPTS" -- "$@") || exit 1
+
+  BACKBEAT_VERSION=""
+  CLOUDSERVER_VERSION=""
+  NIGHTLY_SUFFIX="nightly"
+  DEST="/tmp/"
+  GITHUB_URL="https://github.com"
+  BACKBEAT_REPO_URL="${GITHUB_URL}/scality/backbeat.git"
+  CLOUDSERVER_REPO_URL="${GITHUB_URL}/scality/cloudserver.git"
+  CHART_PATH="$(dirname ${SCRIPT_FULL_PATH})/../../kubernetes/zenko"
+  REGISTRY="registry.scality.com"
+  REPOSITORY="zenko-dev"
+  UPLOAD=""
+
+  eval set -- "${OPTS}"
+
+  while true; do
+    case $1 in
+      --backbeat-revision)
+        BACKBEAT_VERSION=${2}
+        shift
+        ;;
+      --cloudserver-revision)
+        CLOUDSERVER_VERSION=${2}
+        shift
+        ;;
+      --dest)
+        DEST=${2}
+        shift
+        ;;
+      --upload)
+        UPLOAD=${2}
+        shift
+        ;;
+      -h|--help)
+        usage 0
+        ;;
+      --nightly-suffix)
+        NIGHTLY_SUFFIX=${2}
+        shift
+        ;;
+      --)
+        shift
+        if [ $# -gt 0 ]; then
+            echo "Warning: Ignoring arguments \"$*\"" >&2
+        fi
+        break
+        ;;
+      *)
+        echo "Error: Argument invalid: $1" >&2
+        usage 1
+        ;;
+    esac
+    shift
+  done
+
+  test -n "${CLOUDSERVER_VERSION}" || usage 1
+  test -n "${BACKBEAT_VERSION}" || usage 1
+}
+
+# Calculating global variables required
+init() {
+  # Variables related to helm chart packaging
+  CHART_CURRENT_VERSION=$(grep "version:" ${CHART_PATH}/Chart.yaml | cut -c 10-)
+  echo "Zenko Chart version: ${CHART_CURRENT_VERSION}"
+  parse_semver ${CHART_CURRENT_VERSION}
+  CHART_SEMVER=("${SEMVER[@]}")
+  CHART_VERSION="${CHART_SEMVER[0]}.${CHART_SEMVER[1]}-${NIGHTLY_SUFFIX}"
+  CHART_FULL_NAME="${DEST}/zenko-${CHART_VERSION}.tgz"
+
+  # Variables related to components version
+  CLOUDSERVER_SHORT_REV=$(get_short_rev ${CLOUDSERVER_REPO_URL} ${CLOUDSERVER_VERSION})
+  echo "Cloudserver short commit ref: ${CLOUDSERVER_SHORT_REV}"
+
+  BACKBEAT_SHORT_REV=$(get_short_rev ${BACKBEAT_REPO_URL} ${BACKBEAT_VERSION})
+  echo "Backbeat short commit ref: ${BACKBEAT_SHORT_REV}"
+}
+
+package_chart() {
+  helm package ${CHART_PATH} \
+  --version "${CHART_VERSION}" \
+  --app-version "${CHART_VERSION}" \
+  --destination ${DEST} \
+  --set cloudserver.image.repository="${REGISTRY}/${REPOSITORY}/cloudserver" \
+  --set cloudserver.image.tag="${CLOUDSERVER_SHORT_REV}" \
+  --set backbeat.image.repository="${REGISTRY}/${REPOSITORY}/backbeat" \
+  --set backbeat.image.tag="${BACKBEAT_SHORT_REV}"
+}
+
+upload_chart() {
+
+  # This operation can be done via the helm push plugin
+  # but we're now doing it via curl until this issue
+  # https://github.com/chartmuseum/helm-push/issues/37 is fixed
+
+  echo "Uploading chart on registry"
+  curl -L -u "${HARBOR_LOGIN}:${HARBOR_PASSWORD}" \
+  -X POST "${REGISTRY}/api/chartrepo/${UPLOAD}/charts" \
+  -H "accept: application/json" \
+  -H  "Content-Type: multipart/form-data" \
+  -F "chart=@${CHART_FULL_NAME};type=application/x-compressed-tar"
+
+}
+
+parse_opts "$@"
+check_requirements
+init
+package_chart
+if [[ ${UPLOAD} ]]; then
+    upload_chart
+fi

--- a/eve/workers/release/Dockerfile
+++ b/eve/workers/release/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:bionic
+
+WORKDIR /home/eve/workspace
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    python3-buildbot-worker \
+    && rm -rf /var/cache/apt
+
+# Helm >= 3.0.0 required to run the nightly release script
+ARG HELM_VERSION=3.0.1
+RUN curl -sSL https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz | tar -xvz \
+ && install linux-amd64/helm /usr/local/bin \
+ && rm -rf linux-amd64
+
+WORKDIR /home/eve/workspace

--- a/eve/workers/release/pod.yaml
+++ b/eve/workers/release/pod.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: release-worker
+spec:
+  containers:
+    - name: release-worker
+      image: "{{ images.release }}"
+      command: ["/bin/sh", "-c"]
+      args: ["buildbot-worker create-worker . ${BUILDMASTER}:${BUILDMASTER_PORT} ${WORKERNAME} ${WORKERPASS} && buildbot-worker start --nodaemon"]
+      resources:
+        requests:
+          cpu: "250m"
+          memory: 1Gi
+        limits:
+          cpu: "1"
+          memory: 1Gi
+      volumeMounts:
+      - name: worker-workspace
+        mountPath: /home/eve/workspace
+  volumes:
+  - name: worker-workspace
+    emptyDir: {}

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -138,6 +138,43 @@ simulate and try to validate a compatible upgrade. Running with the `--debug` wi
 templated values and deployment configurations that will be installed. These are just basic validations
 but upgrade implications should be fully taken into account by you and/or your Kubernetes administrator.
 
+
+Nightly Releases
+----------------
+
+Nightly releases are currently available under our [private chart registry](https://registry.scality.com). They're designed for dev purposes only, so that
+you can get an early preview of what's about to be released.
+
+### Install
+
+They can be installed like the following:
+
+```shell
+# Add the zenko-dev repo to your helm setup
+$ helm repo add zenko-dev https://registry.scality.com/chartrepo/zenko-dev
+# Then you can install Zenko
+$ helm install zenko-dev/zenko --version 1.2-nightly
+```
+
+### Upgrade
+
+To update your nightly release setup you follow this commands:
+
+```shell
+# To ensure your repo is up to date
+$ helm repo update
+# Then upgrade your release
+$ helm upgrade my-release zenko-dev/zenko --version 1.2-nightly
+```
+
+### Version Scheme
+
+For the nightly version scheme we use the Major and Minor version of Zenko
+(we use semver) suffixed by `-nightly`. So that it looks like the following
+`${MAJOR_VERSION}.${MINOR_VERSION}-nightly`.
+
+We also upload the same chart with a date suffix so that we can keep an history of every nightly.
+
 [Helm]: https://helm.sh
 [Scality]: https://scality.com
 [Zenko]: https://zenko.io


### PR DESCRIPTION
This PR gives us a little helper script to create nightly releases along with the CD pipeline to deliver it on harbor.

The idea is that this job will be triggered on a nightly based and offer us a nightly release of zenko hosted on our registry.

A nightly version is already available and you can take it for a spin to check if it works on your setup. I installed one and the image of cloudserver and backbeat were properly targeting the lastest versions.

Here's how to install it:
```shell
# Add the zenko-dev repo to your helm setup
$ helm repo add zenko-dev https://registry.scality.com/chartrepo/zenko-dev
# Then you can install Zenko
$ helm install zenko-dev/zenko --version 1.2-nightly
```