### PR TITLE
documentation: ZENKO-2409_install_guide_walkthru_changes

### DIFF
--- a/docs/docsource/installation/configure/configure_ingress.rst
+++ b/docs/docsource/installation/configure/configure_ingress.rst
@@ -20,21 +20,22 @@ directory:
 3. Set Zenko chart values in options.yaml to resemble::
 
      ingress:
-       enabled: true
+       enabled: "true"
+       annotations:
        hosts:
          - zenko.local
        max_body_size: 100m
-       annotations:
        tls:
          - secretName: zenko-tls
            hosts:
              - zenko.local
 
-4. Install or upgrade Zenko from this directory (Zenko/kubernetes/zenko). Helm
+4. Install or upgrade Zenko from this directory (Zenko/kubernetes). Helm
    will pick up the settings in options.yaml.
+
    ::
 
-     $ helm upgrade --install -f options.yaml zenko .
+     $ helm upgrade --install ./zenko -f options.yaml
 
 Ports
 -----

--- a/docs/docsource/installation/configure/configuring_zenko.rst
+++ b/docs/docsource/installation/configure/configuring_zenko.rst
@@ -25,18 +25,17 @@ these instructions will remain valid and portable to the production system.
 Modify options.yaml
 -------------------
 
-The options.yaml file is not present by default, but you added a simple one
-at Zenko/kubernetes/zenko/options.yaml when
-:ref:`deploying Zenko<create_options.yaml>`. options.yaml is
-the best place to make all changes to your configuration (with one 
-exception, nodeCounts). While it is possible to reconfigure any aspect of
-Zenko or its attendant microservices from those services' base settings or in
-the Zenko settings, it is better to make changes to options.yaml. Because
-options.yaml is not a part of the base installation, it is not overwritten
-on a Zenko version upgrade. Likewise, finding changes written to several 
-values.yaml file locations can become quite difficult and cumbersome. For 
-these reasons, it is a best practice to *confine all modifications to 
-options.yaml.*
+The options.yaml file is not present by default, but you added a simple one at
+Zenko/kubernetes/options.yaml when :ref:`deploying
+Zenko<create_options.yaml>`. options.yaml is the best place to make all changes
+to your configuration (with one exception, nodeCounts). While it is possible to
+reconfigure any aspect of Zenko or its attendant microservices from those
+services' base settings or in the Zenko settings, it is better to make changes
+to options.yaml. Because options.yaml is not a part of the base installation, it
+is not overwritten on a Zenko version upgrade. Likewise, finding changes written
+to several values.yaml file locations can become quite difficult and
+cumbersome. For these reasons, it is a best practice to *confine all
+modifications to options.yaml.*
 
 **Examples:**
 
@@ -50,7 +49,7 @@ default. To deactivate Cosmos:
       cosmos:
         enabled: true
 
-#. Open (or create) Zenko/kubernetes/zenko/options.yaml and paste the
+#. Open (or create) Zenko/kubernetes/options.yaml and paste the
    block you copied there. 
 #. Change the value of ``enabled`` to ``false``.
 
@@ -88,7 +87,7 @@ Push Modifications to Zenko
 ---------------------------
 
 Once you have entered all changes to options.yaml or changed the values.yaml
-nodeCount parameter, issue the following command from Zenko/kubernetes/zenko
+nodeCount parameter, issue the following command from Zenko/kubernetes
 to push your changes to the deployed Zenko instance::
 
-   $ helm upgrade {{zenko-server-name}} . -f options.yaml
+   $ helm upgrade {{zenko-server-name}} ./zenko -f options.yaml 

--- a/docs/docsource/installation/install/install_helm.rst
+++ b/docs/docsource/installation/install/install_helm.rst
@@ -3,25 +3,40 @@
 Install Helm
 ============
 
-1. If you are using MetalK8s, use the MetalK8s virtual shell. Change to the
-   directory from which you will deploy Zenko:
+1. Change to the directory from which you will deploy Zenko:
 
    ::
 
-    (metal-k8s) $ cd /path/to/installation
-
-   If you are not installing from MetalK8s, follow the instructions in
-   Zenko/docs/gke.md to install Helm on your cluster.
+     $ cd /path/to/installation
 
 2. If Helm is not already installed on the machine from which you will be 
-   conducting the deployment, install it as described at: 
-   https://github.com/helm/helm#Install
+   conducting the deployment, install Helm on your cluster.
+   as described at:  https://github.com/helm/helm#Install
+
+    a. Download Helm:
+
+       ::
+        
+         $ curl -LO "https://get.helm.sh/helm-v{{version-number}}-linux-amd64.tar.gz"
+
+    #. Unpack the tarball:
+
+       ::
+	  
+	 $ tar -xvzf helm-v{{version-number}}-linux-amd64.tar.gz
+
+    #. Add Helm to your PATH:
+
+       ::
+	  
+	 $ export PATH="$PATH:/path/to/helm"
+	 $ source ~/.bashrc
 
 3. Initialize Helm:
    
    ::
 
-    (metal-k8s) $ helm init
+    $ helm init
     Creating /home/centos/.helm
     Creating /home/centos/.helm/repository
     Creating /home/centos/.helm/repository/cache
@@ -36,7 +51,7 @@ Install Helm
     Warning: Tiller is already installed in the cluster.
     (Use --client-only to suppress this message, or --upgrade to upgrade Tiller to the current version.)
     Happy Helming!
-    (metal-k8s) $
+    $
 
    Helm can now install applications on the Kubernetes cluster.
 

--- a/docs/docsource/installation/prepare/configure_logical_volumes.rst
+++ b/docs/docsource/installation/prepare/configure_logical_volumes.rst
@@ -1,73 +1,44 @@
 .. _configure_logical_volumes:
 
-Configure Logical Volumes
-=========================
+Configuring Logical Volumes
+===========================
 
 Set up a cluster of nodes conforming to the specifications described in 
 :ref:`sizing`. If you are using MetalK8s, do this by downloading
-the latest stable MetalK8s source code from the MetalK8s releases page:
-https://github.com/scality/metalk8s/releases. Follow the Quickstart guide
-(in docs/usage/quickstart.rst) to install MetalK8s on your cluster,
-instantiating the desired number of nodes.
+`the latest release <latest-release_>`_, and
+following the `installation instructions <mk8s-install_>`_.
 
 .. note::
 
    It is a best practice to install Zenko on a fresh cluster.
 
-Volume Sizing
--------------
+When building your cluster, you must take sizing into account. It's easiest to
+use the MetalK8s GUI to set volume sizes. If you are deploying non-default
+sizing, make sure your volume sizing is sufficient.
 
-When building your cluster, take sizing into account. If you are deploying
-non-default sizing, make sure your volume sizing is sufficient. For MetalK8s,
-you *must* size the volumes in the inventory during setup in
-metalk8s/inventory/group_vars/kube-node.yml.
+For MetalK8s, you *must* size the volumes during setup. The easiest way to do
+this is to set the volume sizes when creating them, then to assign them
+using `the MetalK8s GUI <mk8s_volume_create_>`_.
+
+You can also control this from the command line by editing
+metalk8s/inventory/group_vars/kube-node.yml as described in :ref:`Setting Volume
+Sizes from the Command Line`.
 
 Minimum Volume Size for Cluster Deployments
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------------
 
-For a default sizing, paste the following into kube-node.yml:
+The following volume sizes are known good for a five-node cluster.
 
-.. code-block:: yaml
-		
-  metalk8s_lvm_default_vg: False
-  metalk8s_lvm_vgs: ['vg_metalk8s']
-  metalk8s_lvm_drives_vg_metalk8s: ['/dev/vdb']
-  metalk8s_lvm_lvs_vg_metalk8s:
-    lv01:
-      size: 125G
-    lv02:
-      size: 125G
-    lv03:
-      size: 125G
-    lv04:
-      size: 62G
-    lv05:
-      size: 62G
+For each node, one volume of each of the following sizes:
 
+- 6 GB
+- 10 GB
+- 12 GB
+- 22 GB
+- 54 GB
 
