### PR TITLE
improvement: add iso md5sum

### DIFF
--- a/eve/workers/build-iso/Dockerfile
+++ b/eve/workers/build-iso/Dockerfile
@@ -10,7 +10,7 @@ RUN yum install -y yum-utils gettext && \
     yum-config-manager \
         --add-repo \
         https://download.docker.com/linux/centos/docker-ce.repo
-RUN yum install -y python3 make skopeo wget mkisofs git docker-ce docker-ce-cli
+RUN yum install -y python3 make skopeo wget mkisofs git docker-ce docker-ce-cli isomd5sum
 RUN wget https://dl.google.com/go/go1.14.3.linux-amd64.tar.gz
 RUN curl -sSL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz | \
     tar -xvz && install linux-amd64/helm /usr/local/bin

--- a/solution-base/build.sh
+++ b/solution-base/build.sh
@@ -194,6 +194,8 @@ function build_iso()
         -input-charset iso8859-1 \
         -output-charset iso8859-1 \
         ${ISO_ROOT}
+    echo Implant MD5 sum into ISO
+    implantisomd5 --supported-iso ${ISO}
     sha256sum ${ISO} > ${ISO_ROOT}/SHA256SUM
     echo ISO File at ${ISO}
     echo SHA256 for ISO:

--- a/solution/build.sh
+++ b/solution/build.sh
@@ -133,6 +133,8 @@ function build_iso()
         -input-charset iso8859-1 \
         -output-charset iso8859-1 \
         ${ISO_ROOT}
+    echo Implant MD5 sum into ISO
+    implantisomd5 --supported-iso ${ISO}
     sha256sum ${ISO} > ${ISO_ROOT}/SHA256SUM
     echo ISO File at ${ISO}
     echo SHA256 for ISO:


### PR DESCRIPTION
<!--
Thank you for contributing to Zenko!

Please enter applicable information below.
-->

**What does this PR do, and why do we need it?**
Embed the md5 sum of the iso within the iso. allows for verifying if an iso is corrupted using `checkisomd5` 

**Which issue does this PR fix?**

ZENKO-3369

**Special notes for your reviewers**:
