### PR TITLE
feature: ZENKO-3400-update-vault-to-8.2.0-alpha.3

### DIFF
--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -54,7 +54,7 @@ zenko-operator:
 vault:
   sourceRegistry: registry.scality.com/vault
   image: vault
-  tag: 8.2.0-alpha.2
+  tag: 8.2.0-alpha.3
   envsubst: VAULT_TAG
 backbeat:
   sourceRegistry: registry.scality.com/zenko-dev


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
Updates Vault tag from `8.2.0-alpha.2` to `8.2.0-alpha.3`

**Which issue does this PR fix?**

fixes #ZENKO-3400

**Special notes for your reviewers**:
This will be merged after Zenko v2.0.0-alpha.5 is released. We are aiming for Zenko v2.0.0-alpha.6 per Jira fix version.

