### PR TITLE
use `--no-cache-dir` flag to `pip` in dockerfiles to save space

### DIFF
--- a/eve/workers/build-iso/Dockerfile
+++ b/eve/workers/build-iso/Dockerfile
@@ -15,6 +15,6 @@ RUN curl -sSL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz | \
 RUN tar -C /usr/local -xzf go1.14.3.linux-amd64.tar.gz
 
 # install python + buildbot worker
-RUN pip3 install buildbot-worker
+RUN pip3 install --no-cache-dir buildbot-worker
 CMD buildbot-worker create-worker . "$BUILDMASTER:$BUILDMASTER_PORT" "$WORKERNAME" "$WORKERPASS" \
     && buildbot-worker start --nodaemon

--- a/eve/workers/ceph/Dockerfile
+++ b/eve/workers/ceph/Dockerfile
@@ -20,7 +20,7 @@ RUN chmod +x /entrypoint-wrapper.sh && \
     rm /etc/yum.repos.d/python-rtslib.repo && \
     yum install -y python-pip && \
     yum clean all && \
-    pip install awscli && \
+    pip install --no-cache-dir awscli && \
     rm -rf /root/.cache/pip && \
     mkdir /artifacts
 

--- a/eve/workers/cosbench/Dockerfile
+++ b/eve/workers/cosbench/Dockerfile
@@ -5,4 +5,4 @@ ADD ./ /cosbench
 WORKDIR /cosbench
 RUN apk add --update curl && rm -rf /var/cache/apk/* && \
     chmod +x /usr/local/bin/trigger_run.sh && \
-    pip install -r requirements.txt
+    pip install --no-cache-dir -r requirements.txt

--- a/eve/workers/mocks/azure/Dockerfile
+++ b/eve/workers/mocks/azure/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add -U --no-cache python3 ca-certificates git haproxy \
         gcc \
         make \
         openssl-dev \
-    && python3 -m pip install azure-cli \
+    && python3 -m pip install --no-cache-dir azure-cli \
     && apk del .build-deps \
     && mkdir -p /usr/src/app
 

--- a/tests/sfko/Dockerfile
+++ b/tests/sfko/Dockerfile
@@ -10,7 +10,7 @@ ADD ./requirements.txt /tmp/
 
 RUN apk add -U --no-cache openssl libffi coreutils su-exec && \
     apk add -U --no-cache --virtual .build-deps g++ musl-dev libffi-dev openssl-dev && \
-    pip install -r /tmp/requirements.txt && \
+    pip install --no-cache-dir -r /tmp/requirements.txt && \
     apk del .build-deps && \
     addgroup -S sfko && adduser -S -G sfko sfko && \
     mkdir -p /config

--- a/tests/zenko_tests/Dockerfile
+++ b/tests/zenko_tests/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -y \
 COPY ./node_tests/package.json ./node_tests/package-lock.json /usr/local/bin/tests/node_tests/
 COPY ./python_tests/requirements.txt /tmp
 
-RUN python3 -m pip install -r /tmp/requirements.txt tox && \
+RUN python3 -m pip install --no-cache-dir -r /tmp/requirements.txt tox && \
     cd /usr/local/bin/tests/node_tests && \
     npm install && \
     rm -rf /var/cache/apk/* && \


### PR DESCRIPTION
**What does this PR do, and why do we need it?**

using "--no-cache-dir" flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>