### PR TITLE
feature(ZENKO-3510):adding-apiversion-v1

### DIFF
--- a/kubernetes/zenko/Chart.yaml
+++ b/kubernetes/zenko/Chart.yaml
@@ -1,6 +1,7 @@
 name: zenko
 version: 1.2.2
 appVersion: 1.2.2
+apiVersion: v1
 kubeVersion: '>=1.11.3-0'
 description: Zenko is the open source multi-cloud data controller
 home: https://www.zenko.io/


### PR DESCRIPTION
Fixes issue with apiVersion: v1 not present in helm charts 
fixes #ZENKO-3510