### PR TITLE
documentation/ZENKO-3041_fix_product_variables_in_indexes

### DIFF
--- a/docs/docsource/conf.py
+++ b/docs/docsource/conf.py
@@ -105,7 +105,7 @@ pygments_style = 'sphinx'
 # -- rst prolog ---------------------------------------------------------
 
 # This section contains text substitution for custom variables and link
-# substitution for MSFT doc links. As we become more complete in our
+# substitution, mostly for MSFT doc links. As we become more complete in our
 # documentation, we can replace these with references to our own documentation.
 
 rst_prolog = """

--- a/docs/docsource/operation/Architecture/Kubernetes.rst
+++ b/docs/docsource/operation/Architecture/Kubernetes.rst
@@ -41,6 +41,7 @@ volumes to containers managed in the cluster.
 MetalK8s is hosted at https://github.com/scality/metalk8s. Instructions for
 deploying MetalK8s on your choice of hardware (real or virtual) are provided
 there. Documentation is available at: https://metal-k8s.readthedocs.io/.
-Installation instructions specific to deploying MetalK8s for |product| are included
-in :version-ref:`|product| Installation
-<https://documentation.scality.com/Zenko/{version}/installation/index.html>`.
+Installation instructions specific to deploying MetalK8s for |product| are
+included in the
+:version-ref:`Installation<https://documentation.scality.com/Zenko/{version}/installation/index.html>`
+documentation.

--- a/docs/docsource/operation/CLI/index.rst
+++ b/docs/docsource/operation/CLI/index.rst
@@ -26,7 +26,7 @@ Set Up CloudServer API Access
 -----------------------------
 
 |product| supports a limited set of S3 and Azure API commands. For a comprehensive
-listing of supported S3 commands, see the :version-ref:`|product| Reference
+listing of supported S3 commands, see the |product| :version-ref:`Reference
 <https://documentation.scality.com/Zenko/{version}/reference/index.html>`.
 
 To access |product|’s AWS S3 and Azure Blob APIs, you must perform the following

--- a/docs/docsource/operation/GUI/Bucket_Management/out-of-band_updates/set_up_AWS_for_OOB.rst
+++ b/docs/docsource/operation/GUI/Bucket_Management/out-of-band_updates/set_up_AWS_for_OOB.rst
@@ -66,13 +66,13 @@ AWS location named "my-aws".
 Cron Job Defaults
 ~~~~~~~~~~~~~~~~~
 
-|product|'s AWS ingestion cron job is triggered every 12 hours (12 pm and 12 am) by
-default, but this is configurable. The cron specification supports both the
+|product|'s AWS ingestion cron job is triggered every 12 hours (12 pm and 12 am)
+by default, but this is configurable. The cron specification supports both the
 traditional (``* *0 * * * *``) format as well as the non-standard (``@hourly``)
-format. Adding and `upgrading |product|
-<https://github.com/scality/Zenko/blob/development/1.1/docs/docsource/installation/upgrade/upgrade_zenko.rst#upgrading>`_
-with the following YAML added as custom values sets a default cron schedule for
-all future created AWS locations.
+format. Adding and
+:version-ref:`upgrading<https://github.com/scality/Zenko/blob/development/{version}/docs/docsource/installation/upgrade/upgrade_zenko.rst#upgrading>`
+|product| with the following YAML added as custom values sets a default cron
+schedule for all future created AWS locations.
 
 ::
 
@@ -114,7 +114,7 @@ Managed Resources
 Due to the Kubernetes operator-managed nature of the AWS locations, resources
 like cron jobs or deployments related to each location are "enforced state."
 This means that if a cron job for a location is deleted, it is automatically
-recreated, which can be useful for testing and debugging. This also means,
+re-created, which can be useful for testing and debugging. This also means,
 however, that you *cannot* directly edit a managed cronjob or deployment
 resource, because your changes are immediately changed to match the state
 defined in the "cosmos" resource. Desired changes must be made by editing the
@@ -123,3 +123,5 @@ AWS resources themselves using kubectl.
 ::
 
    $ kubectl edit cosmos <my-aws-location-name>
+
+

--- a/docs/docsource/operation/GUI/Bucket_Management/out-of-band_updates/set_up_NFS_for_OOB.rst
+++ b/docs/docsource/operation/GUI/Bucket_Management/out-of-band_updates/set_up_NFS_for_OOB.rst
@@ -72,13 +72,12 @@ NFS location named "my-nfs".
 Cron Job Defaults
 ~~~~~~~~~~~~~~~~~
 
-|product|'s NFS ingestion cron job is triggered every 12 hours (12 pm and 12 am) by
-default, but this is configurable. The cron specification supports both the
+|product|'s NFS ingestion cron job is triggered every 12 hours (12 pm and 12 am)
+by default, but this is configurable. The cron specification supports both the
 traditional (``* *0 * * * *``) format as well as the non-standard (``@hourly``)
-format. Adding and `upgrading |product|
-<https://github.com/scality/Zenko/blob/development/1.1/docs/docsource/installation/upgrade/upgrade_zenko.rst#upgrading>`_
-with the following YAML added as custom values sets a default cron schedule for
-all future created NFS locations. 
+format. Adding and :version-ref:`upgrading<https://github.com/scality/Zenko/blob/development/{version}/docs/docsource/installation/upgrade/upgrade_zenko.rst#upgrading>`
+|product| with the following YAML added as custom values sets a default cron
+schedule for all future created NFS locations.
 
 ::
 
@@ -129,3 +128,7 @@ nfs resources themselves using kubectl.
 ::
 
    $ kubectl edit cosmos <my-nfs-location-name>
+
+
+
+   

--- a/docs/docsource/operation/GUI/File_Operations/delete_files.rst
+++ b/docs/docsource/operation/GUI/File_Operations/delete_files.rst
@@ -72,7 +72,9 @@ Run it as follows:
    .. tip::
 
       The s3utils pod is disabled by default. You can also enable it by adding
-      the following to the options file and upgrading your |product| deployment::
+      the following to the options file and upgrading your |product| deployment
+
+      .. parsed-literal::
 
         maintenance:
 	  debug:

--- a/docs/docsource/operation/GUI/Location_Management/index.rst
+++ b/docs/docsource/operation/GUI/Location_Management/index.rst
@@ -41,9 +41,10 @@ notice.
 
    https://access.redhat.com/documentation/en-us/red_hat_ceph_storage
 
-See :version-ref:`|product| Installation
-<https://documentation.scality.com/Zenko/{version}/installation/index.html>` for
-advice on sizing, cluster configuration, and other preparations.
+See the :version-ref:`Installation
+<https://documentation.scality.com/Zenko/{version}/installation/index.html>`
+documentation for advice on sizing, cluster configuration, and other
+preparations.
 
 Scality RING with S3 Connector
 ------------------------------

--- a/docs/docsource/operation/GUI/User_Management/index.rst
+++ b/docs/docsource/operation/GUI/User_Management/index.rst
@@ -1,5 +1,5 @@
-User Management Tasks
-=====================
+User Management
+===============
 
 Using the Orbit interface, you can manage users by adding them, changing
 their credentials (secret keys), or revoking their credentials

--- a/docs/docsource/operation/GUI/index.rst
+++ b/docs/docsource/operation/GUI/index.rst
@@ -11,16 +11,16 @@ providing ease of use and excellent opportunities for visualizing managed data.
 .. toctree::
    :maxdepth: 1
 
-    Orbit Security<Orbit_Security>
-    Setting Up Orbit<Setting_Up_Orbit/index>
-    The Dashboard<Dashboard>
-    Statistics<Statistics>
-    Settings<Settings>
-    User Management<User_Management/index>
-    Location Management<Location_Management/index>
-    Bucket Management<Bucket_Management/index>
-    File Operations<File_Operations/index>
-    Searching Metadata with |product|<../Metadata_Search/Searching_Metadata_with_XDM>
+   Orbit_Security
+   Setting_Up_Orbit/index
+   Dashboard
+   Statistics
+   Settings
+   User_Management/index
+   Location_Management/index
+   Bucket_Management/index
+   File_Operations/index
+   ../Metadata_Search/Searching_Metadata_with_XDM
 
 
 

--- a/docs/docsource/operation/index.rst
+++ b/docs/docsource/operation/index.rst
@@ -8,15 +8,17 @@ enables data backup, transfer, and replication across private and public clouds.
 Using |product|, you can store to a Scality RING storage device and automatically
 back up to one or several public clouds. Alternatively, you can use a public
 cloud such as Amazon S3 as primary storage and replicate data stored
-there—-specific files, file types, or entire buckets—-to other supported clouds,
+there—specific files, file types, or entire buckets—to other supported clouds,
 such as Google Cloud Platform (GCP) or Microsoft Azure.
 
 .. toctree::
    :maxdepth: 2
 
-   About |product|<Introduction/index>
-   Architecture<Architecture/index>
-   Services<Services/index>
-   Using the |product| UI<GUI/index>
-   Cloud Management Services<Dashboards/Cloud_Management_Services>
-   |product| Command Line and API Operation<CLI/index>
+   Introduction/index
+   Architecture/index
+   Services/index
+   GUI/index
+   Dashboards/Cloud_Management_Services
+   CLI/index
+
+

--- a/docs/docsource/operation/index_pdf.rst
+++ b/docs/docsource/operation/index_pdf.rst
@@ -4,9 +4,9 @@
 .. toctree::
    :maxdepth: 2
 
-   About |product|<Introduction/index>
-   Architecture<Architecture/index>
-   Services<Services/index>
-   Using |product| UI<GUI/index>
-   Cloud Management Services<Dashboards/Cloud_Management_Services>
-   |product| from the Command Line<CLI/index>
+   Introduction/index
+   Architecture/index
+   Services/index
+   GUI/index
+   Dashboards/Cloud_Management_Services
+   CLI/index


### PR DESCRIPTION
Fixed several instances where |product| variables were causing trouble.

I left several instances in Orbit sections alone, as this feature is bound for oblivion.
