### PR TITLE
INTEGRATION [PR#947 > development/1.2] ci: ZENKO-2268 avoid naming collision on cluster scope resources

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -158,7 +158,7 @@ models:
       TRANSIENT_SRC_BUCKET_NAME: 'ci-zenko-transient-src-bucket-%(prop:bootstrap)s-${STAGE}'
 
       NFS_SERVER: '%(secret:nfs_backend_endpoint)s'
-      NFS_BACKEND: 'nfs-%(prop:bootstrap)s'
+      NFS_BACKEND: 'nfs-%(prop:bootstrap)s-%(prop:buildnumber)s'
       NFS_BUCKET_NAME: 'zenko-nfs-bucket'
 
   - env: &mock_env


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #947.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/1.2/bugfix/ZENKO-2268-avoid-naming-collision`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/1.2/bugfix/ZENKO-2268-avoid-naming-collision
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/1.2/bugfix/ZENKO-2268-avoid-naming-collision
```

Please always comment pull request #947 instead of this one.