### PR TITLE
ZENKO-2369 fix readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,19 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/docsource/conf.py
+
+# Optionally build your docs in additional formats such as PDF
+formats: []
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - requirements: docs/docsource/requirements.txt

--- a/docs/docsource/conf.py
+++ b/docs/docsource/conf.py
@@ -90,7 +90,7 @@ language = None
 
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
-if tags.has('html'):
+if tags.has('html') or READTHEDOCS:
    master_doc = 'index'
    exclude_patterns.extend(['index_pdf.rst', '*/index_pdf.rst'])
 else:


### PR DESCRIPTION
This PR brings two different changes:
* As recommended by readthedocs, we're adding the proper
yaml spec file to specify the configurations to build the
documentation. It also provides build time env variable that will help us   
identify in the build if we are building with readthedocs or not.

* We were missing the index.html file in the documentation when
building with readthedocs. We're now applying proper rules when building the documentation
with readthedocs. Therefore, making the index.html available.
