### PR TITLE
bf(ZENKO-2653): Fix ingress chart indentation

### DIFF
--- a/kubernetes/zenko/templates/ingress.yaml
+++ b/kubernetes/zenko/templates/ingress.yaml
@@ -64,7 +64,7 @@ spec:
 {{- if or .Values.ingress.tls .Values.ingress.auto_certificates }}
   tls:
 {{- if .Values.ingress.tls }}
-    {{ toYaml .Values.ingress.tls | indent 4 }}
+{{ toYaml .Values.ingress.tls | indent 4 }}
 {{- end -}}
 {{- if .Values.ingress.auto_certificates }}
     - hosts:


### PR DESCRIPTION
Fixes over indentation when manually specifying TLS configuration