### PR TITLE
documentation: ZENKOIO-118_fix_only_declarations

### DIFF
--- a/docs/docsource/_static/custom.css
+++ b/docs/docsource/_static/custom.css
@@ -148,11 +148,7 @@
   font-style: italic;
 }
 
-
-
 @import url(fonts.googleapis.com/css?family=Roboto:400,400italic,500,500italic,700,700italic,900,900italic,300italic,300,100italic,100);
-
-/* Styles by chris.tingom@scality.com Hello and thanks for all the fish! */
 
 div.highlight {
     background-color: #E6E6E6;
@@ -326,36 +322,7 @@ a.reference-internal
     color: '#FFFFFF'
   }
 
-/* h2
-  {
-    font-size: 16pt;
-    font-family: 'Oswald SemiBold';
-  }
 
-h3
-  {
-    font-size: 14pt;
-    font-family: 'Oswald SemiBold';
-  }
-
-h4
-  {
-    font-size: 1em;
-    font-family: 'Oswald SemiBold';
-  }
-
-h5
-  {
-    font-style: italic;
-    font-family: 'Oswald SemiBold';
-  }
-
-h6
-  {
-    font-variant: small-caps;
-    font-family: 'Oswald SemiBold';
-  }
-*/
 img
   {
     align: center
@@ -365,47 +332,37 @@ img
     padding-bottom: 5px;
   }
 
-
 img.FiftyPercent
   {
     max-width: 50%;
   }
 
-
 img.OneHundredPercent
   {
     max-width: 100%;
-/*    padding-left: 10px;
-    padding-right: 10px;
-    padding-top: 5px;
-    padding-bottom: 5px;*/
   }
 
 img.SeventyFivePercent
   {
     align: center;
     max-width: 75%;
-  /*      padding-left: 10px;
-      padding-right: 10px;
-      display: block;
-      padding-top: 5px;
-      padding-bottom: 5px;*/
-    }
+  }
 
 div.footer
   {
     background-color: #201921;
   }
 
-td ul {
+td ul
+   {
     margin-left: 1em;
     padding: 0px 0px 0px 0px;
-}
+   }
 
 td ul li
-{
+   {
     margin-left: 1em;
-}
+   }
 
 
 /* Changes color of note admonition box */
@@ -426,7 +383,7 @@ div.tip {
     border: 1px solid #93d893;
 }
 
-/* H1 */
+
 div.body h1 {
     font-size: 222%;
 }
@@ -445,9 +402,9 @@ code {
     font-family: Courier, "Courier New", monospace;
     font-size: 90%;
     background-color: inherit;
-}
+   }
 
 ol ol {
     list-style-type: lower-alpha;
-}
+   }
 

--- a/docs/docsource/conf.py
+++ b/docs/docsource/conf.py
@@ -50,6 +50,7 @@ if READTHEDOCS:
 extensions = [
             'sphinx.ext.todo',
             'sphinx.ext.ifconfig',
+            'sphinxcontrib.plantuml',
             'sphinxcontrib.spelling',
             'sphinxcontrib.inkscapeconverter',
 	    'sphinx_version_ref',
@@ -89,12 +90,12 @@ language = None
 
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
-# if tags.has('html'):
-#     master_doc = 'index_pdf'
-#     exclude_patterns.extend(['index_pdf.rst', '*/index_pdf.rst'])
-# else:
-#     master_doc = 'index_pdf'
-#     exclude_patterns.extend(['*/index.rst', 'index.rst', '*/glossary.rst'])
+if tags.has('html'):
+   master_doc = 'index'
+   exclude_patterns.extend(['index_pdf.rst', '*/index_pdf.rst'])
+else:
+   master_doc = 'index_pdf'
+   exclude_patterns.extend(['*/index.rst', 'index.rst', '*/glossary.rst'])
 
 # The name of the Pygments (syntax highlighting) style to use.
 
@@ -183,7 +184,8 @@ html_theme_options = {
       ("Knowledge Base", "https://support.scality.com/hc/en-us"),
       ("Training", "https://training.scality.com"),
       ("Privacy Policy", "https://www.scality.com/privacy-policy/"),
-   ]
+   ],
+   'kblink': 'https://support.scality.com/hc/en-us',
 }
 
 # add logo  (your logo goes in _static directory)
@@ -238,8 +240,8 @@ latex_engine = 'xelatex'
 latex_contents = r"""
     \thispagestyle{empty}
     \clearpage
-    \setcounter{page}{1}
     \sphinxtableofcontents
+    \setcounter{page}{1}
 """
 
 latex_logo = scaldoc.resources.get_footer_logo()
