### PR TITLE
Support K8s 1.16

### DIFF
--- a/eve/workers/ceph/chart/templates/deployment.yaml
+++ b/eve/workers/ceph/chart/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "ceph.fullname" . }}

--- a/kubernetes/zenko/charts/backbeat/templates/api/deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/api/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "backbeat.fullname" . }}-api
@@ -9,6 +9,10 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.api.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "backbeat.name" . }}-api
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:

--- a/kubernetes/zenko/charts/backbeat/templates/api/hpa.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/api/hpa.yaml
@@ -10,7 +10,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   scaleTargetRef:
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: {{ template "backbeat.fullname" . }}-api
 {{ toYaml .Values.api.autoscaling.config | indent 2 }}

--- a/kubernetes/zenko/charts/backbeat/templates/gc/deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/gc/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.orbit.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "backbeat.fullname" . }}-gc-consumer
@@ -10,6 +10,10 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.garbageCollector.consumer.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "backbeat.name" . }}-gc
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:

--- a/kubernetes/zenko/charts/backbeat/templates/ingestion/consumer_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/ingestion/consumer_deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.global.orbit.enabled -}}
 {{- if .Values.ingestion.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "backbeat.fullname" . }}-ingestion-consumer
@@ -11,6 +11,10 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.ingestion.consumer.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "backbeat.name" . }}-ingestion
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:

--- a/kubernetes/zenko/charts/backbeat/templates/ingestion/producer_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/ingestion/producer_deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.global.orbit.enabled -}}
 {{- if .Values.ingestion.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "backbeat.fullname" . }}-ingestion-producer
@@ -11,6 +11,10 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.ingestion.producer.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "backbeat.name" . }}-ingestion
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:

--- a/kubernetes/zenko/charts/backbeat/templates/lifecycle/bucket_processor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/lifecycle/bucket_processor_deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.orbit.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "backbeat.fullname" . }}-lifecycle-bucket-processor
@@ -10,6 +10,10 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.lifecycle.bucketProcessor.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "backbeat.name" . }}-lifecycle
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:

--- a/kubernetes/zenko/charts/backbeat/templates/lifecycle/conductor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/lifecycle/conductor_deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.orbit.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "backbeat.fullname" . }}-lifecycle-conductor
@@ -10,6 +10,10 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "backbeat.name" . }}-lifecycle
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:

--- a/kubernetes/zenko/charts/backbeat/templates/lifecycle/object_processor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/lifecycle/object_processor_deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.orbit.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "backbeat.fullname" . }}-lifecycle-object-processor
@@ -10,6 +10,10 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.lifecycle.objectProcessor.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "backbeat.name" . }}-lifecycle
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:

--- a/kubernetes/zenko/charts/backbeat/templates/replication/data_processor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/replication/data_processor_deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "backbeat.fullname" . }}-replication-data-processor
@@ -9,6 +9,10 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ template "backbeat.replication.dataProcessor.replicaCount" . }}
+  selector:
+    matchLabels:
+      app: {{ template "backbeat.name" . }}-replication
+      release: {{ .Release.Name }}
   template:
     metadata:
       {{- if not .Values.global.orbit.enabled }}

--- a/kubernetes/zenko/charts/backbeat/templates/replication/populator_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/replication/populator_deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "backbeat.fullname" . }}-replication-populator
@@ -9,6 +9,10 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replication.populator.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "backbeat.name" . }}-replication
+      release: {{ .Release.Name }}
   template:
     metadata:
       {{- if not .Values.global.orbit.enabled }}

--- a/kubernetes/zenko/charts/backbeat/templates/replication/status_processor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/replication/status_processor_deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "backbeat.fullname" . }}-replication-status-processor
@@ -9,6 +9,10 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replication.statusProcessor.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "backbeat.name" . }}-replication
+      release: {{ .Release.Name }}
   template:
     metadata:
       {{- if not .Values.global.orbit.enabled }}

