### PR TITLE
documentation/ZENKO-2322_x-amz-location-constraint_GET_object_header

### DIFF
--- a/docs/docsource/installation/prepare/setting_up_a_cluster.rst
+++ b/docs/docsource/installation/prepare/setting_up_a_cluster.rst
@@ -3,18 +3,19 @@
 Setting Up a Cluster
 ====================
 
-While running Zenko on a single machine is desirable for certain use cases,
-a clustered operating environment is required for high-availability deployments.
+While running Zenko on a single machine is desirable for certain use cases, a
+clustered operating environment is required for high-availability deployments.
 If you can set up a Kubernetes cluster on your own, review the :ref:`General
-Cluster Requirements` and skip to :ref:`Install_Zenko`. Otherwise, 
-`download MetalK8s <https://github.com/scality/metalk8s/releases>`_
-and follow its instructions (or review the requirements and instructions in 
-Zenko/docs/gke.md) to establish a working Kubernetes instance on your cluster.
+Cluster Requirements` and skip to :ref:`Install_Zenko`. Otherwise, download `the
+latest stable version of MetalK8s
+<https://github.com/scality/metalk8s/releases>`_ and follow its instructions to
+establish a working Kubernetes instance on your cluster.
 
 .. note: 
-   
-   Zenko 1.1 will not install with a Kubernetes instance older than version
-   1.11.3. Scality recommends MetalK8s 1.1, which installs Kubernetes v. 1.11.3.
+
+   Zenko 1.1 and later are not compatible with Kubernetes instances before
+   version |min_kubernetes|. Scality recommends MetalK8s 2.4 or later, which
+   satisfies this requirement.
 
 Most of the complexity of installing Zenko on a cluster involves deploying the
 cluster istelf. Scality supports MetalK8s_, an open source Kubernetes engine
@@ -30,10 +31,10 @@ General Cluster Requirements
 ----------------------------
 
 Setting up a cluster requires at least three machines (these can be VMs)
-running CentOS_ 7.4 or higher (The recommended mimimum for a high-availability
+running CentOS_ 7.4 or higher. The recommended mimimum for a high-availability
 Zenko production service is five server nodes with three masters/etcds, but for
 testing and familiarization, three masters and three nodes is fine. The cluster
-must have an odd number of nodes to provide a quorum). You must have SSH access
+must have an odd number of nodes to provide a quorum. You must have SSH access
 to these machines and they must have SSH access to each other.
 
 Each machine acting as a Kubernetes_ node must also have at least one disk
@@ -45,6 +46,3 @@ it.
 .. _MetalK8s: https://github.com/scality/metalk8s/
 .. _CentOS: https://www.centos.org
 .. _Kubernetes: https://kubernetes.io
-
-
-

--- a/docs/docsource/reference/object_operations/get_object.rst
+++ b/docs/docsource/reference/object_operations/get_object.rst
@@ -3,18 +3,18 @@
 GET Object
 ==========
 
-To use GET Object, it is necessary to have READ access to the target
-object. If READ access is granted to an anonymous user, the object can
-be returned without using an authorization header.
+Using GET Object requires read access to the target object. If read access is
+granted to an anonymous user, the object can be returned without using an
+authorization header.
 
 By default, the GET Object operation returns the current version of an
 object. To return a different version, use the versionId subresource.
 
 .. tip::
 
-  If the current version of the object is a delete marker, Zenko behaves
-  as if the object was deleted and includes x-amz-delete-marker: true in
-  the response.
+  If the current version of the object is a delete marker, Zenko behaves as if
+  the object were deleted and includes ``x-amz-delete-marker: true`` in the
+  response.
 
 Requests
 --------
@@ -35,12 +35,12 @@ Parameters
 
 Values for a set of response headers can be overridden in the GET Object
 response using the query parameters listed in the following table. These
-response header values are sent only on a successful request, one in
-which a status code *200 OK* is returned. The set of headers that can be
-overridden using these parameters is a subset of the headers that Zenko
-accepts when an object is created, including ``Content-Type``,
-``Content-Language``, ``Expires``, ``Cache-Control``,
-``Content-Disposition``, and ``Content-Encoding``.
+response header values are sent only on a successful request, one in which a
+status code *200 OK* is returned. The set of headers that can be overridden
+using these parameters is a subset of the headers that Zenko accepts when an
+object is created, including ``Content-Type``, ``Content-Language``,
+``Expires``, ``Cache-Control``, ``Content-Disposition``, and
+``Content-Encoding``.
 
 .. note::
 
@@ -113,45 +113,70 @@ Headers`).
 .. tabularcolumns:: X{0.25\textwidth}X{0.10\textwidth}X{0.60\textwidth}
 .. table::
 
-   +-------------------------+--------+----------------------------------------+
-   | Header                  | Type   | Description                            |
-   +=========================+========+========================================+
-   | ``If-Modified-Since``   | string | Return the object only if it has been  |
-   |                         |        | modified since the specified time,     |
-   |                         |        | otherwise return a ``304`` (not        |
-   |                         |        | modified).                             |
-   |                         |        |                                        |
-   |                         |        | **Default:** None                      |
-   |                         |        |                                        |
-   |                         |        | **Constraints:** None                  |
-   +-------------------------+--------+----------------------------------------+
-   | ``If-Unmodified-Since`` | string | Return the object only if it has not   |
-   |                         |        | been modified since the specified      |
-   |                         |        | time, otherwise return a ``412``       |
-   |                         |        | (precondition failed).                 |
-   |                         |        |                                        |
-   |                         |        | **Default:** None                      |
-   |                         |        |                                        |
-   |                         |        | **Constraints:** None                  |
-   +-------------------------+--------+----------------------------------------+
-   | ``If-Match``            | string | Return the object only if its entity   |
-   |                         |        | tag (ETag) is the same as the one      |
-   |                         |        | specified; otherwise, return a ``412`` |
-   |                         |        | (precondition failed).                 |
-   |                         |        |                                        |
-   |                         |        | **Default:** None                      |
-   |                         |        |                                        |
-   |                         |        | **Constraints:** None                  |
-   +-------------------------+--------+----------------------------------------+
-   | ``If-None-Match``       | string | Return the object only if its entity   |
-   |                         |        | tag (ETag) is different from the one   |
-   |                         |        | specified; otherwise, return a ``304`` |
-   |                         |        | (not modified)                         |
-   |                         |        |                                        |
-   |                         |        | **Default:** None                      |
-   |                         |        |                                        |
-   |                         |        | **Constraints:** None                  |
-   +-------------------------+--------+----------------------------------------+
+   +-------------------------------+--------+----------------------------------------+
+   | Header                        | Type   | Description                            |
+   +===============================+========+========================================+
+   | ``If-Modified-Since``         | string | Return the object only if it has been  |
+   |                               |        | modified since the specified time,     |
+   |                               |        | otherwise return a ``304`` (not        |
+   |                               |        | modified).                             |
+   |                               |        |                                        |
+   |                               |        | **Default:** None                      |
+   |                               |        |                                        |
+   |                               |        | **Constraints:** None                  |
+   +-------------------------------+--------+----------------------------------------+
+   | ``If-Unmodified-Since``       | string | Return the object only if it has not   |
+   |                               |        | been modified since the specified      |
+   |                               |        | time, otherwise return a ``412``       |
+   |                               |        | (precondition failed).                 |
+   |                               |        |                                        |
+   |                               |        | **Default:** None                      |
+   |                               |        |                                        |
+   |                               |        | **Constraints:** None                  |
+   +-------------------------------+--------+----------------------------------------+
+   | ``If-Match``                  | string | Return the object only if its entity   |
+   |                               |        | tag (ETag) is the same as the one      |
+   |                               |        | specified; otherwise, return a ``412`` |
+   |                               |        | (precondition failed).                 |
+   |                               |        |                                        |
+   |                               |        | **Default:** None                      |
+   |                               |        |                                        |
+   |                               |        | **Constraints:** None                  |
+   +-------------------------------+--------+----------------------------------------+
+   | ``If-None-Match``             | string | Return the object only if its entity   |
+   |                               |        | tag (ETag) is different from the one   |
+   |                               |        | specified; otherwise, return a ``304`` |
+   |                               |        | (not modified)                         |
+   |                               |        |                                        |
+   |                               |        | **Default:** None                      |
+   |                               |        |                                        |
+   |                               |        | **Constraints:** None                  |
+   +-------------------------------+--------+----------------------------------------+
+   | ``x-amz-location-constraint`` | string | Return object from the location        |
+   |                               |        | specified here. Location value must be |
+   |                               |        | a valid Zenko location name to which   |
+   |                               |        | the object has been replicated, or an  |
+   |                               |        | error is returned.                     |
+   |                               |        |                                        |
+   |                               |        | **Default:** None                      |
+   |                               |        |                                        |
+   |                               |        | **Constraints:** Location name         |
+   |                               |        | provided in header must be a valid     |
+   |                               |        | replication target.                    |
+   +-------------------------------+--------+----------------------------------------+
+
+Users can specify in a GET request a location from which to read the object by
+providing the custom "x-amz-location-constraint" header and the name of the
+alternate location as value. Using this request, header, and location, an object
+can be retrieved even if the object is unavailable in the original/preferred
+location. The location value must be a valid Zenko location name to which the
+object has been replicated, or an error is returned.
+
+.. note::
+
+   This Zenko extension is not available in the standard S3 API. While
+   applications may be modified to use this header for greater availability,
+   doing so may incur egress fees for the specified cloud.
 
 Elements
 ~~~~~~~~
@@ -213,6 +238,7 @@ Headers
    |                                     |         |                           |
    |                                     |         | **Default:** None         |
    +-------------------------------------+---------+---------------------------+
+
 
 Elements
 ~~~~~~~~


### PR DESCRIPTION
added x-amz-location-constraint header for GET object API.

This PR adds brief documentation for the x-amz-location-constraint GET object header. It also adds "mk8s 2.4 or later" to the cluster setup instructions.

This resolves ZENKO-2322 and addresses the simple part of ZENKOIO-138.

