### PR TITLE
Documentation/zenko 3269/pdf image width fixed

### DIFF
--- a/docs/docsource/installation/install/install_zenko.rst
+++ b/docs/docsource/installation/install/install_zenko.rst
@@ -151,14 +151,17 @@ Register with Orbit
    authenticate through Google.
 
    .. image:: ../Graphics/orbit_authenticate.png
-
+      :width: 50%
+	      
 #. Click the **Register My Instance** button.
 
 #. Paste the instance ID into the Instance ID dialog. Name the instance what
    you will.
 
    .. image:: ../Graphics/orbit_enter_instance_ID.png
+      :width: 75%
 
 #. Your instance is registered.
 
    .. image:: ../Graphics/orbit_install_success.png
+      :width: 100%

--- a/docs/docsource/installation/prepare/configure_logical_volumes.rst
+++ b/docs/docsource/installation/prepare/configure_logical_volumes.rst
@@ -134,18 +134,22 @@ For each node,
 #. Click the name of the node in the Platform menu to display node details.
 
    .. image:: ../Graphics/MK8s_node_select.png
+      :width: 75%
 
 #. Click the **Volumes** tab.
 
    .. image:: ../Graphics/MK8s_details.png
+      :width: 50%
 
 #. Click the **+** button.
 
    .. image:: ../Graphics/MK8s_volume_tab.png
+      :width: 75%
 
 #. The **Create a New Volume** window displays.
 
    .. image:: ../Graphics/MK8s_volume_create.png
+      :width: 100%
 
 #. Enter the volume's
 

--- a/docs/docsource/installation/prepare/node_setup.rst
+++ b/docs/docsource/installation/prepare/node_setup.rst
@@ -6,15 +6,18 @@ Follow these steps to set up the node structure using MetalK8s.
 #. Open MetalK8s.
 
    .. image:: ../Graphics/MK8s_clean.png
+      :width: 100%
 
 #. Click **Create a New Node**.
 
    .. image:: ../Graphics/MK8s_new_node.png
-
+      :width: 75%
+	      
 #. Enter the hostname, roles, and SSH information for the node.
 
    .. image:: ../Graphics/MK8s_new_node_filled_in.png
-
+      :width: 75%
+	      
    .. tip::
 
       If you aren't certain about the node's hostname, open the node in SSH and
@@ -24,7 +27,8 @@ Follow these steps to set up the node structure using MetalK8s.
    banner.
 
    .. image:: ../Graphics/MK8s_node_created_green.png
-
+      :width: 100%
+      
 Troubleshooting
 ---------------
 

--- a/docs/docsource/operation/Dashboards/Kubernetes_Dashboard.rst
+++ b/docs/docsource/operation/Dashboards/Kubernetes_Dashboard.rst
@@ -5,7 +5,8 @@ The Kubernetes dashboard is the master dashboard for visualizing your
 cluster’s performance. You can use a cloud-hosted version of Kubernetes,
 or host it yourself using MetalK8s.
 
-|image0|
+.. image:: ../Graphics/kubernetes_dashboard.png
+   :width: 100%
 
 Your Kubernetes user experience will vary depending on which Kubernetes
 you use. At a minimum, you will see everything available to you by
@@ -25,6 +26,3 @@ up Kubernetes proxying in the MetalK8s Quickstart. These instructions
 may prove useful to non-MetalK8s installations as well.
 
 .. _`Grafana`: Grafana.html
-
-.. |image0| image:: ../Graphics/kubernetes_dashboard.png
-   :class: OneHundredPercent

--- a/docs/docsource/operation/Dashboards/Prometheus.rst
+++ b/docs/docsource/operation/Dashboards/Prometheus.rst
@@ -11,6 +11,7 @@ in your browser. If you are configured to see the other dashboards,
 the Prometheus dashboard displays: 
 
 .. image:: ../Graphics/prometheus.png
+   :width: 100%
 
 If you use a different Kubernetes implementation than MetalK8s, you will have
 to install your own Prometheus instance to use this feature.  

--- a/docs/docsource/operation/Orbit_UI/Bucket_Management/AWS_to_AWS_Replication.rst
+++ b/docs/docsource/operation/Orbit_UI/Bucket_Management/AWS_to_AWS_Replication.rst
@@ -13,7 +13,7 @@ AWS-to-AWS Replication
    bucket you just created.
 
    .. image:: ../../Graphics/Orbit_Add_Storage_location_AWS.png
-      :align: center
+      :width: 75%
 
 #. From the Multicloud Browser, create another bucket and set the new AWS
    location as its location constraint.
@@ -25,9 +25,7 @@ AWS-to-AWS Replication
    up bucket replication** dialog box.
 
    .. image:: ../../Graphics/Orbit_set_up_bucket_replication_pulldown.png
+      :width: 75%
 
 #. With the AWS target now visible, enter the flow as described in :ref:`Set Up
    Replication`.
-
-
-

--- a/docs/docsource/operation/Orbit_UI/Bucket_Management/Searching_Metadata_from_Orbit.rst
+++ b/docs/docsource/operation/Orbit_UI/Bucket_Management/Searching_Metadata_from_Orbit.rst
@@ -16,23 +16,21 @@ To search the metadata of files stored in clouds managed by Zenko,
 
 #. Click **Search** in the sidebar to raise the **Multicloud Search** window.
 
-   |image0|
+   .. image:: ../../Graphics/Orbit_multicloud_search.png
+      :width: 100%
 
 #. Pick a bucket to search.
 
-   |image1|
+   .. image:: ../../Graphics/Orbit_multicloud_search_bucket_select.png
+      :width: 75%
 
 #. Enter metadata search terms in the modified NoSQL format described in
    :ref:`Searching Metadata with Zenko`. Click the magnifying glass icon.
 
    .. image::  ../../Graphics/metadata_search_results.png
+      :width: 100%
 
    Orbit returns the search results.
 
    Clicking the arrow icon next to the search result takes you to the
    item’s location (directory) in the bucket.
-
-.. |image0| image:: ../../Graphics/Orbit_multicloud_search.png
-   :class: OneHundredPercent
-.. |image1| image:: ../../Graphics/Orbit_multicloud_search_bucket_select.png
-   :class: FiftyPercent

--- a/docs/docsource/operation/Orbit_UI/Bucket_Management/View_Bucket_Info.rst
+++ b/docs/docsource/operation/Orbit_UI/Bucket_Management/View_Bucket_Info.rst
@@ -12,10 +12,11 @@ To access this feature:
 #. Click the **Browser** item in the sidebar.
 
    .. image:: ../../Graphics/sidebar_browser_button.png
+      :width: 50%
 
 #. The Multicloud Browser **Buckets** list displays:
 
-   |image0|
+   .. image:: ../../Graphics/Orbit_multicloud_browser_with_values.png
 
    Select a bucket from the list of bucket names, then click **View
    Info**.
@@ -23,7 +24,7 @@ To access this feature:
 #. Orbit displays bucket info:
 
    .. image:: ../../Graphics/Orbit_bucket_view_info.png
-      :align: center
+      :width: 75%
 
 From this panel, you can:
 
@@ -34,6 +35,3 @@ From this panel, you can:
 For more information on versioning, review the Amazon S3 documentation
 at: \ https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html.
 Zenko implements S3 logic for versioning.
-
-.. |image0| image:: ../../Graphics/Orbit_multicloud_browser_with_values.png
-

--- a/docs/docsource/operation/Orbit_UI/Bucket_Management/delete_a_bucket.rst
+++ b/docs/docsource/operation/Orbit_UI/Bucket_Management/delete_a_bucket.rst
@@ -20,10 +20,12 @@ To delete a bucket:
 #. Pick the bucket to delete from the **Buckets** list:
 
    .. image:: ../../Graphics/multicloud_browser_select_bucket.png
+      :width: 100%
 
 #. Click the **Delete** button.
 
    .. image:: ../../Graphics/delete_button.png
+      :width: 50%
 
 #. Orbit requests confirmation:
 
@@ -36,4 +38,3 @@ To delete a bucket:
       :width: 75%
 
 #. The Multicloud Browser refreshes, and the bucket is deleted.
-

--- a/docs/docsource/operation/Orbit_UI/Bucket_Management/lifecycle_management/Lifecycle_Management-Expiration.rst
+++ b/docs/docsource/operation/Orbit_UI/Bucket_Management/lifecycle_management/Lifecycle_Management-Expiration.rst
@@ -16,19 +16,18 @@ Establishing an Object Expiration Policy
 
 #. The **Bucket Lifecycle** screen displays.
 
-   |image1|
+   .. image:: ../../../Graphics/Orbit_lifecycle_bucket_select.png
+      :width: 100%
 
 #. Choose a bucket and pick **Add New Rule > Expiration**
 
    .. image:: ../../../Graphics/Orbit_lifecycle_add_new_rule.png
-      :scale: 75 %
-      :align: center
+      :scale: 100 %
 
 #. The **Add New Expiration Rule** dialog displays:
 
    .. image:: ../../../Graphics/Orbit_lifecycle_add_expiration_rule.png
       :scale: 50 %
-      :align: center
 
    You may enter a distinct directory or subdirectory to which the rule applies.
    Enter an expiration time span and a deletion time span.
@@ -39,16 +38,11 @@ Establishing an Object Expiration Policy
 
 #. The new rule is displayed:
 
-   |image4|
+   .. image:: ../../../Graphics/Orbit_lifecycle_expiration_rule_success.png
+      :width: 100%
 
    Zenko will enforce these rules on this bucket. 
 
 Versioning logic precludes simply deleting an object: that day’s object
 is deleted, but earlier versions remain. See warning at 
 :ref:`Deleting Objects<deleting-objects>`.
-
-.. |image0| image:: ../../../Graphics/Orbit_lifecycle_select.png
-.. |image1| image:: ../../../Graphics/Orbit_lifecycle_bucket_select.png
-   :class: OneHundredPercent
-.. |image4| image:: ../../../Graphics/Orbit_lifecycle_expiration_rule_success.png
-   :class: OneHundredPercent

--- a/docs/docsource/operation/Orbit_UI/Bucket_Management/lifecycle_management/Lifecycle_Management-Transition.rst
+++ b/docs/docsource/operation/Orbit_UI/Bucket_Management/lifecycle_management/Lifecycle_Management-Transition.rst
@@ -15,23 +15,21 @@ To establish a lifecycle transition rule:
 #. Click the **Bucket Lifecycle** tab in the sidebar.
 
    .. image:: ../../../Graphics/Orbit_lifecycle_select.png
-      :scale: 80%
+      :scale: 75%
 
 #. The **Bucket Lifecycle** screen displays.
 
-   |image1|
+   .. image:: ../../../Graphics/Orbit_lifecycle_bucket_select.png
 
 #. Choose a bucket and pick **Add New Rule > Transition**
 
    .. image:: ../../../Graphics/Orbit_lifecycle_add_new_rule.png
-      :scale: 80 %
-      :align: center
+      :scale: 100 %
 
 #. The **Add New Transition Rule** dialog displays:
 
    .. image:: ../../../Graphics/Orbit_lifecycle_add_transition_rule.png
       :width: 75 %
-      :align: center
 
    You may specify an prefix to identify objects to which the rule applies. Enter
    a time span after the object's current version was last modified and specify
@@ -43,10 +41,8 @@ To establish a lifecycle transition rule:
 #. The new rule is displayed:
 
    .. image:: ../../../Graphics/Orbit_lifecycle_transition_rule_success.png
-      :align: center
+      :width: 75%
 
    Zenko will enforce these rules on this bucket. If replication is configured, 
    any change of state to objects in this bucket can be replicated to buckets 
    on other clouds.
-
-.. |image1| image:: ../../../Graphics/Orbit_lifecycle_bucket_select.png

--- a/docs/docsource/operation/Orbit_UI/Bucket_Management/out-of-band_updates/set_up_AWS_for_OOB.rst
+++ b/docs/docsource/operation/Orbit_UI/Bucket_Management/out-of-band_updates/set_up_AWS_for_OOB.rst
@@ -35,11 +35,13 @@ Set Up Out-of-Band Updates for AWS
 #. Create the AWS location in Orbit.
 
    .. image:: ../../../Graphics/Add_AWS_location_for_OOB.png
+      :width: 75%
 
 #. Create your bucket in the mirror-mode version of the location just
    created.
 
    .. image:: ../../../Graphics/Add_AWS_bucket_for_OOB.png
+      :width: 75%
 
    With the bucket created, Zenko deploys and configures new pods in Kubernetes
    to access and ingest file metadata. Naming is based on the location name and

--- a/docs/docsource/operation/Orbit_UI/Bucket_Management/out-of-band_updates/set_up_NFS_for_OOB.rst
+++ b/docs/docsource/operation/Orbit_UI/Bucket_Management/out-of-band_updates/set_up_NFS_for_OOB.rst
@@ -38,9 +38,8 @@ Set Up Out of Band Updates from NFS
    different folders to their own buckets in Zenko.
 
    .. image:: ../../../Graphics/add_nfs_location.png
-      :scale: 75%
-      :align: center
-
+      :scale: 50%
+   
 #. Create your bucket in the mirror-mode version of the location just
    created. As of Zenko 1.1.0, only the "Mirror Mode" option is supported, and
    the standard location option does not allow writes to the location.

--- a/docs/docsource/operation/Orbit_UI/Bucket_Management/out-of-band_updates/set_up_S3C_for_OOB.rst
+++ b/docs/docsource/operation/Orbit_UI/Bucket_Management/out-of-band_updates/set_up_S3C_for_OOB.rst
@@ -57,12 +57,12 @@ Set Up Out-of-Band Updates for S3 Connector
 
       .. image:: ../../../Graphics/add_new_location_dialog.*
          :width: 75%
-         :align: center
 
    The new cloud location appears in the Cloud Locations window. The Mirroring
    indicator is grayed out.
 
    .. image:: ../../../Graphics/new_cloud_location.*
+      :width: 100%
 
 #. Open the Multicloud Browser and click **Create Bucket**.
 
@@ -73,6 +73,7 @@ Set Up Out-of-Band Updates for S3 Connector
       is followed by "(Mirror mode)".
 
       .. image:: ../../../Graphics/create_bucket_mirror_mode.*
+         :width: 100%
 
    #. Click **Create**.
 

--- a/docs/docsource/operation/Orbit_UI/Bucket_Management/set_up_crr.rst
+++ b/docs/docsource/operation/Orbit_UI/Bucket_Management/set_up_crr.rst
@@ -14,22 +14,24 @@ To set up a replication configuration:
 #. Click **Replication** in the sidebar:
 
    .. image:: ../../Graphics/sidebar_replication_button.png
+      :width: 50%
 
 #. Orbit raises the Replication window:
 
-   |image0|
+   .. image:: ../../Graphics/Orbit_Replication_New.png
+      :width: 100%
 
    If no locations are configured, Orbit displays this message:
 
    .. image:: ../../Graphics/replication_no_target_message.png
-      :align: center
+      :width: 75%
 
    Click the link text to create a :ref:`suitable replication target<orbit_add_location>`.
 
 #. Click **New**. The **Set up bucket replication** dialog displays.
 
    .. image:: ../../Graphics/Orbit_set_up_bucket_replication.png
-      :align: center
+      :width: 75%
 
    Name the new replication configuration, and enter source and destination
    bucket information. The replication configuration name is free-form, and not
@@ -38,7 +40,8 @@ To set up a replication configuration:
 #. The named configuration and specified destination(s) display on successful
    implementation.
 
-   |image2|
+   .. image:: ../../Graphics/Orbit_replication_success.png
+      :width: 100%
 
 With one or more replication instances configured, the Replication window lets
 you add a new replication configuration, or edit, suspend, or delete an existing
@@ -48,8 +51,3 @@ Replication is not retroactive. In other words, if you have files stored in a
 bucket and you configure that bucket to be replicated, replication only occurs
 to files written to that bucket after you have configured and set the
 replication.
-
-.. |image0| image:: ../../Graphics/Orbit_Replication_New.png
-   :class: OneHundredPercent
-.. |image2| image:: ../../Graphics/Orbit_replication_success.png
-   :class: OneHundredPercent

--- a/docs/docsource/operation/Orbit_UI/Dashboard.rst
+++ b/docs/docsource/operation/Orbit_UI/Dashboard.rst
@@ -3,7 +3,8 @@ The Dashboard
 
 On login, the dashboard displays:
 
-|image0|
+.. image:: ../Graphics/Orbit_dashboard.png
+   :width: 100%
 
 The dashboard provides useful information about ongoing Zenko
 operations, replication status, and cloud server health.
@@ -28,6 +29,3 @@ buttons for:
 In addition to the options on the left sidebar, you can click
 the :ref:`View More Statistics<Statistics>` button to see more
 statistics about buckets, objects, and resources.
-
-
-.. |image0| image:: ../Graphics/Orbit_dashboard.png

--- a/docs/docsource/operation/Orbit_UI/File_Operations/delete_files.rst
+++ b/docs/docsource/operation/Orbit_UI/File_Operations/delete_files.rst
@@ -8,27 +8,26 @@ To delete objects from a selected bucket:
 #. Click the **Browser** button in the sidebar to open the Multicloud Browser:
 
    .. image:: ../../Graphics/sidebar_browser_button.png
+      :width: 50%
 
 #. Double-click a button to open it:   
 
    .. image:: ../../Graphics/Orbit_multicloud_browser_with_values1.png
-      :align: center
+      :width: 100%
 
 #. Click the check box next to each object to be deleted. The number of objects
    to be deleted is indicated in the top bar of the file list.
 
    .. image:: ../../Graphics/Orbit_file_delete.png
-      :align: center
 
 #. Click the **Delete** button.
 
    .. image:: ../../Graphics/Orbit_file_delete_button.png
-      :align: center
 
 #. Orbit requests confirmation of the deletion.
 
    .. image:: ../../Graphics/Orbit_file_delete_confirm.png
-      :align: center
+      :width: 75%
 
 #. The object is deleted from the bucket.
 

--- a/docs/docsource/operation/Orbit_UI/File_Operations/download_a_file.rst
+++ b/docs/docsource/operation/Orbit_UI/File_Operations/download_a_file.rst
@@ -9,10 +9,12 @@ To download a file from a selected bucket:
    Browser.
 
    .. image:: ../../Graphics/sidebar_browser_button.png
+      :width: 50%
 
 #. Double-click a bucket to open it. 
 
-   .. image:: ../../Graphics/Orbit_multicloud_browser_with_values1.png  
+   .. image:: ../../Graphics/Orbit_multicloud_browser_with_values1.png
+      :width: 100%  
 
 #. Select the file to download.
 
@@ -20,8 +22,7 @@ To download a file from a selected bucket:
 
 #. Click **Download**.
 
-   .. image:: ../../Graphics/download_button_selected.png 
+   .. image:: ../../Graphics/download_button_selected.png
+      :width: 50%
 
 #. The file download is handled by the browser.
-
-

--- a/docs/docsource/operation/Orbit_UI/File_Operations/index.rst
+++ b/docs/docsource/operation/Orbit_UI/File_Operations/index.rst
@@ -13,15 +13,18 @@ To access these operations:
 #. Click **Browser** in the sidebar to open the Multicloud Browser.
 
    .. image:: ../../Graphics/sidebar_browser_button.png
+      :width: 50%
 
 #. Double-click the bucket you want to access.
 
    .. image:: ../../Graphics/multicloud_browser_1_bucket.png
+      :width: 100%
 
    -  If the bucket is empty, Zenko asks you to **Drag and Drop
       Objects**:
 
-      |image0|
+      .. image:: ../../Graphics/Orbit_upload_objects.png
+         :width: 100%
 
       Clicking the **Upload Objects** button takes you to your local machine’s
       file system to pick files to upload. Clicking **skip** takes you to the
@@ -29,7 +32,8 @@ To access these operations:
 
    -  Otherwise, the Multicloud Browser displays the bucket’s contents:
 
-      |image1|
+      .. image:: ../../Graphics/Orbit_file_operations.png
+         :width: 100%
 
 For each uploaded file, you can :ref:`Download<Download a File>`, :ref:`View Info<View
 File Info>`, or :ref:`Delete<deleting-objects>`.
@@ -41,7 +45,3 @@ File Info>`, or :ref:`Delete<deleting-objects>`.
     View Files <view_file_info>
     Download Files <download_a_file>
     Delete Files <delete_files>
