### PR TITLE
ZENKO-2254 Upgrading CI to metalk8s 2 and nfs server fix

### DIFF
--- a/eve/scripts/setup-k8s.sh
+++ b/eve/scripts/setup-k8s.sh
@@ -8,7 +8,7 @@ echo "${CI_KUBECONFIG}" | envsubst > /root/.kube/config
 
 echo "Setting up k8s namespace"
 kubectl config get-contexts --kubeconfig ${KUBECONFIG}
-kubectl config use-context admin-cluster.local || exit 1
+kubectl config use-context kubernetes-admin@kubernetes || exit 1
 kubectl get ns
 kubectl create namespace "${NAMESPACE}"
 kubectl create rolebinding view-configmap \

--- a/tests/zenko_tests/python_tests/zenko_e2e/cosmos/test_cosmos_deployment.py
+++ b/tests/zenko_tests/python_tests/zenko_e2e/cosmos/test_cosmos_deployment.py
@@ -10,11 +10,10 @@ from .. import util
 _log = logging.getLogger('cosmos')  # pylint: disable=invalid-name
 
 MD5_HASHES = {
-    "file1": "e61d15de7ad98164bad4394b818510a9",
-    "file2": "18bcf93f4a001b4cdfc3fc702847864f",
-    "file3": "b4bf46b4640547ab96e75b24170242c1",
-    "file4": "1baecec7b7c658357288ac736b6e95a6",
-    "file5": "465e3cc6ea85a2503de80459ad0b8634",
+    "file1": "e61d15de7ad98164bad4394b818510a9",  # 1KB
+    "file2": "18bcf93f4a001b4cdfc3fc702847864f",  # 1MB
+    "file3": "e463f804492a9be73d8621e1f54f57d6",  # 10MB
+    "file4": "1baecec7b7c658357288ac736b6e95a6",  # 100MB
 }
 
 


### PR DESCRIPTION
CI infrastructure was in a bad shape, updating Zenko towards the new modification.

CI secret has been upgraded to speak with a metalk8s 2.x cluster.

our nfs server had a corrupted file stored, due to a lost disk. We removed the file and updated the md5sum on the test suite.