### PR TITLE
feature: Generate config.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,6 @@ tests/artifacts
 .DS_Store
 .tox/
 
-*_build
+**/_build
 docs/_templates/page.html_orig
 *.pyc

--- a/solution/Makefile
+++ b/solution/Makefile
@@ -1,0 +1,19 @@
+.POSIX:
+
+PWD := $(shell pwd)
+
+# Destination Paths
+BUILD_ROOT ?= $(PWD)/_build
+ISO_ROOT ?= $(BUILD_ROOT)/root
+
+# Solution default configuration
+config: $(ISO_ROOT)/config.yaml
+.PHONY: config
+
+$(ISO_ROOT)/config.yaml: $(PWD)/config.yaml
+	@mkdir -p $(@D)
+	cp -f $< $@
+
+.PHONY: clean
+clean:
+	rm -rf $(BUILD_ROOT)

--- a/solution/README.md
+++ b/solution/README.md
@@ -1,0 +1,11 @@
+# _WIP_ Zenko Solution
+
+## Using
+TODO
+
+## Requirements
+TODO
+
+## Building
+TODO
+

--- a/solution/config.yaml
+++ b/solution/config.yaml
@@ -1,0 +1,12 @@
+apiVersion: solutions.metalk8s.scality.com/v1alpha1
+kind: SolutionConfig
+operator:
+  image:
+    name: zenko-operator
+    tag: 1.0.0
+ui:
+  image:
+    name: zenko-ui
+    tag: 1.0.0
+customApiGroups:
+  - zenko.scality.com


### PR DESCRIPTION
* Simple makefile to get started
* One make target to generate config.yaml
* Empty README.md to fill in later
* Add nested _build to gitignore

**What does this PR do, and why do we need it?**
Generate config.yaml required for the solution ISO

**Which issue does this PR fix?**

fixes ZENKO-2600 

**Special notes for your reviewers**:
