### PR TITLE
Feature/zenko 3513 bump pensieve api

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -59,7 +59,7 @@ models:
   - SetProperties: &set_operator_properties
       properties:
         OPERATOR_IMAGE_NAME: registry.scality.com/sf-eng/zenko-operator
-        OPERATOR_IMAGE_TAG: '1.0.0-rc.2'
+        OPERATOR_IMAGE_TAG: '1.0.0-rc.3'
 
 stages:
   pre-merge:

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -39,7 +39,7 @@ jabba:
 pensieve-api:
   sourceRegistry: registry.scality.com/pensieve-api
   image: pensieve-api
-  tag: 1.0.0-alpha.8
+  tag: 1.0.0-rc.2
   envsubst: PENSIEVE_API_TAG
 utapi:
   sourceRegistry: registry.scality.com/sf-eng

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -49,7 +49,7 @@ utapi:
 zenko-operator:
   sourceRegistry: registry.scality.com/sf-eng
   image: zenko-operator
-  tag: 1.0.0-rc.2
+  tag: 1.0.0-rc.3
   envsubst: ZENKO_OPERATOR_TAG
 vault:
   sourceRegistry: registry.scality.com/vault


### PR DESCRIPTION
Updates pensieve-api and zenko-operator to fix erroneous attempts at sending metrics to CloudWatch.