### PR TITLE
ZENKO-2424: Fix templating of PV Selector for mgob

### DIFF
--- a/kubernetes/zenko/charts/mgob/templates/statefulset.yaml
+++ b/kubernetes/zenko/charts/mgob/templates/statefulset.yaml
@@ -77,9 +77,9 @@ spec:
         storageClassName: "{{ .Values.persistentVolume.storageClass }}"
       {{- end }}
       {{- end }}
-      {{- if .Values.persistence.selector }}
+      {{- if .Values.persistentVolume.selector }}
         selector:
-{{ toYaml .Values.persistence.selector | indent 10 }}
+{{ toYaml .Values.persistentVolume.selector | indent 10 }}
       {{- end }}
 {{- else }}
         - name: mgob-storage


### PR DESCRIPTION
We made a mistake: used `persistence` instead of `persistentVolume`.
Interesting facts:
- this name isn't consistent across the charts (would be nice)
- this wasn't caught in CI tests (would be nice too)

