### PR TITLE
charts/cosmos: properly support `Pod` settings

### DIFF
--- a/kubernetes/cosmos/templates/rclone-cronjob.yaml
+++ b/kubernetes/cosmos/templates/rclone-cronjob.yaml
@@ -74,6 +74,20 @@ spec:
                 mountPath: /root/.config/rclone
               - name: backend-storage
                 mountPath: {{ template "cosmos.src" . }}
+            resources:
+{{ toYaml .Values.rclone.resources | indent 14 }}
+    {{- with .Values.rclone.nodeSelector }}
+          nodeSelector:
+{{ toYaml . | indent 12 }}
+    {{- end }}
+    {{- with .Values.rclone.affinity }}
+          affinity:
+{{ toYaml . | indent 12 }}
+    {{- end }}
+    {{- with .Values.rclone.tolerations }}
+          tolerations:
+{{ toYaml . | indent 12 }}
+    {{- end }}
           volumes:
           - name: rclone-config
             configMap:


### PR DESCRIPTION
Despite being listed in `values.yaml`, `Pod` settings for `rclone`
`Pod`s (started as a `Job` or `CronJob`) were simply ignored.

This patch ensures they're taken into account when rendering the
relevant templates.

<!--
Thank you for contributing to Zenko!

Please enter applicable information below.
-->

**What does this PR do, and why do we need it?**

**Which issue does this PR fix?**

fixes #<ISSUE>

**Special notes for your reviewers**:
