### PR TITLE
ci: ZENKO-2268 avoid naming collision on cluster scope resources

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -158,7 +158,7 @@ models:
       TRANSIENT_SRC_BUCKET_NAME: 'ci-zenko-transient-src-bucket-%(prop:bootstrap)s-${STAGE}'
 
       NFS_SERVER: '%(secret:nfs_backend_endpoint)s'
-      NFS_BACKEND: 'nfs-%(prop:bootstrap)s'
+      NFS_BACKEND: 'nfs-%(prop:bootstrap)s-%(prop:buildnumber)s'
       NFS_BUCKET_NAME: 'zenko-nfs-bucket'
 
   - env: &mock_env


### PR DESCRIPTION
cosmos tests creates PV which are resources not linked to a specific
namespace. We need to ensure we will never create resources name that
could possibly collide.


