### PR TITLE
bf(ZENKO(2515): Add missing conditionals for opal

### DIFF
--- a/kubernetes/zenko/charts/opal/templates/blobserver/async-delete-cron.yaml
+++ b/kubernetes/zenko/charts/opal/templates/blobserver/async-delete-cron.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.blobserver.enabled -}}
 {{- $successfulJobsHistory :=  .Values.blobserver.asyncDeletes.successfulJobsHistory -}}
 {{- $failedJobsHistory :=  .Values.blobserver.asyncDeletes.failedJobsHistory -}}
 {{- $local := . -}}
@@ -47,4 +48,5 @@ spec:
                   value: "{{ .maxConcurrentProcs }}"
                 - name: BLOB_CONCURRENT_DELETES
                   value: "{{ .maxConcurrentDeletes }}"
+{{- end }}
 {{- end }}

--- a/kubernetes/zenko/charts/opal/templates/blobserver/deployment.yaml
+++ b/kubernetes/zenko/charts/opal/templates/blobserver/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.blobserver.enabled -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -102,4 +103,5 @@ spec:
           secret:
             secretName: {{ template "opal.fullname" . }}-kmip-cert
         {{- end }}
+{{- end }}
 {{- end }}

--- a/kubernetes/zenko/charts/opal/templates/blobserver/hpa.yaml
+++ b/kubernetes/zenko/charts/opal/templates/blobserver/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.blobserver.autoscaling.enabled -}}
+{{- if and .Values.blobserver.autoscaling.enabled .Values.blobserver.enabled -}}
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:

--- a/kubernetes/zenko/charts/opal/templates/blobserver/ingress.yaml
+++ b/kubernetes/zenko/charts/opal/templates/blobserver/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.blobserver.ingress.enabled -}}
+{{- if and .Values.blobserver.enabled .Values.blobserver.ingress.enabled -}}
 {{- $root := . -}}
 {{ $fullName := include "blobserver.fullname" . -}}
 {{- $servicePort := .Values.blobserver.service.port -}}

--- a/kubernetes/zenko/charts/opal/templates/blobserver/service.yaml
+++ b/kubernetes/zenko/charts/opal/templates/blobserver/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.blobserver.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -21,3 +22,4 @@ spec:
   selector:
     app: {{ template "blobserver.name" . }}
     release: {{ .Release.Name }}
+{{- end }}

--- a/kubernetes/zenko/charts/opal/templates/jabba/deployment.yaml
+++ b/kubernetes/zenko/charts/opal/templates/jabba/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.jabba.enabled -}}
+{{- if and .Values.blobserver.enabled .Values.jabba.enabled -}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/kubernetes/zenko/charts/opal/templates/jabba/hpa.yaml
+++ b/kubernetes/zenko/charts/opal/templates/jabba/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.jabba.autoscaling.enabled -}}
+{{- if and .Values.blobserver.enabled .Values.jabba.autoscaling.enabled -}}
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:

--- a/kubernetes/zenko/charts/opal/templates/jabba/ingress.yaml
+++ b/kubernetes/zenko/charts/opal/templates/jabba/ingress.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.jabba.enabled -}}
-{{ if .Values.jabba.ingress.enabled -}}
+{{- if and .Values.blobserver.enabled .Values.jabba.enabled .Values.jabba.ingress.enabled -}}
 {{- $root := . -}}
 {{- $fullName := include "jabba.fullname" . -}}
 {{- $servicePort := .Values.jabba.service.port -}}
@@ -38,5 +37,4 @@ spec:
               serviceName: {{ $fullName }}
               servicePort: http
   {{- end }}
-{{- end }}
 {{- end }}

--- a/kubernetes/zenko/charts/opal/templates/jabba/service.yaml
+++ b/kubernetes/zenko/charts/opal/templates/jabba/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.jabba.enabled -}}
+{{- if and .Values.blobserver.enabled .Values.jabba.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/kubernetes/zenko/charts/opal/values.yaml
+++ b/kubernetes/zenko/charts/opal/values.yaml
@@ -148,7 +148,7 @@ jabba:
           topologyKey: 'kubernetes.io/hostname'
           labelSelector:
             matchLabels:
-              app: {{ include 'jabba.name' . }}
+              app: {{ include "jabba.name" . }}
               release: {{ .Release.Name | quote }}
 
   autoscaling:

--- a/kubernetes/zenko/templates/NOTES.txt
+++ b/kubernetes/zenko/templates/NOTES.txt
@@ -7,8 +7,6 @@ It is currently honored, but may be removed in future versions.
 
 Access the Zenko S3 endpoint from this URL:
 {{- if .Values.ingress.hosts }}
-The ingress.hosts option has been DEPRECATED.
-It is currently honored, but may be removed in future versions.
 {{- range .Values.ingress.hosts }}
   http://{{ . }}
 {{- end }}
@@ -17,10 +15,17 @@ It is currently honored, but may be removed in future versions.
 {{- range .Values.ingress.s3_extra_hosts }}
   http://{{ . }}
 {{- end }}
+{{- if .Values.opal.blobserver.enabled }}
 
 Access the Zenko Blob endpoint from this URL:
 {{ printf "http://%s.%s" .Values.ingress.blob_subdomain .Values.ingress.root_domain }}
 {{- range .Values.ingress.blob_extra_hosts }}
   http://{{ . }}
+{{- end }}
+{{- end }}
+{{- if .Values.opal.jabba.enabled }}
+
+Access the Zenko SRP endpoint from this URL:
+{{ printf "http://%s.%s" .Values.ingress.blob_mgmt_subdomain .Values.ingress.root_domain }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to Zenko!

Please enter applicable information below.
-->

**What does this PR do, and why do we need it?**
Opal is disabled by default and should only be deployed if set in the user's values. Currently blobserver and some of its async jobs are created using the default. This PR adds the missing conditionals to the helm chart to prevent this. It also fixes a minor quoting mistake.
**Which issue does this PR fix?**

fixes ZENKO-2515

**Special notes for your reviewers**:
