### PR TITLE
feature: ZENKO-3134-update-vault-image-v8.2.0-alpha.1

### DIFF
--- a/solution/deps.txt
+++ b/solution/deps.txt
@@ -7,7 +7,7 @@ registry.scality.com/sf-eng/blobserver:1.0.8
 registry.scality.com/sf-eng/jabba:940d
 registry.scality.com/sf-eng/pensieve-api:611b9ca
 registry.scality.com/sf-eng/utapi:zenko-1.0.0
-registry.scality.com/sf-eng/vault:zenko-2.0.0
+registry.scality.com/vault/vault:8.2.0-alpha.1
 registry.scality.com/sf-eng/zenko-operator:0a7b2f0
 registry.scality.com/zenko-dev/backbeat:161b9c1
 registry.scality.com/zenko-dev/cloudserver:latest-8.1.2

--- a/solution/zenkoversion.yaml
+++ b/solution/zenkoversion.yaml
@@ -50,8 +50,8 @@ spec:
       image: kafka
       tag: 2.12-2.3.0
     vault:
-      image: vault
-      tag: zenko-2.0.0
+      image: ${SOLUTION_REGISTRY}/vault
+      tag: 8.2.0-alpha.1
     shell:
       image: busybox
       tag: latest


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
Update Vault image with v8.2.0-alpha.1

**Special notes for your reviewers**:
Image pull command: `docker pull registry.scality.com/vault/vault:8.2.0-alpha.1`

For instructions on docker login: https://github.com/scality/Vault/blob/development/8.2/docs/RELEASE.md#how-to-pull-docker-images

Respective Operator PR merged: https://github.com/scality/zenko-operator/pull/128/files