@@ -265,7 +267,6 @@ latex_elements = {
      'pointsize': '11pt',
 
     # Additional stuff for the LaTeX preamble.
-    #
     'preamble': scaldoc.resources.get_latex_preamble(
         cover=os.path.basename(latex_cover),
         logo=os.path.basename(latex_logo),
@@ -274,12 +275,19 @@ latex_elements = {
         version=release,
         copyright=copyright
      ),
+
+   'tableofcontents': latex_contents,
+   
     # Latex figure (float) alignment
     #
     # 'figure_align': 'htbp',
 }
 
-latex_additional_files = [latex_logo, latex_cover]
+latex_additional_files = [
+   latex_logo,
+   latex_cover,
+   os.path.join(scaldoc.paths.SHARED_INCLUDES, 'legal_notice.txt'),
+]
 latex_additional_files.extend(scaldoc.resources.get_fonts())
 
 # Grouping the document tree into LaTeX files. List of tuples
@@ -288,25 +296,25 @@ latex_additional_files.extend(scaldoc.resources.get_fonts())
 
 if tags.has('install'):
    latex_documents = [(
-      'installation/index',
+      'installation/index_pdf',
       'Zenko_Installation.tex',
-      'Zenko Installation Documentation',
+      'Zenko Installation',
       'Scality Technical Publications',
       'manual'
    )]
 elif tags.has('operation'):
    latex_documents = [(
-      'operation/index',
+      'operation/index_pdf',
       'Zenko_Operation.tex',
-      'Zenko Operation Documentation',
+      'Zenko Operation',
       'Scality Technical Publications',
       'manual'
    )]
 elif tags.has('reference'):
    latex_documents = [(
-      'reference/index',
+      'reference/index_pdf',
       'Zenko_Reference.tex',
-      'Zenko Reference Documentation',
+      'Zenko Reference',
       'Scality Technical Publications',
       'manual'
    )]
@@ -314,7 +322,6 @@ elif tags.has('reference'):
 # Override the default formatter with our custom one.
 
 PygmentsBridge.latex_formatter = scaldoc.latex.Formatter
- 
  
 def setup(app):
      app.add_stylesheet('custom.css')

--- a/docs/docsource/include/legal_notice.txt
+++ b/docs/docsource/include/legal_notice.txt
@@ -1,0 +1,44 @@
+\thispagestyle{empty}
+\chapter*{Legal notice}
+
+All brands and product names cited in Scality's technical documentation are
+the property of their respective owners.
+
+The author and publisher have taken care in the preparation of the technical
+documentation content but make no expressed or implied warranty of any kind
+and assume no responsibility for errors or omissions. No liability is assumed
+for incidental or consequential damages in connection with or arising out of
+the use of the information or programs contained therein.
+
+Scality retains the right to make changes at any time without notice.
+
+Scality assumes no liability, including liability for infringement of any
+patent or copyright, for the license, sale, or use of its products except as
+set forth in the Scality licenses.
+
+Scality assumes no obligation to update the information contained in its
+documentation.
+
+All rights reserved. No part of this documentation may be reproduced, stored
+in a retrieval system, or transmitted, in any form, or by any means,
+electronic, mechanical, photocopying, recording, or otherwise, without prior
+written consent from Scality, S.A.
+
+Copyright ©2009–2020 Scality. All rights reserved.
+
+\section*{About Scality}
+
+Since 2009, Scality has enabled people to derive maximum value from data by
+solving their cloud-scale data storage and management challenges with our
+award-winning RING and Zenko technologies. Now, more than 500 million users rely
+on Scality RING and Zenko to store and manage hundreds of petabytes of data—more
+than one trillion data objects. A recognized leader in distributed file and
+object storage by both Gartner® and IDC®, Scality offers solutions for today’s
+reality of hybrid and multi-cloud data management. RING turns commodity x86
+servers into an unlimited storage pool for unstructured data, whether file or
+object; and the Zenko multi-cloud controller, available in open source and
+enterprise editions, provides a window into data, no matter where it lives, with
+orchestration, management and search functionality. Follow us on Twitter
+\href{https://twitter.com/scality}{@scality} and
+\href{https://twitter.com/zenko}{@zenko}. Visit us at
+\url{www.scality.com}.

--- a/docs/docsource/include/marketing_intro.txt
+++ b/docs/docsource/include/marketing_intro.txt
@@ -1,0 +1,13 @@
+Since 2009, Scality has enabled people to derive maximum value from data by
+solving their cloud-scale data storage and management challenges with our
+award-winning RING and Zenko technologies. Now, more than 500 million users rely
+on Scality RING and Zenko to store and manage hundreds of petabytes of data—more
+than one trillion data objects. A recognized leader in distributed file and
+object storage by both Gartner® and IDC®, Scality offers solutions for today’s
+reality of hybrid and multi-cloud data management. RING turns commodity x86
+servers into an unlimited storage pool for unstructured data, whether file or
+object; and the Zenko multi-cloud controller, available in open source and
+enterprise editions, provides a window into data, no matter where it lives, with
+orchestration, management and search functionality. Follow us on Twitter
+www.twitter.com/scality (@scality) and www.twitter.com/zenko (@zenko). Visit us
+at www.scality.com.

--- a/docs/docsource/include/publication_history.txt
+++ b/docs/docsource/include/publication_history.txt
@@ -1,0 +1,24 @@
+\textbf{Publication History}
+
+X\{0.20textwidth\}X\{0.15textwidth\}X\{0.60textwidth\}
+
+\begin{longtable}[]{@{}lll@{}}
+\toprule
+\begin{minipage}[b]{0.23\columnwidth}\raggedright
+Version\strut
+\end{minipage} & \begin{minipage}[b]{0.17\columnwidth}\raggedright
+Date\strut
+\end{minipage} & \begin{minipage}[b]{0.52\columnwidth}\raggedright
+What's New\strut
+\end{minipage}\tabularnewline
+\midrule
+\endhead
+\begin{minipage}[t]{0.23\columnwidth}\raggedright
+1.2\strut
+\end{minipage} & \begin{minipage}[t]{0.17\columnwidth}\raggedright
+\strut
+\end{minipage} & \begin{minipage}[t]{0.52\columnwidth}\raggedright
+\strut
+\end{minipage}\tabularnewline
+\bottomrule
+\end{longtable}

--- a/docs/docsource/index_pdf.rst
+++ b/docs/docsource/index_pdf.rst
@@ -1,0 +1,14 @@
+.. Zenko documentation master file, created by
+   sphinx-quickstart on Thu Jun 21 14:50:43 2018.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Zenko
+=====
+
+.. toctree::
+   :maxdepth: 2
+
+   installation/index_pdf
+   operation/index_pdf
+   reference/index_pdf

--- a/docs/docsource/installation/index_pdf.rst
+++ b/docs/docsource/installation/index_pdf.rst
@@ -1,0 +1,13 @@
+.. _Zenko Installation:
+
+Zenko Installation
+==================
+
+.. toctree::
+   :maxdepth: 2
+
+   prepare/index
+   install/index
+   configure/index
+   upgrade/upgrade_zenko
+   uninstall/index

--- a/docs/docsource/operation/Introduction/index.rst
+++ b/docs/docsource/operation/Introduction/index.rst
@@ -1,6 +1,16 @@
 About Zenko
 ===========
 
+Zenko is Scality's multi-cloud storage controller. It provides a single point of
+integration using the Amazon S3 and Azure Blob Storage cloud storage APIs, and
+enables data backup, transfer, and replication across private and public clouds.
+
+Using Zenko, you can store to a Scality RING storage device and automatically
+back up to one or several public clouds. Alternatively, you can use a public
+cloud such as Amazon S3 as primary storage and replicate data stored
+there--specific files, file types, or entire buckets--to other supported clouds,
+such as Google Cloud Platform (GCP) or Microsoft Azure.
+
 The Zenko open-source project, described at https://www.zenko.io/ and hosted on
 GitHub at https://github.com/scality/Zenko, provides the core logic of the Zenko
 product. This core is a stack of microservices, written primarily in Node.js and

--- a/docs/docsource/operation/index_pdf.rst
+++ b/docs/docsource/operation/index_pdf.rst
@@ -1,0 +1,12 @@
+Zenko Operation
+===============
+
+.. toctree::
+   :maxdepth: 2
+
+   About Zenko<Introduction/index>
+   Architecture<Architecture/index>
+   Services<Services/index>
+   Using Orbit<Orbit_UI/index>
+   Cloud Management Services<Dashboards/Cloud_Management_Services>
+   Zenko from the Command Line<Zenko_CLI/index>

--- a/docs/docsource/reference/index_pdf.rst
+++ b/docs/docsource/reference/index_pdf.rst
@@ -1,0 +1,14 @@
+.. _Reference:
+
+Zenko Reference
+===============
+
+.. toctree::
+   :maxdepth: 2
+
+   introduction/index
+   cloudserver/index
+   blobserver/index
+   prometheus/index
+
+

--- a/docs/docsource/templates/preamble.tex
+++ b/docs/docsource/templates/preamble.tex
@@ -93,6 +93,10 @@
 
     % Restore original margins.
     \restoregeometry
+
+    ~\\\newpage
+    \input{legal_notice.txt}
+%    \input{publication_history.txt}
 }
 
 % To remove fancyhdr warning "\headheight is too small"


### PR DESCRIPTION
Fixed latexpdf build tools to achieve parity with RING PDF builds: legal notice and
marketing copy appear as front matter in PDF outputs.

Added frontmatter structure to imitate RING docs for PDF output.

Made minor changes to conf.py and custom.css

fixes #ZENKOIO-118
