### PR TITLE
Documentation/zenko 2350 support for 3 servers

### DIFF
--- a/docs/docsource/installation/prepare/setting_up_a_cluster.rst
+++ b/docs/docsource/installation/prepare/setting_up_a_cluster.rst
@@ -30,12 +30,18 @@ clusters, where such resources are available on demand.
 General Cluster Requirements
 ----------------------------
 
-Setting up a cluster requires at least three machines (these can be VMs)
-running CentOS_ 7.4 or higher. The recommended mimimum for a high-availability
-Zenko production service is five server nodes with three masters/etcds, but for
-testing and familiarization, three masters and three nodes is fine. The cluster
-must have an odd number of nodes to provide a quorum. You must have SSH access
-to these machines and they must have SSH access to each other.
+Setting up a cluster requires at least three machines (these can be VMs) running
+CentOS_ 7.4 or higher. The recommended mimimum for a high-availability Zenko
+production service is five server nodes with three masters/etcds, but three-node
+configurations are also supported. The cluster must have an odd number of nodes to provide a
+quorum. You must have SSH access to these machines and they must have SSH access
+to each other.
+
+.. important::
+   
+   Three-server clusters can continue to operate without service disruption or
+   data loss if one node fails. Five-server clusters can operate without
+   disruption or loss if two nodes fail.
 
 Each machine acting as a Kubernetes_ node must also have at least one disk
 available to provision storage volumes.

--- a/docs/docsource/installation/prepare/setting_up_a_cluster.rst
+++ b/docs/docsource/installation/prepare/setting_up_a_cluster.rst
@@ -3,18 +3,19 @@
 Setting Up a Cluster
 ====================
 
-While running Zenko on a single machine is desirable for certain use cases,
-a clustered operating environment is required for high-availability deployments.
+While running Zenko on a single machine is desirable for certain use cases, a
+clustered operating environment is required for high-availability deployments.
 If you can set up a Kubernetes cluster on your own, review the :ref:`General
-Cluster Requirements` and skip to :ref:`Install_Zenko`. Otherwise, 
-`download MetalK8s <https://github.com/scality/metalk8s/releases>`_
-and follow its instructions (or review the requirements and instructions in 
-Zenko/docs/gke.md) to establish a working Kubernetes instance on your cluster.
+Cluster Requirements` and skip to :ref:`Install_Zenko`. Otherwise, download `the
+latest stable version of MetalK8s
+<https://github.com/scality/metalk8s/releases>`_ and follow its instructions to
+establish a working Kubernetes instance on your cluster.
 
 .. note: 
    
-   Zenko 1.1 will not install with a Kubernetes instance older than version
-   1.11.3. Scality recommends MetalK8s 1.1, which installs Kubernetes v. 1.11.3.
+   Zenko 1.1 and later are not compatible with Kubernetes instances before
+   version |min_kubernetes|. Scality recommends MetalK8s 2.4 or later, which
+   satisfies this requirement.
 
 Most of the complexity of installing Zenko on a cluster involves deploying the
 cluster istelf. Scality supports MetalK8s_, an open source Kubernetes engine
@@ -30,10 +31,10 @@ General Cluster Requirements
 ----------------------------
 
 Setting up a cluster requires at least three machines (these can be VMs)
-running CentOS_ 7.4 or higher (The recommended mimimum for a high-availability
+running CentOS_ 7.4 or higher. The recommended mimimum for a high-availability
 Zenko production service is five server nodes with three masters/etcds, but for
 testing and familiarization, three masters and three nodes is fine. The cluster
-must have an odd number of nodes to provide a quorum). You must have SSH access
+must have an odd number of nodes to provide a quorum. You must have SSH access
 to these machines and they must have SSH access to each other.
 
 Each machine acting as a Kubernetes_ node must also have at least one disk
@@ -45,6 +46,3 @@ it.
 .. _MetalK8s: https://github.com/scality/metalk8s/
 .. _CentOS: https://www.centos.org
 .. _Kubernetes: https://kubernetes.io
-
-
-

--- a/docs/docsource/installation/prepare/setting_up_a_cluster.rst
+++ b/docs/docsource/installation/prepare/setting_up_a_cluster.rst
@@ -32,10 +32,11 @@ General Cluster Requirements
 
 Setting up a cluster requires at least three machines (these can be VMs) running
 CentOS_ 7.4 or higher. The recommended mimimum for a high-availability Zenko
-production service is five server nodes with three masters/etcds, but three-node
-configurations are also supported. The cluster must have an odd number of nodes to provide a
-quorum. You must have SSH access to these machines and they must have SSH access
-to each other.
+production service is the Standard Architecture, a five-node server with three
+masters/etcds. The Compact Architecture, a three-node configuration, is also
+supported. The cluster must have an odd number of nodes to provide a quorum. You
+must have SSH access to these machines and they must have SSH access to each
+other.
 
 .. important::
    
