### PR TITLE
INTEGRATION [PR#1040 > development/1.2] improvement: ZENKO-2669 expose backbeat concurrency tunables

### DIFF
--- a/kubernetes/zenko/charts/backbeat/templates/replication/data_processor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/replication/data_processor_deployment.yaml
@@ -148,6 +148,11 @@ spec:
               value: "{{ .Values.replication.dataProcessor.retry.gcp.backoff.jitter }}"
             - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_GCP_RETRY_BACKOFF_FACTOR
               value: "{{ .Values.replication.dataProcessor.retry.gcp.backoff.factor }}"
+              # Other backbeat config
+            - name: EXTENSIONS_REPLICATION_QUEUE_PROCESSOR_CONCURRENCY
+              value: "{{ .Values.replication.dataProcessor.concurrency }}"
+            - name: EXTENSIONS_REPLICATION_STATUS_PROCESSOR_CONCURRENCY
+              value: "{{ .Values.replication.statusProcessor.concurrency }}"
           livenessProbe:
             httpGet:
               path: {{ .Values.health.path.liveness}}

--- a/kubernetes/zenko/charts/backbeat/values.yaml
+++ b/kubernetes/zenko/charts/backbeat/values.yaml
@@ -125,6 +125,7 @@ replication:
   dataProcessor:
     replicaCount: 1
     replicaFactor: 1
+    concurrency: 10
 
     resources: {}
     nodeSelector: {}
@@ -166,6 +167,7 @@ replication:
 
   statusProcessor:
     replicaCount: 1
+    concurrency: 10
 
     resources: {}
     nodeSelector: {}


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1040.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/1.2/improvement/ZENKO-2669-backbeatConcurrencyTunable`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/1.2/improvement/ZENKO-2669-backbeatConcurrencyTunable
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/1.2/improvement/ZENKO-2669-backbeatConcurrencyTunable
```

Please always comment pull request #1040 instead of this one.