### PR TITLE
feature: Add knob to trigger transitions one day early

### DIFF
--- a/kubernetes/zenko/charts/backbeat/templates/lifecycle/bucket_processor_deployment.yaml
+++ b/kubernetes/zenko/charts/backbeat/templates/lifecycle/bucket_processor_deployment.yaml
@@ -30,6 +30,8 @@ spec:
           command: ["/usr/src/app/docker-entrypoint.sh"]
           args: ["npm", "run", "lifecycle_bucket_processor"]
           env:
+            - name: TRANSITION_ONE_DAY_EARLIER
+              value: '{{ .Values.lifecycle.triggerTransitionsOneDayEarlierForTesting | default false }}'
             - name: ZOOKEEPER_AUTO_CREATE_NAMESPACE
               value: "1"
             - name: ZOOKEEPER_CONNECTION_STRING

--- a/kubernetes/zenko/charts/backbeat/values.yaml
+++ b/kubernetes/zenko/charts/backbeat/values.yaml
@@ -95,6 +95,8 @@ ingestion:
     affinity: {}
 
 lifecycle:
+  triggerTransitionsOneDayEarlierForTesting: false
+
   conductor:
     cronRule: 0 */6 * * *
     resources: {}


### PR DESCRIPTION
**What does this PR do, and why do we need it?**

Add knob to trigger transitions one day early as a helm value:

```yaml
backbeat:
  lifecycle:
    triggerTransitionsOneDayEarlierForTesting: true
```

because the usual way to test "immediate" lifecycle with the `CI` env var does not apply to transitions.

**Which issue does this PR fix?**

fixes ZENKO-2881