### PR TITLE
charts: Add support for PVC 'spec.selector'

### DIFF
--- a/kubernetes/zenko/charts/grafana/templates/pvc.yaml
+++ b/kubernetes/zenko/charts/grafana/templates/pvc.yaml
@@ -21,4 +21,8 @@ spec:
     requests:
       storage: {{ .Values.persistence.size | quote }}
   storageClassName: {{ .Values.persistence.storageClassName }}
+  {{- if .Values.persistence.selector }}
+  selector:
+{{ toYaml .Values.persistence.selector | indent 4 }}
+  {{- end }}
 {{- end -}}

--- a/kubernetes/zenko/charts/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/kubernetes/zenko/charts/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -354,6 +354,10 @@ spec:
         storageClassName: "{{ .Values.persistentVolume.storageClass }}"
       {{- end }}
       {{- end }}
+      {{- if .Values.persistentVolume.selector }}
+        selector:
+{{ toYaml .Values.persistentVolume.selector | indent 10 }}
+      {{- end }}
 {{- else }}
         - name: datadir
           emptyDir: {}

--- a/kubernetes/zenko/charts/prometheus/templates/alertmanager-statefulset.yaml
+++ b/kubernetes/zenko/charts/prometheus/templates/alertmanager-statefulset.yaml
@@ -124,6 +124,10 @@ spec:
         storageClassName: "{{ .Values.alertmanager.persistentVolume.storageClass }}"
       {{- end }}
       {{- end }}
+      {{- if .Values.alertmanager.persistentVolume.selector }}
+        selector:
+{{ toYaml .Values.alertmanager.persistentVolume.selector | indent 10 }}
+      {{- end }}
 {{- else }}
         - name: storage-volume
           emptyDir: {}

--- a/kubernetes/zenko/charts/prometheus/templates/server-statefulset.yaml
+++ b/kubernetes/zenko/charts/prometheus/templates/server-statefulset.yaml
@@ -199,6 +199,10 @@ spec:
         storageClassName: "{{ .Values.server.persistentVolume.storageClass }}"
       {{- end }}
       {{- end }}
+      {{- if .Values.server.persistentVolume.selector }}
+        selector:
+{{ toYaml .Values.server.persistentVolume.selector | indent 10 }}
+      {{- end }}
 {{- else }}
         - name: storage-volume
           emptyDir: {}

--- a/kubernetes/zenko/charts/redis-ha/templates/redis-ha-statefulset.yaml
+++ b/kubernetes/zenko/charts/redis-ha/templates/redis-ha-statefulset.yaml
@@ -273,6 +273,10 @@ spec:
       storageClassName: "{{ .Values.persistentVolume.storageClass }}"
     {{- end }}
     {{- end }}
+    {{- if .Values.persistentVolume.selector }}
+      selector:
+{{ toYaml .Values.persistentVolume.selector | indent 8 }}
+    {{- end }}
 {{- else if .Values.hostPath.path }}
       - name: data
         hostPath:

