### PR TITLE
documentation: ZENKOIO-143_add_K8s_variable

### DIFF
--- a/docs/docsource/conf.py
+++ b/docs/docsource/conf.py
@@ -101,13 +101,15 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 pygments_style = 'sphinx'
 
 
-# -- rst prolog experiment -----------------------------------------
-# This section contains link substitution for MSFT doc links. As we become
+# -- rst prolog  ---------------------------------------------------------
+# This section contains text substitution for custom variables and link
+# substitution for MSFT doc links. As we become
 # more complete in our documentation, we can replace these with references
-# to our own documentation. These are for the Blobserver section of the
-# Reference book only.
+# to our own documentation.
 
 rst_prolog = """
+
+.. |min_kubernetes| replace:: 1.11.3
 
 .. |set-blob-timeouts| replace:: `Setting Timeouts for Blob Service Operations <https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-blob-service-operations>`__
 
@@ -119,21 +121,13 @@ rst_prolog = """
 
 .. |storage-tracking| replace:: `Windows Azure Logging: Using Logs to Track Storage Requests <https://blogs.msdn.microsoft.com/windowsazurestorage/2011/08/02/windows-azure-storage-logging-using-logs-to-track-storage-requests/>`__
 
-.. |api-troubleshoot| replace:: `Troubleshooting API operations <https://docs.microsoft.com/en-us/rest/api/storageservices/troubleshooting-api-operations>`__                                                                        
-                                                 
-.. |emulator-dev-test| replace:: `Use the Azure Storage Emulator for Development and Testing <https://docs.microsoft.com/en-us/azure/storage/common/storage-use-emulator>`__
+.. |api-troubleshoot| replace:: `Troubleshooting API operations <https://docs.microsoft.com/en-us/rest/api/storageservices/troubleshooting-api-operations>`__
 
 .. |cors-support| replace:: `Cross-Origin Resource Sharing (CORS) support for Azure Storage <https://docs.microsoft.com/en-us/rest/api/storageservices/cross-origin-resource-sharing--cors--support-for-the-azure-storage-services>`__
 
-.. |snapshot-blob| replace:: `Create a snapshot of a blob <https://docs.microsoft.com/en-us/rest/api/storageservices/Creating-a-Snapshot-of-a-Blob>`__
-
 .. |conditional-headers| replace:: `Specifying conditional headers for Blob service operations <https://docs.microsoft.com/en-us/rest/api/storageservices/specifying-conditional-headers-for-blob-service-operations>`__
 
-.. |get-page-ranges| replace:: `Getting the Page Ranges of a Large Page Blob in Segments <https://blogs.msdn.microsoft.com/windowsazurestorage/2012/03/26/getting-the-page-ranges-of-a-large-page-blob-in-segments/>`__
-
 .. |create-sas| replace:: `Create a service SAS <https://docs.microsoft.com/en-us/rest/api/storageservices/create-service-sas>`__
-
-.. |snapshot-charges| replace:: `Understanding how blob snapshots accrue charges <https://docs.microsoft.com/en-us/rest/api/storageservices/understanding-how-snapshots-accrue-charges>`__
 
 .. |define-access| replace:: `Define a stored access policy <https://docs.microsoft.com/en-us/rest/api/storageservices/define-stored-access-policy>`__
 
