### PR TITLE
ZENKO-3575 bumped sphinx tools version to v3.2 to reflect doc rebranding changes

### DIFF
--- a/docs/docsource/requirements.in
+++ b/docs/docsource/requirements.in
@@ -5,4 +5,4 @@ sphinxcontrib-plantuml == 0.14
 sphinxcontrib-svg2pdfconverter == 0.1.0
 sphinx-version-ref >= 0.0.1a1
 
--e git+https://github.com/scality/sphinx-tools.git@v1.1#egg=sphinx_scality
+-e git+https://github.com/scality/sphinx-tools.git@v3.2#egg=sphinx_scality

--- a/docs/docsource/requirements.txt
+++ b/docs/docsource/requirements.txt
@@ -4,32 +4,31 @@
 #
 #    tox -e pip-compile
 #
--e git+https://github.com/scality/sphinx-tools.git@v1.0#egg=sphinx_scality
+-e git+https://github.com/scality/sphinx-tools.git@v3.2#egg=sphinx_scality
 alabaster==0.7.12         # via sphinx
-attrs==19.1.0             # via packaging
-babel==2.7.0              # via sphinx
-certifi==2019.9.11        # via requests
-chardet==3.0.4            # via requests
-commonmark==0.9.0         # via recommonmark
-docutils==0.15.2          # via recommonmark, sphinx
-future==0.17.1            # via commonmark
-idna==2.8                 # via requests
-imagesize==1.1.0          # via sphinx
-jinja2==2.10.1            # via sphinx
-markupsafe==1.1.1         # via jinja2
-packaging==19.1           # via sphinx
-pyenchant==2.0.0          # via sphinxcontrib-spelling
-pygments==2.4.2           # via sphinx
-pyparsing==2.4.2          # via packaging
-pytz==2019.2              # via babel
+babel==2.9.1              # via sphinx
+certifi==2021.5.30        # via requests
+chardet==4.0.0            # via requests
+commonmark==0.9.1         # via recommonmark
+docutils==0.17.1          # via recommonmark, sphinx
+idna==2.10                # via requests
+imagesize==1.2.0          # via sphinx
+jinja2==3.0.1             # via sphinx
+markupsafe==2.0.1         # via jinja2
+packaging==21.0           # via sphinx
+pyenchant==3.2.1          # via sphinxcontrib-spelling
+pygments==2.9.0           # via sphinx
+pyparsing==2.4.7          # via packaging
+pytz==2021.1              # via babel
 recommonmark==0.5.0
-requests==2.22.0          # via sphinx
-six==1.12.0               # via packaging, sphinx, sphinxcontrib-spelling
-snowballstemmer==1.9.1    # via sphinx
+requests==2.25.1          # via sphinx
+six==1.16.0               # via sphinx, sphinxcontrib-spelling
+snowballstemmer==2.1.0    # via sphinx
 sphinx-version-ref==0.1.0
 sphinx==1.8.3
 sphinxcontrib-plantuml==0.14
+sphinxcontrib-serializinghtml==1.1.5  # via sphinxcontrib-websupport
 sphinxcontrib-spelling==4.2.0
 sphinxcontrib-svg2pdfconverter==0.1.0
-sphinxcontrib-websupport==1.1.2  # via sphinx
-urllib3==1.25.3           # via requests
+sphinxcontrib-websupport==1.2.4  # via sphinx
+urllib3==1.26.6           # via requests


### PR DESCRIPTION
Bumped sphinx tools link to version v3.2 in `requirements.in` to reflect rebranding changes.
-> Check out the CI build to see the changes 😉

Fixes [ZENKO-3575](https://scality.atlassian.net/browse/ZENKO-3575)!