### PR TITLE
run end2end tests in series

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -211,12 +211,22 @@ stages:
         - build-doc
         - test-cosmos
     - TriggerStages:
-        name: trigger end2end tests
+        name: trigger python end2end tests
         haltOnFailure: true
         doStepIf: '%(prop:launch_end2end)s'
         stage_names:
         - python-tests
+    - TriggerStages:
+        name: trigger node 1 end2end tests
+        haltOnFailure: true
+        doStepIf: '%(prop:launch_end2end)s'
+        stage_names:
         - node-tests-01
+    - TriggerStages:
+        name: trigger node 2 end2end tests
+        haltOnFailure: true
+        doStepIf: '%(prop:launch_end2end)s'
+        stage_names:
         - node-tests-02
 
   build-doc:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -27,6 +27,7 @@ HELM_REPOSITORY_INCUBATOR ?= https://charts.helm.sh/incubator
 
 # This is for dumping logs, command is long so storing as a variable
 ZENKO_PODS := {{range .items}}{{$$pod := .metadata.name}}{{range .spec.containers}}"kubectl logs -n $(HELM_NAMESPACE) {{$$pod}} -c {{.name}} --previous=true >> artifacts/{{.name}}-{{$$pod}}.log;kubectl logs -n $(HELM_NAMESPACE) {{$$pod}} -c {{.name}} >> artifacts/{{.name}}-{{$$pod}}.log ; exit 0"{{"\n"}}{{end}}{{end}}
+ZENKO_DESCRIBE_PODS := {{range .items}}{{$$pod := .metadata.name}}"kubectl describe -n $(HELM_NAMESPACE) pod {{$$pod}} >> artifacts/{{$$pod}}-describe.log; exit 0"{{"\n"}}{{end}}
 
 # Defaults for our test images
 IMAGE_REGISTRY := docker.io
@@ -242,6 +243,7 @@ install-common: | install-tiller install-helm-repos install-orbit-simulator inst
 .PHONY: install-common
 
 dump-logs: | artifacts
+	$(v)(kubectl  -n $(HELM_NAMESPACE) get pods -o go-template --template '$(ZENKO_DESCRIBE_PODS)') | xargs -n 1 -r sh -c;
 	$(V)(kubectl  -n $(HELM_NAMESPACE) get pods -o go-template --template '$(ZENKO_PODS)') | xargs -n 1 -r sh -c;
 	tar -czvf ./artifacts/$(HELM_NAMESPACE).tar.gz ./artifacts
 .PHONY: dump-logs


### PR DESCRIPTION
<!--
Thank you for contributing to Zenko!

Please enter applicable information below.
-->

**What does this PR do, and why do we need it?**
Modify the CI config to run the end-to-end tests in series; improves CI stability by only running a single zenko instance at a time. 3 parallel instances seems to be taxing the k8s environment, timing out on stabilization checks. 

**Which issue does this PR fix?**

fixes ZENKO-3290

**Special notes for your reviewers**:
