### PR TITLE
bugfix: ZENKO-2620 comment out ingress annotations

### DIFF
--- a/kubernetes/zenko/values.yaml
+++ b/kubernetes/zenko/values.yaml
@@ -15,7 +15,7 @@ ingress:
   hosts:
     - zenko.local
   max_body_size: 100m
-  annotations:
+  # annotations:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   tls:


### PR DESCRIPTION
Helm 2.16 raises a warning as the ingress annotations is declared as `nil` and
gets converted to a map based on the chart's default. This fix suppresses the warnings
when upgrading or installing a zenko release