-
-.. |image0| image:: ../../Graphics/Orbit_upload_objects.png
-   :class: FiftyPercent
-.. |image1| image:: ../../Graphics/Orbit_file_operations.png

--- a/docs/docsource/operation/Orbit_UI/File_Operations/upload_files_to_buckets.rst
+++ b/docs/docsource/operation/Orbit_UI/File_Operations/upload_files_to_buckets.rst
@@ -8,22 +8,27 @@ at least one bucket.
 #. Click **Browser** in the sidebar to open the Multicloud Browser:
 
    .. image:: ../../Graphics/sidebar_browser_button.png
+      :width: 50%
 
 #. Double-click the bucket to which you will upload data. 
 
-   |image0|
+   .. image:: ../../Graphics/Orbit_multicloud_browser_with_values1.png
+      :width: 100%
 
    - If the bucket is empty, the **Drag and Drop Objects** dialog displays:
 
-     |image1|
+     .. image:: ../../Graphics/Orbit_upload_objects.png
+        :width: 100%
 
    - Otherwise, Orbit displays the bucket's contents:
 
      .. image:: ../../Graphics/Orbit_file_operations.png
+        :width: 100%
 
    - Click **Upload** to raise the **Drag and Drop Objects** dialog.
   
      .. image:: ../../Graphics/upload_button_hover.png