--- a/kubernetes/zenko/charts/cloudserver/templates/deployment.yaml
+++ b/kubernetes/zenko/charts/cloudserver/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "cloudserver.fullname" . }}

--- a/kubernetes/zenko/charts/cloudserver/templates/hpa.yaml
+++ b/kubernetes/zenko/charts/cloudserver/templates/hpa.yaml
@@ -10,7 +10,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   scaleTargetRef:
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: {{ template "cloudserver.fullname" . }}
 {{ toYaml .Values.autoscaling.config | indent 2 }}

--- a/kubernetes/zenko/charts/cloudserver/templates/ingress.yaml
+++ b/kubernetes/zenko/charts/cloudserver/templates/ingress.yaml
@@ -2,7 +2,11 @@
 {{- $fullName := include "cloudserver.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+apiVersion: networking.k8s.io/v1beta1
+  {{- else -}}
 apiVersion: extensions/v1beta1
+  {{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/kubernetes/zenko/charts/cloudserver/templates/manager-deployment.yaml
+++ b/kubernetes/zenko/charts/cloudserver/templates/manager-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.orbit.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "cloudserver.fullname" . }}-manager

--- a/kubernetes/zenko/charts/grafana/templates/deployment.yaml
+++ b/kubernetes/zenko/charts/grafana/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "grafana.fullname" . }}

--- a/kubernetes/zenko/charts/grafana/templates/ingress.yaml
+++ b/kubernetes/zenko/charts/grafana/templates/ingress.yaml
@@ -2,7 +2,11 @@
 {{- $fullName := include "grafana.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+apiVersion: networking.k8s.io/v1beta1
+  {{- else -}}
 apiVersion: extensions/v1beta1
+  {{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/kubernetes/zenko/charts/grafana/templates/podsecuritypolicy.yaml
+++ b/kubernetes/zenko/charts/grafana/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.pspEnabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "grafana.fullname" . }}

--- a/kubernetes/zenko/charts/opal/templates/blobserver/deployment.yaml
+++ b/kubernetes/zenko/charts/opal/templates/blobserver/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.blobserver.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "blobserver.fullname" . }}

--- a/kubernetes/zenko/charts/opal/templates/blobserver/hpa.yaml
+++ b/kubernetes/zenko/charts/opal/templates/blobserver/hpa.yaml
@@ -10,7 +10,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   scaleTargetRef:
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: {{ template "blobserver.fullname" . }}
 {{ toYaml .Values.blobserver.autoscaling.config | indent 2 }}

