### PR TITLE
bugfix: ZENKO-3547 bump zenko-operator version to 1.0.0-rc.4

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -59,7 +59,7 @@ models:
   - SetProperties: &set_operator_properties
       properties:
         OPERATOR_IMAGE_NAME: registry.scality.com/sf-eng/zenko-operator
-        OPERATOR_IMAGE_TAG: '1.0.0-rc.3'
+        OPERATOR_IMAGE_TAG: '1.0.0-rc.4'
 
 stages:
   pre-merge:

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -49,7 +49,7 @@ utapi:
 zenko-operator:
   sourceRegistry: registry.scality.com/sf-eng
   image: zenko-operator
-  tag: 1.0.0-rc.3
+  tag: 1.0.0-rc.4
   envsubst: ZENKO_OPERATOR_TAG
 vault:
   sourceRegistry: registry.scality.com/vault


### PR DESCRIPTION
**What does this PR do, and why do we need it?**

to satisfy web browser https security policy on zenko-ui/shell-ui

**Which issue does this PR fix?**

fixes [ZENKO-3547](https://scality.atlassian.net/browse/ZENKO-3547)

**Special notes for your reviewers**:
