### PR TITLE
bugfix: ZENKO-2634_fix_bad_1.20_docs_links

### DIFF
--- a/docs/docsource/operation/Architecture/Orbit.rst
+++ b/docs/docsource/operation/Architecture/Orbit.rst
@@ -36,7 +36,7 @@ Orbit offers the following features:
 You can test drive Orbit by following the “`Try Zenko`_” link at
 https://www.zenko.io/ and following the instructions for :ref:`Setting Up an Orbit Sandbox Instance`.
 
-For a full walk-through of these features, see `Using Orbit`_.
+For a full walk-through of these features, see :ref:`Using Orbit`.
 
 .. _`Try Zenko`: https://admin.zenko.io/user
 .. _`Using Orbit`: ../Orbit_UI/index.html

--- a/docs/docsource/operation/Metadata_Search/HTTP_Search_Requests.rst
+++ b/docs/docsource/operation/Metadata_Search/HTTP_Search_Requests.rst
@@ -1,9 +1,11 @@
-HTTP Search Requests
+.. _`HTTP Search Requests`:
+
+HTTP Search Requests
 ====================
 
 Search requests can be also performed by making HTTP requests
 authenticated with the AWS Signature version 4 scheme. See the following
-URLs for more information about AWS V4 authentication.
+URLs for more information about AWS V4 authentication.
 
 -  http://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html
 -  http://docs.aws.amazon.com/general/latest/gr/sigv4-signed-request-examples.html

--- a/docs/docsource/operation/Metadata_Search/Searching_Metadata_with_Zenko.rst
+++ b/docs/docsource/operation/Metadata_Search/Searching_Metadata_with_Zenko.rst
@@ -12,13 +12,11 @@ If these requirements are satisfied, you can perform metadata searches
 by
 
 -  Entering a search in the Orbit Search tool from an authorized session.
-   See `Searching Metadata from Orbit`_.
+   See :ref:`Searching Metadata from Orbit`.
 -  Using the ``search_bucket`` tool (found in the
    `Scality/S3 <https://github.com/scality/S3>`__ GitHub repository) as
-   described in `Using search_bucket`_.
+   described in :ref:`Using search_bucket`.
 -  Making an Auth V4-signed HTTP request to Zenko as described in
-   `HTTP Search Requests`_.
+   :ref:`HTTP Search Requests`.
 
-.. _`Searching Metadata from Orbit`: ../Orbit_UI/Searching_Metadata_from_Orbit.html
-.. _`Using search_bucket`: Using_search_bucket.html
-.. _`HTTP Search Requests`: HTTP_Search_Requests.html
+

--- a/docs/docsource/operation/Metadata_Search/Using_search_bucket.rst
+++ b/docs/docsource/operation/Metadata_Search/Using_search_bucket.rst
@@ -1,3 +1,5 @@
+.. _`Using search_bucket`:
+
 Using search\_bucket
 ====================
 

--- a/docs/docsource/operation/Orbit_UI/index.rst
+++ b/docs/docsource/operation/Orbit_UI/index.rst
@@ -1,3 +1,5 @@
+.. _`Using Orbit`:
+
 Using Orbit
 ===========
 

--- a/docs/docsource/operation/Zenko_CLI/CRR_Metrics_and_Health.rst
+++ b/docs/docsource/operation/Zenko_CLI/CRR_Metrics_and_Health.rst
@@ -1,4 +1,4 @@
-.. _`crr_metrics-health`:
+.. _`crr_metrics_health`:
 
 CRR Metrics and Healthcheck
 ===========================

--- a/docs/docsource/operation/Zenko_CLI/CRR_Pause-Resume.rst
+++ b/docs/docsource/operation/Zenko_CLI/CRR_Pause-Resume.rst
@@ -1,4 +1,4 @@
-.. _CRR Pause and Resume:
+.. _crr_pause_resume:
 
 CRR Pause and Resume
 ====================

--- a/docs/docsource/operation/Zenko_CLI/Monitoring_NFS-SOFS_Ingestion.rst
+++ b/docs/docsource/operation/Zenko_CLI/Monitoring_NFS-SOFS_Ingestion.rst
@@ -1,4 +1,4 @@
-.. _`Monitoring_NFS-SOFS_Ingestion`:
+.. _`monitoring_nfs_sofs_ingestion`:
 
 Monitoring NFS/SOFS Ingestion
 =============================

--- a/docs/docsource/operation/Zenko_CLI/index.rst
+++ b/docs/docsource/operation/Zenko_CLI/index.rst
@@ -10,16 +10,13 @@ internal Backbeat server's APIs is through CloudServer API calls.
 Enabling command-line interactions enables programmatic access to the following
 features:
 
-  .. toctree::
-   :maxdepth: 1
+*  :ref:`crr_metrics_health`
+*  :ref:`crr_retry`
+*  :ref:`crr_pause_resume`
+*  :ref:`object_lifecycle`
+*  :ref:`monitoring_nfs_sofs_ingestion`
+*  :ref:`managing_bucket_policies`
 
-   CRR_Metrics_and_Health
-   CRR_Retry
-   CRR_Pause-Resume
-   Object_Lifecycle_Management
-   Monitoring_NFS-SOFS_Ingestion
-   managing_bucket_policies
-   
 To access Zenko from the command line, you must first set up access to 
 the desired APIs.
 
@@ -320,7 +317,16 @@ Helper Script
       $ node test-request.js
 
 
-.. _`CRR Metrics and Healthcheck`: CRR_Metrics_and_Health.html
+  .. toctree::
+   :hidden:
+   :maxdepth: 1
 
