### PR TITLE
ZENKO-3090 adding information required by artifacts to promote a build

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -76,6 +76,22 @@ stages:
         doStepIf: '%(prop:launch_end2end)s'
         stage_names:
         - end2end
+    - ShellCommand:
+        name: add successful .final_status to artifacts
+        command: >
+            mkdir build_status
+            && echo -n "SUCCESSFUL" > build_status/.final_status
+        haltOnFailure: True
+    - ShellCommand:
+        name: add failed .final_status to artifacts if needed
+        command: >
+            [ -f build_status/.final_status ]
+            || ( mkdir build_status && echo -n "FAILED" > build_status/.final_status )
+        haltOnFailure: True
+        alwaysRun: True
+    - Upload:
+        source: build_status
+        alwaysRun: True
 
   build-doc:
     worker:


### PR DESCRIPTION
The build status file, is required by the artifacts service to ensure that the build is a success before promoting it.