-Minimum Volume Size for Single-Server Deployments
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-For a default sizing, paste the following into kube-node.yml:
-
-.. code-block:: yaml
-		
-  metalk8s_lvm_default_vg: False
-  metalk8s_lvm_vgs: ['vg_metalk8s']
-  metalk8s_lvm_drives_vg_metalk8s: ['/dev/vdb']
-  metalk8s_lvm_lvs_vg_metalk8s:
-    lv01:
-      size: 120G
-    lv02:
-      size: 120G
-    lv03:
-      size: 120G
-    lv04:
-      size: 60G
-    lv05:
-      size: 60G
-    lv06:
-      size: 10G
+One additional 100 GB volume for S3 data, which can be bound to any of the
+nodes, is also required.
 
 Custom Sizing
 ~~~~~~~~~~~~~
@@ -77,3 +48,32 @@ increase these base numbers.
 
 For non-MetalK8s deployments, follow your vendor or community’s instructions for
 configuring persistent volumes at 500 GB/node.
+
+.. _Setting Volume Sizes from the Command Line:
+
+Setting Volume Sizes from the Command Line
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To configure the volume size from the command line, paste the following into
+kube-node.yml, with the sizes changed to suit your volumes:
+
+.. code-block:: yaml
+		
+  metalk8s_lvm_default_vg: False
+  metalk8s_lvm_vgs: ['vg_metalk8s']
+  metalk8s_lvm_drives_vg_metalk8s: ['/dev/vdb']
+  metalk8s_lvm_lvs_vg_metalk8s:
+    lv01:
+      size: 125G
+    lv02:
+      size: 125G
+    lv03:
+      size: 125G
+    lv04:
+      size: 62G
+    lv05:
+      size: 62G
+
+.. _latest-release: https://github.com/scality/metalk8s/releases
+.. _mk8s-install: https://metal-k8s.readthedocs.io/en/stable/installation/index.html
+.. _mk8s_volume_create: https://metal-k8s.readthedocs.io/en/stable/operation/volume_management/volume_creation_deletion_gui.html#volume-creation

--- a/docs/docsource/installation/prepare/setting_up_a_cluster.rst
+++ b/docs/docsource/installation/prepare/setting_up_a_cluster.rst
@@ -47,8 +47,6 @@ other.
 Each machine acting as a Kubernetes_ node must also have at least one disk
 available to provision storage volumes.
 
-Once you have set up a cluster, you cannot change the size of the machines on
-it.
 
 Service and Component Architecture
 ----------------------------------

--- a/docs/docsource/installation/prepare/sizing.rst
+++ b/docs/docsource/installation/prepare/sizing.rst
@@ -1,14 +1,15 @@
 .. _sizing:
 
-Sizing
-======
+========
+ Sizing
+========
 
 The following sizes for Zenko instances have been tested on live systems using
 MetalK8s, which adds some overhead. If you are running a different Kubernetes
 engine, fewer resources may be required, but such configurations remain to be
 tested.
 
-Reserve the following resources for each node.
+Reserve at least the following resources for each node.
 
 -  Cores per server
 
@@ -29,7 +30,7 @@ Reserve the following resources for each node.
 
 -  Storage
 
-   -  1 TB persistent volume per node minimum
+   -  200 GB persistent volume per node 
 
       .. note::
 
@@ -38,37 +39,39 @@ Reserve the following resources for each node.
         anticipated use. You may have to attach a separate storage volume to
         each cloud server instance.
 
-All servers must run CentOS 7.4 or later, and must be ssh-accessible.
+All servers must run CentOS 7.7 or later, with kernel version 3.10.0-1062.4.1 or
+later, and must be SSH-accessible.
 
 Custom Sizing
--------------
+=============
 
 The default persistent volume sizing requirements are sufficient for a
-conventional deployment. Your requirements may vary based on total data
-managed and total number of objects managed.
+conventional deployment. Your requirements may vary based on total data managed
+and total number of objects managed.
 
 .. Important::
 
-   Persistent volume storage must match or exceed the maximum
-   anticipated demand. Once set, the cluster cannot be resized
-   without redefining new volumes.
+   Persistent volume storage must match or exceed the maximum anticipated
+   demand. Once set, the cluster cannot be resized without redefining new
+   volumes.
 
-To size your deployment, review the default values in Zenko/kubernetes/zenko/\
-values.yaml. This file reserves space for each component
-in the build. This is the baseline build, which Helm will install unless
-instructed otherwise.
+To size your deployment, review the default values in
+Zenko/kubernetes/zenko/values.yaml. This file reserves space for each component
+in the build. values.yaml contains baseline build settings, which Helm installs
+unless instructed otherwise.
 
 Next, review the values discussed in Zenko/kubernetes/zenko/storage.yaml.
-The storage.yaml file contains sizing instructions and settings that, when
-specified in a Helm installation, override the default values expressed in the
-values.yaml file. To override default values using storage.yaml, use the
-following addendum to the ``helm install`` invocation at 
-:ref:`Zenko deployment<Install_Zenko>`.
+The storage.yaml file contains default sizing instructions and settings.
+
+To make changes, copy the default settings from values.yaml or storage.yaml to
+Zenko/kubernetes/options.yaml and modify the values there.
+
+To override default values using options.yaml, use the following addendum to the
+``helm install`` invocation at :ref:`Install_Zenko`.
 
 ::
 
-   $ helm install [other options] -f storage.yaml
-
+   $ helm install [other options] -f options.yaml
 
 How much persistent volume space is required is calculable based on total data
 managed, total objects managed, and other factors. See storage.yaml for details.

--- a/docs/docsource/installation/upgrade/upgrade_zenko.rst
+++ b/docs/docsource/installation/upgrade/upgrade_zenko.rst
@@ -1,11 +1,11 @@
-Upgrade
-=======
+Upgrading
+=========
 
 Once a Zenko instance is up and running, you can upgrade it with a
 simple Helm command. 
 
-Before Upgrading 
-----------------
+Before Upgrade
+--------------
 
 Most installations use custom values to set them up as required.
 Compare any live values to those to be applied in an
@@ -37,8 +37,8 @@ For example::
    their upgrade implications must be considered by both the Zenko and
    Kubernetes administrators.
 
-Upgrading
----------
+Upgrade
+-------
 
 To upgrade Zenko: 
 
@@ -53,7 +53,7 @@ To upgrade Zenko:
 
 #. Unpack the .zip or .tar.gz file and navigate to Zenko/kubernetes/. 
 
-#. Copy Zenko/kubernetes/zenko/options.yaml from your existing Zenko
+#. Copy Zenko/kubernetes/options.yaml from your existing Zenko
    source directory to the same directory in the new Zenko source.  
 
 #. If you have modified the node count from the default value of 3,
@@ -63,18 +63,20 @@ To upgrade Zenko:
 #. From the kubernetes/ directory of the new Zenko source, enter this
    Helm command, inserting your Zenko server's name:
 
-   :: 
-
+   ::
+      
       $ helm upgrade {{zenko-server-name}} ./zenko
 
    If you are using custom values, reuse options.yaml on upgrades.
+   
    ::
 
       $ helm upgrade {{zenko-server-name}} ./zenko -f options.yaml
 
 #. On success, Helm reports:
-   :: 
-
+   
+   ::
+      
       Release "{{zenko-server-name}}" has been upgraded. Happy Helming!
 
    After a few seconds, Helm displays a voluminous status report on the
@@ -84,93 +86,4 @@ To upgrade Zenko:
 
       Expect the cluster to take a few minutes to stabilize. You may see 
       CrashLoopBackoff errors. This is normal, expected behavior.
