### PR TITLE
ZENKO-2254 review resource usage on CI tests

### DIFF
--- a/eve/ci-values.yaml
+++ b/eve/ci-values.yaml
@@ -186,10 +186,10 @@ backbeat:
       resources:
         limits:
           cpu: 250m
-          memory: 768Mi
+          memory: 256Mi
         requests:
           cpu: 250m
-          memory: 768Mi
+          memory: 256Mi
     populator:
       resources: &backbeat
         limits:

--- a/eve/workers/mocks/aws-mock.yaml
+++ b/eve/workers/mocks/aws-mock.yaml
@@ -51,10 +51,10 @@ spec:
     resources:
       limits:
         cpu: 1
-        memory: 2Gi
+        memory: 1Gi
       requests:
         cpu: 1
-        memory: 2Gi
+        memory: 1Gi
   volumes:
   - name: metadata
     emptyDir: {}

--- a/eve/workers/mocks/azure-mock.yaml
+++ b/eve/workers/mocks/azure-mock.yaml
@@ -29,7 +29,7 @@ spec:
     resources:
       limits:
         cpu: 1
-        memory: 2Gi
+        memory: 512Mi
       requests:
         cpu: 1
-        memory: 2Gi
+        memory: 512Mi

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -260,8 +260,8 @@ run-tests: | build-tests
 		--restart=Never \
 		--image=$(E2E_IMAGE)  \
 		--namespace $(HELM_NAMESPACE) \
-		--limits='cpu=300m,memory=2Gi' \
-		--requests='cpu=300m,memory=2Gi' \
+		--limits='cpu=300m,memory=1Gi' \
+		--requests='cpu=300m,memory=1Gi' \
 		--env MOCHA_TAGS="$(NODE_TEST_TAGS)" \
 		--env CLOUDSERVER_ENDPOINT="http://$(ZENKO_HELM_RELEASE)-cloudserver:80" \
 		$(shell ../eve/workers/ci_env.sh env)


### PR DESCRIPTION
Reviewing pod resource usage, I felt like we were asking too much RAM resource.

I reviewed each resource request with the actual usage when the test are running. I'm still giving more than I should, but this will help us save some space in our infra.