--- a/kubernetes/zenko/charts/s3-data/templates/pvc.yaml
+++ b/kubernetes/zenko/charts/s3-data/templates/pvc.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.persistentVolume.enabled -}}
-{{- if not .Values.persistentVolume.existingClaim -}}
+{{- if and .Values.persistentVolume.enabled (not .Values.persistentVolume.existingClaim) -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -16,18 +15,21 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   accessModes:
-{{- range .Values.persistentVolume.accessModes }}
+  {{- range .Values.persistentVolume.accessModes }}
     - {{ . | quote }}
-{{- end }}
+  {{- end }}
   resources:
     requests:
       storage: {{ .Values.persistentVolume.size | quote }}
-{{- if .Values.persistentVolume.storageClass }}
-{{- if (eq "-" .Values.persistentVolume.storageClass) }}
+  {{- if .Values.persistentVolume.storageClass }}
+    {{- if (eq "-" .Values.persistentVolume.storageClass) }}
   storageClassName: ""
-{{- else }}
+    {{- else }}
   storageClassName: "{{ .Values.persistentVolume.storageClass }}"
-{{- end }}
-{{- end }}
-{{- end -}}
+    {{- end }}
+  {{- end }}
+  {{- if .Values.persistentVolume.selector }}
+  selector:
+{{ toYaml .Values.persistentVolume.selector | indent 4 }}
+  {{- end }}
 {{- end -}}

--- a/kubernetes/zenko/charts/zenko-queue/templates/statefulset.yaml
+++ b/kubernetes/zenko/charts/zenko-queue/templates/statefulset.yaml
@@ -237,10 +237,14 @@ spec:
         requests:
           storage: {{ .Values.persistence.size }}
       {{- if .Values.persistence.storageClass }}
-      {{- if (eq "-" .Values.persistence.storageClass) }}
+        {{- if (eq "-" .Values.persistence.storageClass) }}
       storageClassName: ""
-      {{- else }}
+        {{- else }}
       storageClassName: "{{ .Values.persistence.storageClass }}"
+        {{- end }}
       {{- end }}
+      {{- if .Values.persistence.selector }}
+      selector:
+{{ toYaml .Values.persistence.selector | indent 8 }}
       {{- end }}
   {{- end }}

--- a/kubernetes/zenko/charts/zenko-quorum/templates/statefulset.yaml
+++ b/kubernetes/zenko/charts/zenko-quorum/templates/statefulset.yaml
@@ -184,4 +184,8 @@ spec:
         storageClassName: "{{ .Values.persistence.storageClass }}"
         {{- end }}
       {{- end }}
+      {{- if .Values.persistence.selector }}
+        selector:
+{{ toYaml .Values.persistence.selector | indent 10 }}
+      {{- end }}
 {{- end }}

--- a/kubernetes/zenko/storage.yaml
+++ b/kubernetes/zenko/storage.yaml
@@ -28,6 +28,9 @@ mongodb-replicaset:
       - ReadWriteOnce
     size: 50Gi
     annotations: {}
+    # selector:
+    #   matchLabels:
+    #     app: mongodb-replicaset
 
 prometheus:
   server:
@@ -49,6 +52,9 @@ prometheus:
       ## Useful if the volume's root directory is not empty
       ##
       subPath: ""
+      # selector:
+      #   matchLabels:
+      #     app: prometheus
 
 redis-ha:
   ## Notes:
@@ -62,6 +68,9 @@ redis-ha:
       - ReadWriteOnce
     size: 10Gi
     annotations: {}
+    # selector:
+    #   matchLabels:
+    #     app: redis-ha
 
 s3-data:
   ## Notes: 
@@ -78,6 +87,9 @@ s3-data:
     existingClaim: ""
     size: 90Gi
     storageClass: null
+    # selector:
+    #   matchLabels:
+    #     app: s3-data
  
 zenko-queue:
   ## Notes:
@@ -96,6 +108,9 @@ zenko-queue:
     ##
     mountPath: "/opt/kafka/data"
     storageClass: null
+    # selector:
+    #   matchLabels:
+    #     app: zenko-queue
 
 zenko-quorum:
   ## Notes:
@@ -107,3 +122,6 @@ zenko-quorum:
     storageClass: null
     accessMode: ReadWriteOnce
     size: 5Gi
+    # selector:
+    #   matchLabels:
+    #     app: zenko-quorum


### PR DESCRIPTION
When pre-provisioning PersistentVolumes for a Zenko deployment, one may
not want to (and should not) use one StorageClass per StatefulSet, and
instead will likely want to rely on some form of selector to match PVs
with the PVCs generated by the StatefulSet.
To support this, we add this option to each chart supporting persistent
storage, either under `.persistentVolume.selector` or
`.persistence.selector`, depending on the individual chart.

Fixes: ZENKO-2424