### PR TITLE
ZENKO-2637 bump zenko-releng image with new helm version

### DIFF
--- a/eve/workers/zenko.yaml
+++ b/eve/workers/zenko.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: aggressor
-    image: zenko/zenko-releng:0.0.10
+    image: zenko/zenko-releng:0.0.11
     imagePullPolicy: Always
     resources:
       requests:


### PR DESCRIPTION
Bumping zenko-releng image version which comes with helm version `2.16.7`