@@ -141,17 +135,11 @@ rst_prolog = """
 
 .. |geo-redundant| replace:: `Windows Azure Storage Redundancy Options and Read Access Geo Redundant Storage <https://blogs.msdn.microsoft.com/windowsazurestorage/2013/12/11/windows-azure-storage-redundancy-options-and-read-access-geo-redundant-storage/>`__
 
-.. |hot-cool-archive| replace:: `Azure Blob storage: hot, cool, and archive access tiers <https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-storage-tiers>`__
-
-.. |premium-ssd| replace:: `Premium SSD <https://docs.microsoft.com/en-us/azure/virtual-machines/windows/disks-types#premium-ssd>`__
-
 .. |list-blob-storage| replace:: `Listing Blob storage resources <https://docs.microsoft.com/en-us/rest/api/storageservices/enumerating-blob-resources>`__
 
 .. |range-header| replace:: `Specifying the Range Header for Blob Service Operations <https://docs.microsoft.com/en-us/rest/api/storageservices/specifying-the-range-header-for-blob-service-operations>`__
 
 .. |manage-access| replace:: `Manage anonymous read access to containers and blobs <https://docs.microsoft.com/en-us/azure/storage/blobs/storage-manage-access-to-resources>`__
-
-.. |diff-emulator-azure| replace:: `Differences Between the Storage Emulator and Azure Storage <https://docs.microsoft.com/en-us/azure/storage/common/storage-use-emulator#differences-between-the-storage-emulator-and-azure-storage>`__
 
 .. |naming-referencing| replace:: `Naming and Referencing Containers, Blobs, and Metadata <https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata>`__
 

--- a/docs/docsource/installation/prepare/setting_up_a_cluster.rst
+++ b/docs/docsource/installation/prepare/setting_up_a_cluster.rst
@@ -11,10 +11,11 @@ Cluster Requirements` and skip to :ref:`Install_Zenko`. Otherwise,
 and follow its instructions (or review the requirements and instructions in 
 Zenko/docs/gke.md) to establish a working Kubernetes instance on your cluster.
 
-.. note: 
+.. note:: 
    
    Zenko 1.1 will not install with a Kubernetes instance older than version
-   1.11.3. Scality recommends MetalK8s 1.1, which installs Kubernetes v. 1.11.3.
+   |min_kubernetes|. Scality recommends MetalK8s 2.x, which satisfies this
+   requirement.
 
 Most of the complexity of installing Zenko on a cluster involves deploying the
 cluster istelf. Scality supports MetalK8s_, an open source Kubernetes engine

--- a/docs/docsource/installation/upgrade/upgrade_zenko.rst
+++ b/docs/docsource/installation/upgrade/upgrade_zenko.rst
@@ -30,8 +30,8 @@ For example::
 .. note::
 
    A production environment may neccessitate additional validation
-   before upgrading. Upgrades run with the `--dry-run` flag simulate
-   and, if possible, validate a compatible upgrade. If the `--debug`
+   before upgrading. Upgrades run with the ``--dry-run`` flag simulate
+   and, if possible, validate a compatible upgrade. If the ``--debug``
    flag is set, Helm outputs all templated values and deployment
    configurations to be installed. These are basic validations, but
    their upgrade implications must be considered by both the Zenko and

--- a/docs/docsource/operation/Architecture/Kubernetes.rst
+++ b/docs/docsource/operation/Architecture/Kubernetes.rst
@@ -22,14 +22,14 @@ whenever server operations cross pre-configured thresholds. Kubernetes reduces
 the complexity of container service and management previously addressed with
 Docker Swarm. MetalK8s, an open-source Scality project, reduces the complexity
 of deploying Kubernetes outside of a public cloud. You can use any Kubernetes
-deployment (1.11.3 or later) to run Zenko, but MetalK8s offers total platform
-independence.
+deployment (|min_kubernetes| or later) to run Zenko, but MetalK8s offers total
+platform independence.
 
 MetalK8s builds on the Kubespray project to install a base Kubernetes cluster,
 including all dependencies (like etcd), using the Ansible provisioning
 tool. This installation includes operational tools, such as Prometheus, Grafana,
 ElasticSearch, and Kibana, and deploys by default with the popular NGINX ingress
-controller (`ingress-nginx<https://github.com/kubernetes/ingress-nginx>`).
+controller (`ingress-nginx <https://github.com/kubernetes/ingress-nginx>`_).
 All these are managed as Helm packages.
 
 Unlike hosted Kubernetes solutions, where network-attached storage is available

--- a/docs/docsource/operation/Architecture/System_Architecture.rst
+++ b/docs/docsource/operation/Architecture/System_Architecture.rst
@@ -94,10 +94,10 @@ Zenko Cluster Topology
 ----------------------
 
 To operate with high availability, Zenko must operate on a cluster of at least
-three physical or virtual servers running Kubernetes 1.11.3 or later. Run in
-such a cluster configuration, Zenko is highly available: load balancing,
-failover, and service management are handled dynamically in real time by
-Kubernetes. This dramatically improves several aspects of service management,
+three physical or virtual servers running Kubernetes |min_kubernetes| or
+later. Run in such a cluster configuration, Zenko is highly available: load
+balancing, failover, and service management are handled dynamically in real time
+by Kubernetes. This dramatically improves several aspects of service management,
 creating a fast, robust, self-healing, flexible, scalable system. From the
 user’s perspective, Zenko is functionally a single instance that obscures the
 services and servers behind it.

--- a/docs/docsource/operation/Metadata_Search/Using_search_bucket.rst
+++ b/docs/docsource/operation/Metadata_Search/Using_search_bucket.rst
@@ -33,21 +33,19 @@ This produces the following output:
       -h, --help                    output usage information
 
 In the following examples, Zenko is accessible on endpoint
-`http://zenko.local:80` and contains the bucket ``zenkobucket``.
+``http://zenko.local:80`` and contains the bucket ``zenkobucket``.
 
--  To search for objects with metadata “\ ``blue``\ ”:
+-  To search for objects with metadata ``blue``:
 
    ::
 
        $ node bin/search_bucket -a <AccessKey1> -k <verySecretKey1> -b zenkobucket -q "x-amz-meta-color=blue" -h zenko.local -p 80
 
--  The search for objects tagged with “\ ``type=color``\ ”:
+-  The search for objects tagged with ``type=color``:
 
    ::
 
        $ node bin/search_bucket -a <AccessKey1> -k <verySecretKey1> -b zenkobucket -q "tags.type=color" -h zenko.local -p 80
-
-
 
 
 .. _`HTTP Search Requests`: HTTP_Search_Requests.html


### PR DESCRIPTION
This PR: 

Added "min_kubernetes" variable to rst_prolog section of conf.py. Inserted substitution reference whenever "1.11.3" was mentioned in the text. 

Removed some unneeded reference definitions.

Fixed some badly formatted code sections and links.

Fixes ZENKOIO-143