--- a/kubernetes/zenko/charts/opal/templates/blobserver/ingress.yaml
+++ b/kubernetes/zenko/charts/opal/templates/blobserver/ingress.yaml
@@ -3,7 +3,11 @@
 {{ $fullName := include "blobserver.fullname" . -}}
 {{- $servicePort := .Values.blobserver.service.port -}}
 {{- $ingressPath := .Values.blobserver.ingress.path -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+apiVersion: networking.k8s.io/v1beta1
+  {{- else -}}
 apiVersion: extensions/v1beta1
+  {{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/kubernetes/zenko/charts/opal/templates/jabba/deployment.yaml
+++ b/kubernetes/zenko/charts/opal/templates/jabba/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.blobserver.enabled .Values.jabba.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "jabba.fullname" . }}

--- a/kubernetes/zenko/charts/opal/templates/jabba/hpa.yaml
+++ b/kubernetes/zenko/charts/opal/templates/jabba/hpa.yaml
@@ -10,7 +10,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   scaleTargetRef:
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: {{ template "jabba.fullname" . }}
 {{ toYaml .Values.jabba.autoscaling.config | indent 2 }}

--- a/kubernetes/zenko/charts/opal/templates/jabba/ingress.yaml
+++ b/kubernetes/zenko/charts/opal/templates/jabba/ingress.yaml
@@ -3,7 +3,11 @@
 {{- $fullName := include "jabba.fullname" . -}}
 {{- $servicePort := .Values.jabba.service.port -}}
 {{- $ingressPath := .Values.jabba.ingress.path -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+apiVersion: networking.k8s.io/v1beta1
+  {{- else -}}
 apiVersion: extensions/v1beta1
+  {{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/kubernetes/zenko/charts/prometheus/templates/alertmanager-ingress.yaml
+++ b/kubernetes/zenko/charts/prometheus/templates/alertmanager-ingress.yaml
@@ -2,7 +2,11 @@
 {{- $releaseName := .Release.Name -}}
 {{- $serviceName := include "prometheus.alertmanager.fullname" . }}
 {{- $servicePort := .Values.alertmanager.service.servicePort -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+apiVersion: networking.k8s.io/v1beta1
+  {{- else -}}
 apiVersion: extensions/v1beta1
+  {{- end }}
 kind: Ingress
 metadata:
 {{- if .Values.alertmanager.ingress.annotations }}

--- a/kubernetes/zenko/charts/prometheus/templates/alertmanager-statefulset.yaml
+++ b/kubernetes/zenko/charts/prometheus/templates/alertmanager-statefulset.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.alertmanager.enabled -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:

--- a/kubernetes/zenko/charts/prometheus/templates/kube-state-metrics-deployment.yaml
+++ b/kubernetes/zenko/charts/prometheus/templates/kube-state-metrics-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.kubeStateMetrics.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
 {{- if .Values.kubeStateMetrics.deploymentAnnotations }}

--- a/kubernetes/zenko/charts/prometheus/templates/node-exporter-daemonset.yaml
+++ b/kubernetes/zenko/charts/prometheus/templates/node-exporter-daemonset.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.nodeExporter.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
 {{- if .Values.nodeExporter.deploymentAnnotations }}

--- a/kubernetes/zenko/charts/prometheus/templates/pushgateway-deployment.yaml
+++ b/kubernetes/zenko/charts/prometheus/templates/pushgateway-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.pushgateway.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -11,6 +11,11 @@ metadata:
   name: {{ template "prometheus.pushgateway.fullname" . }}
 spec:
   replicas: {{ .Values.pushgateway.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "prometheus.name" . }}
+      component: "{{ .Values.pushgateway.name }}"
+      release: {{ .Release.Name }}
   template:
     metadata:
     {{- if .Values.pushgateway.podAnnotations }}

--- a/kubernetes/zenko/charts/prometheus/templates/pushgateway-ingress.yaml
+++ b/kubernetes/zenko/charts/prometheus/templates/pushgateway-ingress.yaml
@@ -2,7 +2,11 @@
 {{- $releaseName := .Release.Name -}}
 {{- $serviceName := include "prometheus.pushgateway.fullname" . }}
 {{- $servicePort := .Values.pushgateway.service.servicePort -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+apiVersion: networking.k8s.io/v1beta1
+  {{- else -}}
 apiVersion: extensions/v1beta1
+  {{- end }}
 kind: Ingress
 metadata:
 {{- if .Values.pushgateway.ingress.annotations }}

--- a/kubernetes/zenko/charts/prometheus/templates/server-ingress.yaml
+++ b/kubernetes/zenko/charts/prometheus/templates/server-ingress.yaml
@@ -2,7 +2,11 @@
 {{- $releaseName := .Release.Name -}}
 {{- $serviceName := include "prometheus.server.fullname" . }}
 {{- $servicePort := .Values.server.service.servicePort -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+apiVersion: networking.k8s.io/v1beta1
+  {{- else -}}
 apiVersion: extensions/v1beta1
+  {{- end }}
 kind: Ingress
 metadata:
 {{- if .Values.server.ingress.annotations }}

--- a/kubernetes/zenko/charts/prometheus/templates/server-statefulset.yaml
+++ b/kubernetes/zenko/charts/prometheus/templates/server-statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
 {{- if .Values.server.statefulsetAnnotations }}

--- a/kubernetes/zenko/charts/s3-data/templates/deployment.yaml
+++ b/kubernetes/zenko/charts/s3-data/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "s3-data.fullname" . }}
@@ -9,6 +9,10 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "s3-data.name" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:

--- a/kubernetes/zenko/charts/zenko-nfs/templates/deployment.yaml
+++ b/kubernetes/zenko/charts/zenko-nfs/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.enabled -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "zenko-nfs.fullname" . }}

--- a/kubernetes/zenko/charts/zenko-queue-manager/templates/ingress.yaml
+++ b/kubernetes/zenko/charts/zenko-queue-manager/templates/ingress.yaml
@@ -2,7 +2,11 @@
 {{- $fullName := include "kafka-manager.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+apiVersion: networking.k8s.io/v1beta1
+  {{- else -}}
 apiVersion: extensions/v1beta1
+  {{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/kubernetes/zenko/charts/zenko-queue/templates/deployment-kafka-exporter.yaml
+++ b/kubernetes/zenko/charts/zenko-queue/templates/deployment-kafka-exporter.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.prometheus.kafka.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "kafka.fullname" . }}-exporter

--- a/kubernetes/zenko/charts/zenko-queue/templates/statefulset.yaml
+++ b/kubernetes/zenko/charts/zenko-queue/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 {{- $advertisedListenersOverride := first (pluck "advertised.listeners" .Values.configurationOverrides) }}
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "kafka.fullname" . }}
@@ -14,6 +14,10 @@ spec:
   updateStrategy:
 {{ toYaml .Values.updateStrategy | indent 4 }}
   replicas: {{ default 3 .Values.replicas }}
+  selector:
+    matchLabels:
+      app: {{ include "kafka.name" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
 {{- if and .Values.prometheus.jmx.enabled  (not .Values.prometheus.operator.enabled) }}

--- a/kubernetes/zenko/charts/zenko-quorum/templates/statefulset.yaml
+++ b/kubernetes/zenko/charts/zenko-quorum/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "zookeeper.fullname" . }}

--- a/kubernetes/zenko/templates/ingress.yaml
+++ b/kubernetes/zenko/templates/ingress.yaml
@@ -8,7 +8,11 @@
 {{- $jabbaDomain := printf "%s.%s" .Values.ingress.blob_mgmt_subdomain .Values.ingress.root_domain -}}
 {{- $jabbaServiceName := printf "%s-%s-%s" .Release.Name "opal" "jabba" | trunc 63 | trimSuffix "-" -}}
 {{- $addIssuerAnnotation := and .Values.ingress.auto_certificates (or .Values.ingress.issuer .Values.ingress.cluster_issuer) -}}
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
+apiVersion: networking.k8s.io/v1beta1
+  {{- else -}}
 apiVersion: extensions/v1beta1
+  {{- end }}
 kind: Ingress
 metadata:
   name: {{ template "zenko.fullname" . }}

--- a/kubernetes/zenko/templates/maintenance/debug/kafkaclient.yaml
+++ b/kubernetes/zenko/templates/maintenance/debug/kafkaclient.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.maintenance.debug.enabled -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "zenko.debug" . }}-kafka-client

--- a/kubernetes/zenko/templates/maintenance/debug/s3utils.yaml
+++ b/kubernetes/zenko/templates/maintenance/debug/s3utils.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.maintenance.debug.enabled -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "zenko.debug" . }}-s3utils


### PR DESCRIPTION
This is a stash of the changes I had to make the Helm charts work on K8s 1.17, hope it'll be useful. Here's a quick recap:
- Use recent apiVersions to avoid breaking on recent Kubernetes releases.
    - Should maintain compatibility with K8s >= 1.10.
- Second commit on Ingress apiVersion requires Helm v2.15 or higher (could be changed to work with lower Helm versions if needed)