### PR TITLE
INTEGRATION [PR#939 > development/1.2] ci: ZENKO-2254 limit the number of simultaneous builds to 4

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -189,6 +189,7 @@ models:
 
 stages:
   pre-merge:
+    simultaneous_builds: 4
     worker:
       type: local
     steps:


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #939.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/1.2/bugfix/ZENKO-2254-limit-simultaneous-build-premerge`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/1.2/bugfix/ZENKO-2254-limit-simultaneous-build-premerge
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/1.2/bugfix/ZENKO-2254-limit-simultaneous-build-premerge
```

Please always comment pull request #939 instead of this one.