### PR TITLE
bugfix: Update operator and pensieve images

### DIFF
--- a/solution/deps.txt
+++ b/solution/deps.txt
@@ -4,10 +4,10 @@ pravega/zookeeper:0.2.4
 redis:5.0.3
 registry.scality.com/sf-eng/blobserver:1.0.8
 registry.scality.com/sf-eng/jabba:940d
-registry.scality.com/sf-eng/pensieve/api:3374cb1
+registry.scality.com/sf-eng/pensieve-api:cff863c
 registry.scality.com/sf-eng/utapi:zenko-1.0.0
 registry.scality.com/sf-eng/vault:zenko-2.0.0
-registry.scality.com/sf-eng/zenko-operator:ae6bd9d
+registry.scality.com/sf-eng/zenko-operator:cdaa636
 registry.scality.com/sf-eng/zenko-ui:c091051
 registry.scality.com/zenko-dev/backbeat:161b9c1
 registry.scality.com/zenko-dev/cloudserver:latest-8.1.2


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
Fixes issue with pensive pulling the wrong image