@@ -48,6 +49,74 @@ available to provision storage volumes.
 
 Once you have set up a cluster, you cannot change the size of the machines on
 it.
+
+Service and Component Architecture
+----------------------------------
+
+Zenko consists of the following stateful and stateless services.
+
+Stateful Services
+~~~~~~~~~~~~~~~~~
+
+For the following stateful services, each node has a copy of the data. Though
+their terminology varies, each service employs the same strategy for maintaining
+availability. A primary service acts on data and transfers it to replica
+instances on the other nodes. If the service running as the primary fails
+(either due to internal error or node failure), the remaining replica services
+elect a primary to continue. If this occurs on a three-node cluster, no data is
+lost unless two nodes fail. On a five-node cluster, no data is lost unless three
+nodes fail.
+
+If a replica node fails, the primary continues operation without interruption
+or an election.
+
+The following stateful services conform to this failover strategy:
+
+  * MongoDB
+  * Redis
+  * Kafka
+  * ZooKeeper
+
+Stateless Services
+~~~~~~~~~~~~~~~~~~
+
+The following stateless services are based on a transactional model. If a
+service fails, Kubernetes automatically reschedules the process on an available
+node.
+
+**Lifecycle Services**
+
+  * Lifecycle Bucket Processor
+  * Lifecycle Conductor
+  * Lifecycle Object Processor
+  * Garbage Collection (GC) Consumer
+
+**Replication Services**
+
+  * Replication Data Processor
+  * Replication Populator
+  * Replication Status Processor
+
+**APIs**
+
+  * CloudServer API
+  * Backbeat API
+
+**Monitoring Services**
+
+  * Prometheus
+  * Grafana
+
+**Out-of-Band Services**
+
+  * Ingestion Consumer
+  * Ingestion Producer
+  * Cosmos Operator
+  * Cosmos Scheduler
+
+**Orbit Management Layer**
+
+  * CloudServer Manager
 
 .. _MetalK8s: https://github.com/scality/metalk8s/
 .. _CentOS: https://www.centos.org

--- a/docs/docsource/reference/object_operations/get_object.rst
+++ b/docs/docsource/reference/object_operations/get_object.rst
@@ -3,18 +3,18 @@
 GET Object
 ==========
 
-To use GET Object, it is necessary to have READ access to the target
-object. If READ access is granted to an anonymous user, the object can
-be returned without using an authorization header.
+Using GET Object requires read access to the target object. If read access is
+granted to an anonymous user, the object can be returned without using an
+authorization header.
 
 By default, the GET Object operation returns the current version of an
 object. To return a different version, use the versionId subresource.
 
 .. tip::
 
-  If the current version of the object is a delete marker, Zenko behaves
-  as if the object was deleted and includes x-amz-delete-marker: true in
-  the response.
+  If the current version of the object is a delete marker, Zenko behaves as if
+  the object were deleted and includes ``x-amz-delete-marker: true`` in the
+  response.
 
 Requests
 --------
@@ -35,12 +35,12 @@ Parameters
 
 Values for a set of response headers can be overridden in the GET Object
 response using the query parameters listed in the following table. These
-response header values are sent only on a successful request, one in
-which a status code *200 OK* is returned. The set of headers that can be
-overridden using these parameters is a subset of the headers that Zenko
-accepts when an object is created, including ``Content-Type``,
-``Content-Language``, ``Expires``, ``Cache-Control``,
-``Content-Disposition``, and ``Content-Encoding``.
+response header values are sent only on a successful request, one in which a
+status code *200 OK* is returned. The set of headers that can be overridden
+using these parameters is a subset of the headers that Zenko accepts when an
+object is created, including ``Content-Type``, ``Content-Language``,
+``Expires``, ``Cache-Control``, ``Content-Disposition``, and
+``Content-Encoding``.
 
 .. note::
 
