### PR TITLE
Changing helm release to stable 3.5.4 and new official repo location

### DIFF
--- a/eve/workers/end2end/requirements.sh
+++ b/eve/workers/end2end/requirements.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-export HELM_VER=3.5.4
+
+export HELM_VER=2.16.7
+export HELM3_VER=3.5.4
 export KUBECTL_VER=1.11.6
 
 
@@ -17,11 +19,19 @@ systemctl start docker
 usermod -aG docker eve
 
 
-# install helm
-wget -q https://get.helm.sh/helm-v${HELM_VER}-linux-amd64.tar.gz && \ 
+# install helm 2 for tiller migration 
 
+wget -q https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VER}-linux-amd64.tar.gz && \
 tar -xvf helm-v${HELM_VER}-linux-amd64.tar.gz && \
 mv linux-amd64/helm /usr/bin/
+
+rm -rf linux-amd64
+
+# install helm 3 
+wget -q https://get.helm.sh/helm-v${HELM3_VER}-linux-amd64.tar.gz && \ 
+
+tar -xvf helm-v${HELM3_VER}-linux-amd64.tar.gz && \
+mv linux-amd64/helm /usr/bin/helm3
 
 # install kubectl
 wget -q https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VER}/bin/linux/amd64/kubectl -O /usr/bin/kubectl && \

--- a/eve/workers/end2end/requirements.sh
+++ b/eve/workers/end2end/requirements.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export HELM_VER=2.16.7
+export HELM_VER=3.5.4
 export KUBECTL_VER=1.11.6
 
 
@@ -18,7 +18,8 @@ usermod -aG docker eve
 
 
 # install helm
-wget -q https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VER}-linux-amd64.tar.gz && \
+wget -q https://get.helm.sh/helm-v${HELM_VER}-linux-amd64.tar.gz && \ 
+
 tar -xvf helm-v${HELM_VER}-linux-amd64.tar.gz && \
 mv linux-amd64/helm /usr/bin/
 

--- a/tests/zenko_tests/python_tests/zenko_e2e/cosmos/test_cosmos_deployment.py
+++ b/tests/zenko_tests/python_tests/zenko_e2e/cosmos/test_cosmos_deployment.py
@@ -73,8 +73,10 @@ def compare_versions(objkey, aws_target_bucket, zenko_bucket):
 # Timeout has been increased to 180 because of setup time but really shouldn't
 # be increased any further. Please investigate possible regressions or test
 # refactor before increasing the timeout any further.
+# Updated timeout to 360 to allow for increased system latency 
+
 @pytest.fixture
-def wait_for_job(kube_batch, location, timeout=180):
+def wait_for_job(kube_batch, location, timeout=360):
     _timestamp = time.time()
     while time.time() - _timestamp < timeout:
         try:

--- a/tests/zenko_tests/python_tests/zenko_e2e/cosmos/test_cosmos_deployment.py
+++ b/tests/zenko_tests/python_tests/zenko_e2e/cosmos/test_cosmos_deployment.py
@@ -73,7 +73,7 @@ def compare_versions(objkey, aws_target_bucket, zenko_bucket):
 # Timeout has been increased to 180 because of setup time but really shouldn't
 # be increased any further. Please investigate possible regressions or test
 # refactor before increasing the timeout any further.
-# Updated timeout to 360 to allow for increased system latency 
+# Updated timeout to 360 to allow for increased system latency
 
 @pytest.fixture
 def wait_for_job(kube_batch, location, timeout=360):


### PR DESCRIPTION
Moving the helm binary location to the current stable release location at helm.sh as it's no longer being published to the GCP storage.googleapis.com bucket.  

Updated helm install version to stable 3.5.4 build.  