### PR TITLE
Bugfix: ZENKO-2841 add parameters to nginx config gen

### DIFF
--- a/solution/build.sh
+++ b/solution/build.sh
@@ -134,9 +134,13 @@ function build_registry_config()
         --name static-oci-registry \
         --mount type=bind,source=${ISO_ROOT}/images,destination=/var/lib/images \
         --mount type=bind,source=${ISO_ROOT},destination=/var/run \
-         --rm \
-            docker.io/nicolast/static-container-registry:latest \
-        python3 static-container-registry.py --omit-constants /var/lib/images > ${ISO_ROOT}/registry-config.inc.j2
+        --rm \
+        docker.io/nicolast/static-container-registry:latest \
+            python3 static-container-registry.py \
+            --name-prefix '{{ repository }}' \
+            --server-root '{{ registry_root }}' \
+            --omit-constants \
+            /var/lib/images > ${ISO_ROOT}/registry-config.inc.j2
     rm ${ISO_ROOT}/static-container-registry.conf
 }
 


### PR DESCRIPTION
**What does this PR do, and why do we need it?**

Fixes an issue where metalk8s couldn't resolve the docker images after activating the solution.

**Which issue does this PR fix?**

fixes ZENKO-2841 on jira
