### PR TITLE
bugfix: ZENKO-3265 fix zenko deployment on kubernetes 1.18

### DIFF
--- a/kubernetes/zenko/charts/mgob/templates/configmap.yaml
+++ b/kubernetes/zenko/charts/mgob/templates/configmap.yaml
@@ -2,7 +2,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   labels:
-{{ include "mgob.role" . | indent 2 }}
+{{ include "mgob.role" . | indent 4 }}
   name: {{ template "mgob.fullname" . }}-configmap
 data:
 {{ include "mgob.configMap-rendered" . | indent 2 }}

--- a/kubernetes/zenko/charts/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/kubernetes/zenko/charts/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -292,8 +292,8 @@ spec:
                   -mongodb.tls-cert=/work-dir/mongo.pem
                 {{- end }}
                   -test
-              initialDelaySeconds: 30
-              periodSeconds: 10
+            initialDelaySeconds: 30
+            periodSeconds: 10
 {{ end }}
    {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/kubernetes/zenko/charts/zenko-quorum/templates/statefulset.yaml
+++ b/kubernetes/zenko/charts/zenko-quorum/templates/statefulset.yaml
@@ -11,7 +11,6 @@ metadata:
 spec:
   serviceName: {{ template "zookeeper.fullname" . }}-headless
   replicas: {{ .Values.replicaCount }}
-  terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
   selector:
     matchLabels:
       app: {{ template "zookeeper.name" . }}
@@ -44,6 +43,7 @@ spec:
 {{- end }}
       securityContext:
 {{ toYaml .Values.securityContext | indent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       containers:
 
         - name: zookeeper


### PR DESCRIPTION
**What does this PR do, and why do we need it?**

Fixed various indentation and attribute positioning errors in Zenko
charts that triggered validation errors when installing Zenko on
Kubernetes 1.18 (Metalk8s 2.7.1).