@@ -113,45 +113,70 @@ Headers`).
 .. tabularcolumns:: X{0.25\textwidth}X{0.10\textwidth}X{0.60\textwidth}
 .. table::
 
-   +-------------------------+--------+----------------------------------------+
-   | Header                  | Type   | Description                            |
-   +=========================+========+========================================+
-   | ``If-Modified-Since``   | string | Return the object only if it has been  |
-   |                         |        | modified since the specified time,     |
-   |                         |        | otherwise return a ``304`` (not        |
-   |                         |        | modified).                             |
-   |                         |        |                                        |
-   |                         |        | **Default:** None                      |
-   |                         |        |                                        |
-   |                         |        | **Constraints:** None                  |
-   +-------------------------+--------+----------------------------------------+
-   | ``If-Unmodified-Since`` | string | Return the object only if it has not   |
-   |                         |        | been modified since the specified      |
-   |                         |        | time, otherwise return a ``412``       |
-   |                         |        | (precondition failed).                 |
-   |                         |        |                                        |
-   |                         |        | **Default:** None                      |
-   |                         |        |                                        |
-   |                         |        | **Constraints:** None                  |
-   +-------------------------+--------+----------------------------------------+
-   | ``If-Match``            | string | Return the object only if its entity   |
-   |                         |        | tag (ETag) is the same as the one      |
-   |                         |        | specified; otherwise, return a ``412`` |
-   |                         |        | (precondition failed).                 |
-   |                         |        |                                        |
-   |                         |        | **Default:** None                      |
-   |                         |        |                                        |
-   |                         |        | **Constraints:** None                  |
-   +-------------------------+--------+----------------------------------------+
-   | ``If-None-Match``       | string | Return the object only if its entity   |
-   |                         |        | tag (ETag) is different from the one   |
-   |                         |        | specified; otherwise, return a ``304`` |
-   |                         |        | (not modified)                         |
-   |                         |        |                                        |
-   |                         |        | **Default:** None                      |
-   |                         |        |                                        |
-   |                         |        | **Constraints:** None                  |
-   +-------------------------+--------+----------------------------------------+
+   +-------------------------------+--------+----------------------------------------+
+   | Header                        | Type   | Description                            |
+   +===============================+========+========================================+
+   | ``If-Modified-Since``         | string | Return the object only if it has been  |
+   |                               |        | modified since the specified time,     |
+   |                               |        | otherwise return a ``304`` (not        |
+   |                               |        | modified).                             |
+   |                               |        |                                        |
+   |                               |        | **Default:** None                      |
+   |                               |        |                                        |
+   |                               |        | **Constraints:** None                  |
+   +-------------------------------+--------+----------------------------------------+
+   | ``If-Unmodified-Since``       | string | Return the object only if it has not   |
+   |                               |        | been modified since the specified      |
+   |                               |        | time, otherwise return a ``412``       |
+   |                               |        | (precondition failed).                 |
+   |                               |        |                                        |
+   |                               |        | **Default:** None                      |
+   |                               |        |                                        |
+   |                               |        | **Constraints:** None                  |
+   +-------------------------------+--------+----------------------------------------+
+   | ``If-Match``                  | string | Return the object only if its entity   |
+   |                               |        | tag (ETag) is the same as the one      |
+   |                               |        | specified; otherwise, return a ``412`` |
+   |                               |        | (precondition failed).                 |
+   |                               |        |                                        |
+   |                               |        | **Default:** None                      |
+   |                               |        |                                        |
+   |                               |        | **Constraints:** None                  |
+   +-------------------------------+--------+----------------------------------------+
+   | ``If-None-Match``             | string | Return the object only if its entity   |
+   |                               |        | tag (ETag) is different from the one   |
+   |                               |        | specified; otherwise, return a ``304`` |
+   |                               |        | (not modified)                         |
+   |                               |        |                                        |
+   |                               |        | **Default:** None                      |
+   |                               |        |                                        |
+   |                               |        | **Constraints:** None                  |
+   +-------------------------------+--------+----------------------------------------+
+   | ``x-amz-location-constraint`` | string | Return object from the location        |
+   |                               |        | specified here. Location value must be |
+   |                               |        | a valid Zenko location name to which   |
+   |                               |        | the object has been replicated, or an  |
+   |                               |        | error is returned.                     |
+   |                               |        |                                        |
+   |                               |        | **Default:** None                      |
+   |                               |        |                                        |
+   |                               |        | **Constraints:** Location name         |
+   |                               |        | provided in header must be a valid     |
+   |                               |        | replication target.                    |
+   +-------------------------------+--------+----------------------------------------+
+
+Users can specify in a GET request a location from which to read the object by
+providing the custom "x-amz-location-constraint" header and the name of the
+alternate location as value. Using this request, header, and location, an object
+can be retrieved even if the object is unavailable in the original/preferred
+location. The location value must be a valid Zenko location name to which the
+object has been replicated, or an error is returned.
+
+.. note::
+
+   This Zenko extension is not available in the standard S3 API. While
+   applications may be modified to use this header for greater availability,
+   doing so may incur egress fees for the specified cloud.
 
 Elements
 ~~~~~~~~
@@ -213,6 +238,7 @@ Headers
    |                                     |         |                           |
    |                                     |         | **Default:** None         |
    +-------------------------------------+---------+---------------------------+
+
 
 Elements
 ~~~~~~~~


### PR DESCRIPTION
This PR adds the changes requested in ZENKO-2350 concerning support for 3-node clusters.

