### PR TITLE
INTEGRATION [PR#1089 > development/1.2] bf: ZENKO-2889 bump statefulset API version for k8s >= 1.16 compat

### DIFF
--- a/kubernetes/zenko/charts/zookeeper/templates/statefulset.yaml
+++ b/kubernetes/zenko/charts/zookeeper/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "zookeeper.fullname" . }}


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1089.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/1.2/bugfix/ZENKO-2889-fix-statefulset-api-for-k8s-compat`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/1.2/bugfix/ZENKO-2889-fix-statefulset-api-for-k8s-compat
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/1.2/bugfix/ZENKO-2889-fix-statefulset-api-for-k8s-compat
```

Please always comment pull request #1089 instead of this one.