+        :width: 50%
 
 #. In the **Drag and Drop Objects** dialog, you can either upload files by
    dragging and dropping from the local desktop (Windows Explorer, OS X, Linux
@@ -42,6 +47,3 @@ at least one bucket.
       Object key name lengths are limited to 915 single-byte characters (109
       fewer than the 1024 one-byte characters permitted in the AWS
       specification).
-
-.. |image0| image:: ../../Graphics/Orbit_multicloud_browser_with_values1.png
-.. |image1| image:: ../../Graphics/Orbit_upload_objects.png

--- a/docs/docsource/operation/Orbit_UI/File_Operations/view_file_info.rst
+++ b/docs/docsource/operation/Orbit_UI/File_Operations/view_file_info.rst
@@ -8,23 +8,23 @@ To view information about a file:
 #. Click the Browser button to open the Multicloud Browser.
 
    .. image:: ../../Graphics/sidebar_browser_button.png
+      :width: 50%
 
 #. Double-click the bucket containing the file.
 
    .. image:: ../../Graphics/Orbit_multicloud_browser_with_values1.png
-      :align: center
+      :width: 100%
 
 #. Select the file, and click the **View Info** button. File information
    displays in a pop-up window:
 
    .. image:: ../../Graphics/Orbit_file_operations_popup.png
-      :align: center
 
 #. Click the pencil icon in the **Metadata** field to add or edit
    metadata options.
 
    .. image:: ../../Graphics/Orbit_add-edit_metadata.png
-      :align: center
+      :width: 75%
 
    Available options are **cache-control**, **content disposition**,
    **content-encoding**, **content-language**, **content-type**, **expires**,
@@ -37,7 +37,7 @@ To view information about a file:
    permit entry of this “nested” key information.
 
    .. image:: ../../Graphics/Orbit_x-amz-meta.png
-      :align: center
+      :width: 75%
 
    This name space must conform to `Amazon’s bucket naming rules
    <https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html#bucketnamingrules>`__:
@@ -46,11 +46,9 @@ To view information about a file:
 #. Click the pencil icon in the **Tags** field to add custom tags.
 
    .. image:: ../../Graphics/Orbit_add_tags.png
-      :align: center
+      :width: 75%
 
    These are S3-supported tags (see
    https://docs.aws.amazon.com/AmazonS3/latest/dev/object-tagging.html).
    Because other backends may not support the S3 tagging structure,
    operations that use these tags must be performed using Zenko.
-
-

--- a/docs/docsource/operation/Orbit_UI/Location_Management/Adding_a_Storage_Location.rst
+++ b/docs/docsource/operation/Orbit_UI/Location_Management/Adding_a_Storage_Location.rst
@@ -9,14 +9,14 @@ To add a storage location:
    **Cloud Locations** window:
 
    .. image:: ../../Graphics/Orbit_Storage_Locations.png
-      :align: center
+      :width: 100%
 
 #. Click **Add New**.
 
 #. The **Add New Storage Location** dialog displays:
 
    .. image:: ../../Graphics/Orbit_Add_New_Storage_Location.png
-      :align: center
+      :width: 100%
 
    a. Enter a location name in the **Location Name** field using
       lowercase letters, numbers, and dashes.

--- a/docs/docsource/operation/Orbit_UI/Location_Management/Adding_a_Transient_Source_Storage_Location.rst
+++ b/docs/docsource/operation/Orbit_UI/Location_Management/Adding_a_Transient_Source_Storage_Location.rst
@@ -18,6 +18,7 @@ To deploy a transient source storage location:
 #. Click the **Storage Locations** button in the sidebar.
 
    .. image:: ../../Graphics/sidebar_storage_locations_button.png
+      :width: 75%
 
 #. The **Cloud Locations** window displays. Click **Add New**. 
 

--- a/docs/docsource/operation/Orbit_UI/Location_Management/location_status.rst
+++ b/docs/docsource/operation/Orbit_UI/Location_Management/location_status.rst
@@ -7,6 +7,7 @@ The **Location Status** button on the Orbit sidebar opens the Location
 Status window. 
 
 .. image:: ../../Graphics/location_status.png
+   :width: 100%
 
 This provides a "high view" of the cloud locations under Zenko's management.
 From the Location Status window, you can see which locations are configured,

--- a/docs/docsource/operation/Orbit_UI/Setting_Up_Orbit/Setting_Up_a_Full_Orbit_Installation.rst
+++ b/docs/docsource/operation/Orbit_UI/Setting_Up_Orbit/Setting_Up_a_Full_Orbit_Installation.rst
@@ -19,7 +19,8 @@ Orbit.
 
 #. Authenticate:
 
-   |image0|
+   .. image:: ../../Graphics/google_login.png
+      :scale: 75%
 
 #. Click **Install Now**.
 
@@ -28,27 +29,22 @@ Orbit.
 
 #. Review and affirm the Privacy Policy:
 
-   |image1|
-
+   .. image:: ../../Graphics/Orbit_setup_Privacy.png
+      :width: 75%
+   
 #. Click **Register My Instance**.
 
-   |image2|
+   .. image:: ../../Graphics/Orbit_register_my_Instance_detail.png
+      :width: 75%
 
 #. Enter your Instance ID and your instance's name, then click **Submit
    Now!**
 
-   |image3|
+   .. image:: ../../Graphics/Orbit_setup_Instance_ID.png
+      :width: 75%
 
 .. tip::
 
    To find your Instance ID, use the
    :version-ref:`kubectl commands <https://documentation.scality.com/Zenko/{version}/installation/install/Install_Zenko.html#get-instance-id>`
    from :version-ref:`Zenko Installation <https://documentation.scality.com/Zenko/{version}/installation/index.html>`.
-
-.. |image0| image:: ../../Graphics/google_login.png
-   :scale: 75%
-.. |image1| image:: ../../Graphics/Orbit_setup_Privacy.png
-   :width: 75%
-.. |image2| image:: ../../Graphics/Orbit_register_my_Instance_detail.png
-.. |image3| image:: ../../Graphics/Orbit_setup_Instance_ID.png
-   :width: 75%

--- a/docs/docsource/operation/Orbit_UI/Setting_Up_Orbit/Setting_up_a_Sandbox_Instance.rst
+++ b/docs/docsource/operation/Orbit_UI/Setting_Up_Orbit/Setting_up_a_Sandbox_Instance.rst
@@ -18,33 +18,37 @@ your data. To set up a Sandbox instance:
 #. Open `zenko.io <https://zenko.io/>`__, and click `Try Zenko
    <https://www.zenko.io/try-zenko/>`__.
 
-   |image0|
+   .. image:: ../../Graphics/Zenko.io_screen.png
 
 #. Click **Register with Google**. You must authenticate using a Google ID.
 
    .. image:: ../../Graphics/google_login.png
+      :width: 75%
 
 #. After you have registered, the Welcome dialog displays:
 
-   |image1|
+   .. image:: ../../Graphics/Orbit_Welcome_screen.png
+      :width: 75%
 
    Click **Install now**.
 
 #. The **REGISTER AN INSTANCE** screen displays:
 
-   |image2|
+   .. image:: ../../Graphics/Orbit_register_1.png
+      :width: 75%
 
    Choose the Sandbox option (**Next: Let's do this!**)
 
 #. The **CREATE YOUR ZENKO SANDBOX** screen displays:
 
-   |image3|
+   .. image:: ../../Graphics/Orbit_Enter_Sandbox.png
+      :width: 100%
 
    Enter a name for your sandbox and click **Create Sandbox**.
 
 #. After less than a minute, the **Settings** window displays:
 
-   |image4|
+   .. image:: ../../Graphics/Orbit_settings_setup.png
 
    Your sandbox is created. Depending on server load, there may be a delay of
    a few minutes to complete the Orbit setup.
@@ -63,6 +67,7 @@ your data. To set up a Sandbox instance:
    transfer the secret key to your clipboard.
 
    .. image:: ../../Graphics/secret_key_my_account.png
+      :width: 100%
 
    .. important:: You do not get a second chance. Copy this now.
 
@@ -72,13 +77,8 @@ your data. To set up a Sandbox instance:
    **Settings** window's **Sandbox Time Left** indicator.
 
    .. image:: ../../Graphics/sandbox_settings.png
+      :width: 75%
 
    The sandbox runs against a Zenko instance hosted by Scality. Though this
    demonstration instance is limited both in its lifespan and in the amount of
    data it can handle, you can use it to watch Zenko in action. 
-
-.. |image0| image:: ../../Graphics/Zenko.io_screen.png
-.. |image1| image:: ../../Graphics/Orbit_Welcome_screen.png
-.. |image2| image:: ../../Graphics/Orbit_register_1.png
-.. |image3| image:: ../../Graphics/Orbit_Enter_Sandbox.png
-.. |image4| image:: ../../Graphics/Orbit_settings_setup.png

--- a/docs/docsource/operation/Orbit_UI/Settings.rst
+++ b/docs/docsource/operation/Orbit_UI/Settings.rst
@@ -9,6 +9,7 @@ whether you want to receive news updates, as well as a link to Scality Support
 for data retrieval or account deletion.
 
 .. image:: ../Graphics/Settings.png
+   :width: 75%
 
 The Settings window also provides a button, **Unlink this Zenko Instance**,
 which offers to forget the Zenko instance. This option does not delete the

--- a/docs/docsource/operation/Orbit_UI/User_Management/Add_a_new_user.rst
+++ b/docs/docsource/operation/Orbit_UI/User_Management/Add_a_new_user.rst
@@ -5,16 +5,19 @@ Add a New User
 
 #. Click **Storage Accounts** in the sidebar to raise the Storage Accounts window.
 
-   ..  image:: ../../Graphics/sidebar_storage_accounts_button.png
+   .. image:: ../../Graphics/sidebar_storage_accounts_button.png
+      :width: 75%
    
 #. Enter a new user name in the **Account Name** field and click
    **Generate**.
 
-   |image0|
+   .. image:: ../../Graphics/Orbit_user_create_enter_username.png
+      :width: 75%
 
 #. Click **Show** to see the secret key associated with this user:
 
-   |image2|
+   .. image:: ../../Graphics/Orbit_user_create_secret_key.png
+      :width: 75%
 
    Copy this key and store it.
 
@@ -28,8 +31,3 @@ Add a New User
 As the Zenko user, you can create multiple users in the Zenko-managed namespace,
 each with a unique access key and secret key. You can also re-generate 
 access/secret key pairs for any such user.
-
-.. |image0| image:: ../../Graphics/Orbit_user_create_enter_username.png
-   :class: FiftyPercent
-.. |image2| image:: ../../Graphics/Orbit_user_create_secret_key.png
-   :class: FiftyPercent

--- a/docs/docsource/operation/Orbit_UI/User_Management/Changing_User_Credentials.rst
+++ b/docs/docsource/operation/Orbit_UI/User_Management/Changing_User_Credentials.rst
@@ -6,25 +6,25 @@ To change a user’s credentials (public/private key pair) from Orbit:
 #. Click the **Storage Accounts** button in the sidebar.
 
    .. image:: ../../Graphics/sidebar_storage_accounts_button.png
+      :width: 75%
 
 #. Look for the user’s name in the **STORAGE ACCOUNTS** pane.
 
    .. image:: ../../Graphics/credentialed_user.png
+      :width: 75%
 
 #. Click **Replace**.
 #. Orbit warns you that this could cause problems for the user. Click
    **Regenerate**.
 
    .. image:: ../../Graphics/Orbit_User_regen_key.png
-      :scale: 75%
-      :align: center
+      :width: 75%
 
 #. Show the new key by clicking the **Show** button or copy it directly
    to your clipboard using the **Copy** button on the user’s line.
 
    .. image:: ../../Graphics/Orbit_user_secret_key.png
-      :scale: 75%
-      :align: center
+      :width: 75%
 
    .. warning::
 

--- a/docs/docsource/operation/Orbit_UI/User_Management/Copy_Owner_ID.rst
+++ b/docs/docsource/operation/Orbit_UI/User_Management/Copy_Owner_ID.rst
@@ -9,10 +9,12 @@ this string.
 #. Click the **Browser** button to open the Multicloud Browser.
 
    .. image:: ../../Graphics/sidebar_browser_button.png
+      :width: 75%
 
 #. In the **Multicloud Browser** window, double-click a bucket to open it.
 
    .. image:: ../../Graphics/bucket_select.png
+      :width: 100%
 
 #. The **Copy Owner ID** button appears above the file and directory listing.
 

--- a/docs/docsource/operation/Orbit_UI/User_Management/Removing_a_User.rst
+++ b/docs/docsource/operation/Orbit_UI/User_Management/Removing_a_User.rst
@@ -4,16 +4,17 @@ Removing a User
 #. Click **Storage Accounts** in the sidebar.
 
    .. image:: ../../Graphics/sidebar_storage_accounts_button.png
+      :width: 75%
 
 #. Find the user to remove:
 
    .. image:: ../../Graphics/Orbit_User_Remove_Name.png
-      :class: OneHundredPercent
+      :width: 100%
 
 #. Click **Delete**. Orbit requests confirmation.
 
    .. image:: ../../Graphics/orbit_user_revoke_warning.png
-      :align: center
+      :width: 75%
    
 #. The user’s access key is revoked and the user name is deleted from the list of
    storage accounts/tenants. 


### PR DESCRIPTION
Reopened #1235 with the prefix `documentation` in the branch name to bypass the build issues with python-tests.

Taking up on William's work and ticket [ZENKO-3269](https://scality.atlassian.net/browse/ZENKO-3269)! He fixed the PDF image size on the Installation Guide, and I carried on the work with the Operation Guide.
-> Note that the size of some HTML images changed, but it doesn't prevent the readability.