+   CRR_Metrics_and_Health
+   CRR_Retry
+   CRR_Pause-Resume
+   Object_Lifecycle_Management
+   Monitoring_NFS-SOFS_Ingestion
+   managing_bucket_policies
+   
 .. _`AWS documentation`: https://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html#RESTAuthenticationRequestCanonicalization
 

--- a/docs/docsource/operation/Zenko_CLI/managing_bucket_policies.rst
+++ b/docs/docsource/operation/Zenko_CLI/managing_bucket_policies.rst
@@ -1,4 +1,4 @@
-.. _managing bucket policies:
+.. _managing_bucket_policies:
 
 Managing Bucket Policies
 ========================

--- a/docs/docsource/reference/blobserver/Account/SetBlobServiceProperties.rst
+++ b/docs/docsource/reference/blobserver/Account/SetBlobServiceProperties.rst
@@ -26,11 +26,12 @@ and ``example.com`` with the domain name or IP address of your endpoint:
 .. tabularcolumns:: lll
 .. table::
 
-   +--------+------------------------------------------------------------------------------+--------------+
-   | Method | Request URI                                                                  | HTTP Version |
-   +========+==============================================================================+==============+
-   | PUT    | ``https://<account-name>.blob.example.com/?restype=service&comp=properties`` | HTTP/1.1     |
-   +--------+------------------------------------------------------------------------------+--------------+
+   +--------+----------------------------------------------+--------------+
+   | Method | Request URI                                  | HTTP Version |
+   +========+==============================================+==============+
+   | PUT    | ``https://<account-name>.blob.example.com/?\ | HTTP/1.1     |
+   |        | restype=service&comp=properties``            |              |
+   +--------+----------------------------------------------+--------------+
 
 The URI must include the forward slash (/) to separate the host name from the
 path and query portions of the URI. For this operation, the path portion of the
@@ -153,7 +154,7 @@ contents.js file. Doing so will introduce unpredictable Blobserver behavior.
 
 The following table describes the elements of the request body:
 
-.. tabularcolumns:: ll
+.. tabularcolumns:: X{0.30\textwidth}X{0.65\textwidth}
 .. table::
    :class: longtable
 

--- a/docs/docsource/reference/blobserver/Container/ListBlobs.rst
+++ b/docs/docsource/reference/blobserver/Container/ListBlobs.rst
@@ -105,7 +105,7 @@ The following additional parameters may be specified on the URI.
    |                                   | To specify more than one of these     |
    |                                   | options on the URI, you must          |
    |                                   | separate each option with a           |
-   |                                   | URL-encoded comma ("%82").            |
+   |                                   | URL-encoded comma (``%82``).          |
    +-----------------------------------+---------------------------------------+
    | ``timeout``                       | Optional. The ``timeout``             |
    |                                   | parameter is expressed in             |

--- a/docs/docsource/reference/blobserver/Container/SetContainerMetadata.rst
+++ b/docs/docsource/reference/blobserver/Container/SetContainerMetadata.rst
@@ -131,7 +131,7 @@ The response for this operation includes the following headers. The response may
 also include additional standard HTTP headers. All standard headers conform to
 the HTTP/1.1 protocol specification.
 
-.. tabularcolumns:: X{0.35\textwidth}X{0.60\textwidth}
+.. tabularcolumns:: X{0.40\textwidth}X{0.55\textwidth}
 .. table::
 
    +--------------------------------------+---------------------------------------------+

--- a/docs/docsource/reference/cloudserver/backbeat/crr_pause_resume/index.rst
+++ b/docs/docsource/reference/cloudserver/backbeat/crr_pause_resume/index.rst
@@ -1,4 +1,4 @@
-.. `crr_pause-resume`_:
+.. _`crr_pause-resume`:
 
 CRR Pause and Resume
 ====================
@@ -13,17 +13,14 @@ wants to schedule a time to resume CRR.
 
 Backbeat's CRR Pause and Resume feature comprises the following API calls
 
-.. toctree::
-   :maxdepth: 1
-
-   get_crr_status
-   get_crr_status_per_location
-   pause_crr_per_location
-   pause_all_crr
-   resume_crr_per_location
-   resume_all_crr
-   set_crr_resume_time
-   get_crr_resume_time
+* :ref:`Get CRR Status`
+* :ref:`Get CRR Status for a Location`
+* :ref:`Pause CRR for a location`
+* :ref:`Pause All CRR`
+* :ref:`Resume CRR for a Location`
+* :ref:`Resume All CRR`
+* :ref:`Set CRR Resume Time`
+* :ref:`Get CRR Resume Time`
 
 Design
 ------
@@ -56,3 +53,15 @@ subscribed to the CRR topic, so it no longer tries to consume any entries.
 When the paused consumer is resumed, it again resumes consuming entries
 from its last offset.
 
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+      
+   get_crr_status
+   get_crr_status_per_location
+   pause_crr_per_location
+   pause_all_crr
+   resume_crr_per_location
+   resume_all_crr
+   set_crr_resume_time
+   get_crr_resume_time

--- a/docs/projects_common_vars.py
+++ b/docs/projects_common_vars.py
@@ -1,5 +1,5 @@
 author = 'Scality Technical Publications'
-copyright = '2019, Scality, Inc'
+copyright = '2020, Scality, Inc'
 
 # The short X.Y version
 version = '1.2.0'


### PR DESCRIPTION
This PR fixed documentation errors noticed while uploading Zenko 1.2.0 docs to website. 

Specifically: 
* Fixed bad link structures.
* Updated year variable to 2020
* Fixed tables that were running off the PDF margins.

fixes #ZENKO-2634
