### PR TITLE
ZENKO-3289 Remove image pull secret for kubedb operator

### DIFF
--- a/solution-base/kubedb/operator.yaml
+++ b/solution-base/kubedb/operator.yaml
@@ -18,7 +18,6 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       serviceAccountName: ${KUBEDB_SERVICE_ACCOUNT}
-      imagePullSecrets: [${KUBEDB_IMAGE_PULL_SECRET}]
       containers:
       - name: operator
         image: ${KUBEDB_DOCKER_REGISTRY}/${KUBEDB_IMAGE_NAME}:${KUBEDB_OPERATOR_TAG}


### PR DESCRIPTION
When validating this file had the following error:
```
error: error validating "solution-base/kubedb/operator.yaml": error validating data: ValidationError(Deployment.spec.template.spec.imagePullSecrets[0]): invalid type for io.k8s.api.core.v1.LocalObjectReference: got "string", expected "map"; if you choose to ignore these errors, turn validation off with --validate=false

```

As imagepullsecret is not used, removing it.
