### PR TITLE
INTEGRATION [PR#614 > development/1.2] bugfix: ZENKO-1635 re-enable gcp tests

### DIFF
--- a/tests/zenko_tests/node_tests/backbeat/ReplicationUtility.js
+++ b/tests/zenko_tests/node_tests/backbeat/ReplicationUtility.js
@@ -725,7 +725,8 @@ class ReplicationUtility {
             }
             const { srcData, destMetadata, destData } = data;
             assert.strictEqual(srcData.ReplicationStatus, 'COMPLETED');
-            assert.strictEqual(srcData.ContentLength, destMetadata[0].size);
+            assert.strictEqual(`${srcData.ContentLength}`,
+                destMetadata[0].size);
             const srcUserMD = srcData.Metadata;
             const destUserMD = destMetadata[0].metadata;
             assert.strictEqual(

--- a/tests/zenko_tests/node_tests/backbeat/tests/crr/gcpBackend.js
+++ b/tests/zenko_tests/node_tests/backbeat/tests/crr/gcpBackend.js
@@ -22,8 +22,7 @@ const copySource = `/${srcBucket}/${file}`;
 const fileutf8 = `${filePrefix}/%EA%9D%8B崰㈌㒈保轖䳷䀰⺩ቆ楪僷ꈅꓜ퇬枅࿷염곞召㸾⌙ꪊᆐ庍뉆䌗↎幐냂詴 끴鹲萯⇂쫤ᛩ꺶㖭簹릍铰᫫暨鿐魪셑蛃춧㡡竺뫁噛̷ᗰⷑ錜⑔痴䧫㾵᏷ำꎆ꼵껪멷㄀誕㳓腜쒃컹㑻鳃삚舿췈孨੦⮀Ǌ곓⵪꺼꜈嗼뫘悕錸瑺⁤⑬১㵀⡸Ҏ礄䧛졼⮦ٞ쫁퓡厈譤擵泶鵇俻縫륒㜓垻ㆩꝿ詀펉ᆙ舑䜾힑藪碙ꀎꂰ췊Ᏻ   㘺幽醛잯ද汧Ꟑꛒⶨ쪸숞헹㭔ꡔᘼ뺓ᡆ᡾ᑟ䅅퀭耓弧⢠⇙폪ް蛧⃪Ἔ돫ꕢ븥ヲ캂䝄쟐颺ᓾ둾Ұ껗礞ᾰ瘹蒯硳풛瞋襎奺熝妒컚쉴⿂㽝㝳駵鈚䄖戭䌸᫲ᇁ䙪鸮ᐴ稫ⶭ뀟ھ⦿䴳稉ꉕ捈袿놾띐✯伤䃫⸧ꠏ瘌틳藔ˋ㫣敀䔩㭘식↴⧵佶痊牌ꪌ搒꾛æᤈべ쉴挜炩⽍舘ꆗ줣徭Z䐨 敗羥誜嘳ֶꫜ걵ࣀ묟ኋ拃秷䨸菥䟆곘縧멀煣⧃⏶혣뎧邕⢄⭖陙䣎灏ꗛ僚䌁䠒䲎둘ꪎ傩쿌ᨌ뀻阥눉넠猌ㆯ㰢船戦跏灳蝒礯鞰諾벥煸珬㟑孫鞹Ƭꄹ孙ꢱ钐삺ᓧ鈠䁞〯蘼᫩헸ῖ"`; // eslint-disable-line
 const REPLICATION_TIMEOUT = 300000;
 
-tags('flaky') // Tracking via ZENKO-1277
-.describe('Replication with GCP backend', function() {
+describe('Replication with GCP backend', function() {
     this.timeout(REPLICATION_TIMEOUT);
     this.retries(3);
     let roleArn = 'arn:aws:iam::root:role/s3-replication-role';

--- a/tests/zenko_tests/python_tests/zenko_e2e/cloudserver/test_mpu.py
+++ b/tests/zenko_tests/python_tests/zenko_e2e/cloudserver/test_mpu.py
@@ -14,6 +14,7 @@ def test_mpu_aws(aws_ep_bucket, aws_target_bucket, mpufile, objkey):
         objkey, mpufile, aws_ep_bucket, aws_target_bucket)
 
 
+@pytest.mark.skip(reason='test case covered')
 @pytest.mark.flaky(reruns=3)
 @pytest.mark.conformance
 def test_mpu_gcp(gcp_ep_bucket, gcp_target_bucket, mpufile, objkey):

--- a/tests/zenko_tests/python_tests/zenko_e2e/cloudserver/test_replication.py
+++ b/tests/zenko_tests/python_tests/zenko_e2e/cloudserver/test_replication.py
@@ -21,6 +21,7 @@ def test_aws_1_1(aws_crr_bucket, aws_crr_target_bucket, objkey, datafile):
         objkey, data, aws_crr_bucket, [aws_crr_target_bucket])
 
 
+@pytest.mark.skip(reason='test case covered')
 @pytest.mark.flaky(reruns=3)
 @pytest.mark.parametrize('datafile', [testfile, mpufile])
 @pytest.mark.conformance


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #614.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/1.2/bugfix/ZENKO-1635-unskip-gcp`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/1.2/bugfix/ZENKO-1635-unskip-gcp
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/1.2/bugfix/ZENKO-1635-unskip-gcp
```

Please always comment pull request #614 instead of this one.