### PR TITLE
bugfix: ZENKO-3022 kubedb and cert-manager conflicts

### DIFF
--- a/solution-base/build.sh
+++ b/solution-base/build.sh
@@ -32,7 +32,9 @@ SOLUTION_ENV='SOLUTION_ENV'
 export KUBEDB_OPERATOR_TAG=$(grep kubedb/operator: deps.txt | awk -F ':' '{print $2}')
 export KUBEDB_NAMESPACE=${SOLUTION_ENV}
 export KUBEDB_SERVICE_ACCOUNT=kubedb-operator
-export KUBEDB_OPERATOR_NAME=operator
+export KUBEDB_IMAGE_NAME=operator
+export KUBEDB_OPERATOR_NAME=kubedb-operator
+export KUBEDB_CERT_NAME=kubedb-operator-apiserver-cert
 export KUBEDB_DOCKER_REGISTRY=${SOLUTION_REGISTRY}
 export KUBEDB_PRIORITY_CLASS=system-cluster-critical
 
@@ -58,7 +60,6 @@ function clean()
 {
     echo cleaning
     rm -rf ${BUILD_ROOT}
-    rm -rf ca.crt ca.key server.crt server.key
 }
 
 function mkdirs()
@@ -141,12 +142,6 @@ spec:
 EOF
 }
 
