### PR TITLE
Disabling unrequired PV on CI tests

### DIFF
--- a/eve/ci-values.yaml
+++ b/eve/ci-values.yaml
@@ -257,3 +257,7 @@ grafana:
 mgob:
   persistentVolume:
     enabled: false
+
+burry:
+  persistentVolume:
+    enabled: false

--- a/eve/ci-values.yaml
+++ b/eve/ci-values.yaml
@@ -253,3 +253,7 @@ grafana:
     create: false
   adminUser: admin
   adminPassword: strongpassword
+
+mgob:
+  persistentVolume:
+    enabled: false


### PR DESCRIPTION
Disabling unused persistent volumes on ci helm chart `values` 