### PR TITLE
ci: ZENKO-2254 limit the number of simultaneous builds to 4

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -189,6 +189,7 @@ models:
 
 stages:
   pre-merge:
+    simultaneous_builds: 4
     worker:
       type: local
     steps:


### PR DESCRIPTION
To ease up with the CI infrastructure let's limit the number
of simultaneous builds we can handle for now.
