### PR TITLE
ZENKO-2254 freeze kubernetes client version

### DIFF
--- a/tests/zenko_tests/Dockerfile
+++ b/tests/zenko_tests/Dockerfile
@@ -19,7 +19,7 @@ RUN apk add -U \
 COPY ./node_tests/package.json ./node_tests/package-lock.json /usr/local/bin/tests/node_tests/
 COPY ./python_tests/requirements.txt /tmp
 
-RUN python3 -m pip install -r /tmp/requirements.txt tox kubernetes && \
+RUN python3 -m pip install -r /tmp/requirements.txt tox && \
     cd /usr/local/bin/tests/node_tests && \
     npm install && \
     rm -rf /var/cache/apk/* && \

--- a/tests/zenko_tests/python_tests/requirements.txt
+++ b/tests/zenko_tests/python_tests/requirements.txt
@@ -22,6 +22,7 @@ isodate==0.6.0
 jeepney==0.3.1
 jmespath==0.9.3
 keyring==13.2.1
+kubernetes==10.0.1
 more-itertools==4.3.0
 msrest==0.5.4
 msrestazure==0.5.0


### PR DESCRIPTION
Freezing the kubernetes client version to make sure we don't receive an upgrade over time that could possibly break our tests.