### PR TITLE
charts/cosmos: properly support `Pod` settings

### DIFF
--- a/kubernetes/cosmos/templates/rclone-cronjob.yaml
+++ b/kubernetes/cosmos/templates/rclone-cronjob.yaml
@@ -74,6 +74,20 @@ spec:
                 mountPath: /root/.config/rclone
               - name: backend-storage
                 mountPath: {{ template "cosmos.src" . }}
+            resources:
+{{ toYaml .Values.rclone.resources | indent 14 }}
+    {{- with .Values.rclone.nodeSelector }}
+          nodeSelector:
+{{ toYaml . | indent 12 }}
+    {{- end }}
+    {{- with .Values.rclone.affinity }}
+          affinity:
+{{ toYaml . | indent 12 }}
+    {{- end }}
+    {{- with .Values.rclone.tolerations }}
+          tolerations:
+{{ toYaml . | indent 12 }}
+    {{- end }}
           volumes:
           - name: rclone-config
             configMap:


### PR DESCRIPTION
Despite being listed in `values.yaml`, `Pod` settings for `rclone`
`Pod`s (started as a `Job` or `CronJob`) were simply ignored.

This patch ensures they're taken into account when rendering the
relevant templates.

Note: this is utterly untested (though @xaf-scality may test it by patching the `cosmos-operator` container FS in-place...) except for running `helm template` and manually reviewing the result.