-
-Upgrading from 1.0.x to 1.1.x
------------------------------
-
-Zenko 1.0.x versions use MongoDB version 3.4, which has been upgraded to 3.6 in
-Zenko 1.1.x. Although upgrades using the commands above will work, some new
-features, specifically Cosmos (NFS integration) may not function with MongoDB
-3.4.
-
-To upgrade from 1.0.x to 1.1:
-
-#. Run the upgrade command, inserting your Zenko server's release name and
-   disabling the specific feature that depends on MongoDB 3.6.
-   ::
-
-     $ helm upgrade {{zenko-release-name}} ./zenko --set cosmos.enabled=false
-
-   If you are using custom values, be sure to reuse your options.yaml file on
-   any upgrade.
-   ::
-
-      $ helm upgrade {{zenko-server-name}} ./zenko --set cosmos.enabled=false -f options.yaml
-
-#. After the upgrade has stabilized all pod rollouts and prior functionality
-   is verified, run the following command to finalize the MongoDB compatibility
-   upgrade and enable the Cosmos feature set:
-   ::
-
-     $ helm upgrade {{zenko-release-name}} ./zenko --set maintenance.upgradeMongo=true -f options.yaml
-
-#. A pod is deployed. When the upgrade is successful, it shows a "Completed"
-   status.
-
-   ::
-
-     {{zenko-release-name}}-zenko-mongo-upgrade          0/1     Completed          0          4h
-
-   .. note::
-
-      Upgrade failures typically show up as an "Error" or "Crash" state.
-
-#. If, after a few minutes of stabilization, ``kubectl get pods`` shows a
-   CrashLoopBackoff error involving the mongodb-upgrade pod (rather than a
-   Completed status), manually upgrade MongoDB on the primary MongoDB
-   instance. To do this:
-
-   a. Find the primary MongoDB instance with a ``kubectl logs`` query:
-
-      :: 
-
-         kubectl logs -lcomponent=mongodb-upgrade
-
-      On a three-node Zenko cluster, this returns a response resembling:
-
-      ::
-
-         kubectl logs --selector component=mongodb-upgrade                                                                                                                       
-         Checking zenko-mongodb-replicaset-0.zenko-mongodb-replicaset.default.svc.cluster.local:27017 SECONDARY
-         Checking zenko-mongodb-replicaset-1.zenko-mongodb-replicaset.default.svc.cluster.local:27017 PRIMARY
-         Checking zenko-mongodb-replicaset-2.zenko-mongodb-replicaset.default.svc.cluster.local:27017 SECONDARY
-         Unable to upgrade capabilities, manual upgrade may be neccessary
-
-   #. Enter the following command, replicating the primary instance's pod name:
-
-      ::
-
-         kubectl exec -it {{primary-zenko-pod-name}} -- mongo --eval='db.adminCommand({ setFeatureCompatibilityVersion: "3.6" });'
-
-      In the present example, this command reads:
-
-      :: 
-
-         kubectl exec -it zenko-mongodb-replicaset-1 -- mongo --eval='db.adminCommand({ setFeatureCompatibilityVersion: "3.6" });'
-
-
-#. Validate the upgrade's successful by checking the logs. Any errors
-   encountered during the upgrade procedure are listed here as well.
-
-   ::
-
-     $ kubectl logs --selector component=mongodb-upgrade
-       Finished successfully! Compatibility set to version 3.6
-
-#. Once the upgrade is successful, these Zenko upgrade flags are no longer
-   needed for further 1.1.x upgrades. You can now run the typical upgrade command
-   to ensure the desired 1.1 state:
-   ::
-
-     $ helm upgrade {{zenko-release-name}} ./zenko -f options.yaml
 

--- a/docs/docsource/operation/Dashboards/Grafana.rst
+++ b/docs/docsource/operation/Dashboards/Grafana.rst
@@ -25,10 +25,9 @@ options.yaml, and may require further configurations.
 
 To enable application-level Grafana: 
 
-1. Open the options.yaml file for editing. Though it may be located
-   anywhere in your Zenko directory, if you followed the installation
-   instructions closely, you will find it at 
-   Zenko/kubernetes/zenko/options.yaml.
+1. Open the options.yaml file for editing. Though it may be located anywhere in
+   your Zenko directory, if you followed the installation instructions closely,
+   you will find it at Zenko/kubernetes/options.yaml.
 
 2. Add the following block to options.yaml:
    


### PR DESCRIPTION
Made changes recommended by TS walkthrough of Zenko install guide.

**What does this PR do, and why do we need it?**

This PR implements most of XF's walkthrough of MK8s/Zenko instructions. Expect further changes  as a result of my walkthrough in ZENKO-2421.

**Which issue does this PR fix?**

fixes #ZENKO-2409
