### PR TITLE
documentation: ZENKO-2437 fix error in cloudserver get completions AP…

### DIFF
--- a/docs/docsource/reference/cloudserver/backbeat/metrics/get_completions.rst
+++ b/docs/docsource/reference/cloudserver/backbeat/metrics/get_completions.rst
@@ -3,8 +3,8 @@
 Get Completions
 ===============
 
-This route returns the replication completions in number of objects and number
-of total bytes transferred for the specified extension type and location.
+This route returns the replication completions in number of operations and
+number of total bytes transferred for the specified extension type and location.
 Completions are only collected up to an EXPIRY time, set to **15 minutes** by
 default
 


### PR DESCRIPTION
This fixes an error discovered in the CloudServer API documentation for S3C

This fixes #ZENKO-2437