-# function copy_yamls()
-# {
-    # no yamls currently but other dependencies may require them
-    # cp -R -f operator/ ${ISO_ROOT}/operator
-# }
-
 function copy_image()
 {
     IMAGE_NAME=${1##*/}
@@ -208,7 +203,6 @@ kubedb_yamls
 zookeeper_yamls
 kafka_yamls
 gen_manifest_yaml
-# copy_yamls
 for img in "${DEP_IMAGES[@]}"; do
     # only pull if the image isnt already local
     echo downloading ${img}

--- a/solution-base/kubedb/certs.yaml
+++ b/solution-base/kubedb/certs.yaml
@@ -9,11 +9,11 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: kubedb-operator-apiserver-cert
+  name: ${KUBEDB_CERT_NAME}
   namespace: ${KUBEDB_NAMESPACE}
 spec:
   # Secret names are always required.
-  secretName: kubedb-operator-apiserver-cert
+  secretName: ${KUBEDB_CERT_NAME}
   # TODO: How does kubedb handle cert regens?
   duration: 2160h # 90d
   renewBefore: 360h # 15d
@@ -24,8 +24,8 @@ spec:
     size: 2048
   # At least one of a DNS Name, URI, Email Address, or IP address is required.
   dnsNames:
-  - kubedb-${KUBEDB_OPERATOR_NAME}
-  - kubedb-${KUBEDB_OPERATOR_NAME}.${KUBEDB_NAMESPACE}.svc
+  - ${KUBEDB_OPERATOR_NAME}
+  - ${KUBEDB_OPERATOR_NAME}.${KUBEDB_NAMESPACE}.svc
   # Issuer references are always required.
   issuerRef:
     name: selfsigned-issuer

--- a/solution-base/kubedb/mutating-webhook.yaml
+++ b/solution-base/kubedb/mutating-webhook.yaml
@@ -5,8 +5,6 @@ metadata:
   name: mutators.kubedb.com
   labels:
     app: kubedb
-  annotations:
-    cert-manager.io/inject-ca-from: ${KUBEDB_NAMESPACE}/kubedb-operator-apiserver-cert
 webhooks:
 - name: elasticsearch.mutators.kubedb.com
   clientConfig:

--- a/solution-base/kubedb/operator.yaml
+++ b/solution-base/kubedb/operator.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: kubedb-${KUBEDB_OPERATOR_NAME}
+  name: ${KUBEDB_OPERATOR_NAME}
   namespace: ${KUBEDB_NAMESPACE}
   labels:
     app: kubedb
@@ -21,7 +21,7 @@ spec:
       imagePullSecrets: [${KUBEDB_IMAGE_PULL_SECRET}]
       containers:
       - name: operator
-        image: ${KUBEDB_DOCKER_REGISTRY}/${KUBEDB_OPERATOR_NAME}:${KUBEDB_OPERATOR_TAG}
+        image: ${KUBEDB_DOCKER_REGISTRY}/${KUBEDB_IMAGE_NAME}:${KUBEDB_OPERATOR_TAG}
         imagePullPolicy: IfNotPresent
         args:
         - run
@@ -34,7 +34,7 @@ spec:
         - --tls-private-key-file=/var/serving-cert/tls.key
         - --enable-mutating-webhook=true
         - --enable-validating-webhook=true
-        - --enable-status-subresource=false
+        - --enable-status-subresource=true
         - --bypass-validating-webhook-xray=false
         - --enable-analytics=false
         env:
@@ -74,7 +74,7 @@ spec:
       - name: serving-cert
         secret:
           defaultMode: 420
-          secretName: kubedb-${KUBEDB_OPERATOR_NAME}-apiserver-cert
+          secretName: ${KUBEDB_CERT_NAME}
 ---
 apiVersion: v1
 kind: Service
@@ -92,16 +92,36 @@ spec:
     app: kubedb
 ---
 # register as aggregated apiserver
-apiVersion: apiregistration.k8s.io/v1beta1
+apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   name: v1alpha1.validators.kubedb.com
+  namespace: ${KUBEDB_NAMESPACE}
   labels:
     app: kubedb
   annotations:
-    cert-manager.io/inject-ca-from: ${KUBEDB_NAMESPACE}/${KUBEDB_OPERATOR_NAME}-apiserver-cert
+    cert-manager.io/inject-ca-from: ${KUBEDB_NAMESPACE}/${KUBEDB_CERT_NAME}
 spec:
   group: validators.kubedb.com
+  groupPriorityMinimum: 1000
+  versionPriority: 15
+  service:
+    name: ${KUBEDB_OPERATOR_NAME}
+    namespace: ${KUBEDB_NAMESPACE}
+  version: v1alpha1
+---
+# register as aggregated apiserver
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1alpha1.mutators.kubedb.com
+  namespace: ${KUBEDB_NAMESPACE}
+  labels:
+    app: kubedb
+  annotations:
+    cert-manager.io/inject-ca-from: ${KUBEDB_NAMESPACE}/${KUBEDB_CERT_NAME}
+spec:
+  group: mutators.kubedb.com
   groupPriorityMinimum: 1000
   versionPriority: 15
   service:

--- a/solution-base/kubedb/psp-operator.yaml
+++ b/solution-base/kubedb/psp-operator.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: kubedb-${KUBEDB_OPERATOR_NAME}
+  name: ${KUBEDB_OPERATOR_NAME}
   labels:
     app: kubedb
 spec:

--- a/solution-base/kubedb/rbac-list.yaml
+++ b/solution-base/kubedb/rbac-list.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kubedb-operator
+  name: ${KUBEDB_OPERATOR_NAME}
   labels:
     app: kubedb
 rules:
@@ -112,7 +112,7 @@ rules:
   - podsecuritypolicies
   verbs: ["use"]
   resourceNames:
-  - kubedb-${KUBEDB_OPERATOR_NAME}
+  - ${KUBEDB_OPERATOR_NAME}
   - elasticsearch-db
   - etcd-db
   - memcached-db
@@ -139,13 +139,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kubedb-operator
+  name: ${KUBEDB_OPERATOR_NAME}
   labels:
     app: kubedb
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kubedb-operator
+  name: ${KUBEDB_OPERATOR_NAME}
 subjects:
 - kind: ServiceAccount
   name: ${KUBEDB_SERVICE_ACCOUNT}

--- a/solution-base/kubedb/validating-webhook.yaml
+++ b/solution-base/kubedb/validating-webhook.yaml
@@ -5,8 +5,6 @@ metadata:
   name: validators.kubedb.com
   labels:
     app: kubedb
-  annotations:
-    cert-manager.io/inject-ca-from: ${KUBEDB_NAMESPACE}/kubedb-operator-apiserver-cert
 webhooks:
 - name: elasticsearch.validators.kubedb.com
   clientConfig:


### PR DESCRIPTION
**What does this PR do, and why do we need it?**

Resolves the issue where kubedb and cert-manager would both try and patch the ca bundle value.

**Which issue does this PR fix?**

fixes ZENKO-3022

**Special notes for your reviewers**:
