### PR TITLE
INTEGRATION [PR#1050 > development/2.0] build(deps): bump httplib2 from 0.11.3 to 0.18.0 in /eve/workers/cosbench

### DIFF
--- a/eve/workers/cosbench/requirements.txt
+++ b/eve/workers/cosbench/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2018.4.16
 chardet==3.0.4
 gspread==3.0.1
-httplib2==0.11.3
+httplib2==0.18.0
 idna==2.7
 oauth2client==4.1.2
 pyasn1==0.4.4


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1050.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/2.0/dependabot/pip/eve/workers/cosbench/httplib2-0.18.0`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/2.0/dependabot/pip/eve/workers/cosbench/httplib2-0.18.0
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/2.0/dependabot/pip/eve/workers/cosbench/httplib2-0.18.0
```

Please always comment pull request #1050 instead of this one.