### PR TITLE
ZENKO-3100: removed variable from links

### DIFF
--- a/docs/docsource/installation/configure/configuring_zenko.rst
+++ b/docs/docsource/installation/configure/configuring_zenko.rst
@@ -26,8 +26,8 @@ Modify options.yaml
 -------------------
 
 The options.yaml file is not present by default, but you added a simple one at
-Zenko/kubernetes/options.yaml when :ref:`deploying
-|product|<create_options.yaml>`. options.yaml is the best place to make all changes
+Zenko/kubernetes/options.yaml when :ref:`deploying<create_options.yaml>` 
+|product|. options.yaml is the best place to make all changes
 to your configuration (with one exception, nodeCounts). While it is possible to
 reconfigure any aspect of |product| or its attendant microservices from those
 services' base settings or in the |product| settings, it is better to make changes


### PR DESCRIPTION
<!--
Thank you for contributing to Zenko!

Please enter applicable information below.
-->

**What does this PR do, and why do we need it?**

**Which issue does this PR fix?**

The variable |product| has been removed from the following links in:
- docs/docsource/installation/configure/configuring_zenko.rst
- docs/docsource/operation/Orbit_UI/Setting_Up_Orbit/index.rst

fixes #<ISSUE>

**Special notes for your reviewers**:

Couldn't fix the links in docs/docsource/operation/Orbit_UI/Bucket_Management/lifecycle_management/index.rst.
However, I added a space before the <link> and corrected "scality" which was written "scaity".
