### PR TITLE
Bump pensieve-api version

### DIFF
--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -37,9 +37,9 @@ jabba:
   tag: 940d
   envsubst: JABBA_TAG
 pensieve-api:
-  sourceRegistry: registry.scality.com/sf-eng
+  sourceRegistry: registry.scality.com/pensieve-api
   image: pensieve-api
-  tag: 46e279b
+  tag: 1.0.0-alpha.7
   envsubst: PENSIEVE_API_TAG
 utapi:
   sourceRegistry: registry.scality.com/sf-eng


### PR DESCRIPTION
Not strictly necessary for alpha.6, but if any regression has occurred, we should know sooner rather than later.