### PR TITLE
improvement: ZENKO-2669 expose backbeat concurrency tunables

### DIFF
--- a/kubernetes/zenko/charts/backbeat/templates/replication/data_processor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/replication/data_processor_deployment.yaml
@@ -148,6 +148,9 @@ spec:
               value: "{{ .Values.replication.dataProcessor.retry.gcp.backoff.jitter }}"
             - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_GCP_RETRY_BACKOFF_FACTOR
               value: "{{ .Values.replication.dataProcessor.retry.gcp.backoff.factor }}"
+              # Other backbeat config
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_CONCURRENCY
+              value: "{{ .Values.replication.dataProcessor.concurrency }}"
           livenessProbe:
             httpGet:
               path: {{ .Values.health.path.liveness}}

--- a/kubernetes/zenko/charts/backbeat/templates/replication/status_processor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/replication/status_processor_deployment.yaml
@@ -60,6 +60,8 @@ spec:
             - name: EXTENSIONS_REPLICATION_SOURCE_AUTH_ACCOUNT
               value: Replication
             {{- end }}
+            - name: EXTENSIONS_REPLICATION_STATUS_PROCESSOR_CONCURRENCY
+              value: "{{ .Values.replication.statusProcessor.concurrency }}"
             - name: REDIS_SENTINELS
               value: "{{ template "backbeat.redis-hosts" . }}"
             - name: REDIS_HA_NAME

--- a/kubernetes/zenko/charts/backbeat/values.yaml
+++ b/kubernetes/zenko/charts/backbeat/values.yaml
@@ -125,6 +125,7 @@ replication:
   dataProcessor:
     replicaCount: 1
     replicaFactor: 1
+    concurrency: 10
 
     resources: {}
     nodeSelector: {}
@@ -166,6 +167,7 @@ replication:
 
   statusProcessor:
     replicaCount: 1
+    concurrency: 10
 
     resources: {}
     nodeSelector: {}


### PR DESCRIPTION
Add the "concurrency" values to the backbeat chart for the data
processor and status processor, to control how many parallel
operations can run on each single process.
