### PR TITLE
base, docs: Split zenko-base manifests

### DIFF
--- a/docs/docsource/installation/install/install_xdm.rst
+++ b/docs/docsource/installation/install/install_xdm.rst
@@ -66,9 +66,11 @@ Deploy |product| Operator
    .. parsed-literal::
 
       /srv/scality/metalk8s-{{version-number}}/solutions.sh import --archive $ZENKO_BASE_ISO
-      sed "s/SOLUTION_ENV/zenko/g" /srv/scality/zenko-base-|version|/operator.yaml | kubectl apply -f -
+      sed "s/SOLUTION_ENV/zenko/g" /srv/scality/zenko-base-|version|/deploy/kubedb.yaml | kubectl apply -f -
       kubectl -n zenko rollout status --timeout 10m deploy kubedb-operator
-      sed "s/SOLUTION_ENV/zenko/g" /srv/scality/zenko-base-|version|/operator.yaml | kubectl apply -f -
+      kubectl apply -f /srv/scality/zenko-base-|version|/deploy/kubedb-catalogs.yaml
+      sed "s/SOLUTION_ENV/zenko/g" /srv/scality/zenko-base-|version|/deploy/kafka.yaml | kubectl apply -f -
+      sed "s/SOLUTION_ENV/zenko/g" /srv/scality/zenko-base-|version|/deploy/zookeeper.yaml | kubectl apply -f -
 
 #. Install |product| Operator:
 


### PR DESCRIPTION
**What does this PR do, and why do we need it?**

This PR changes the build of zenko-base ISO to split the operators (KubeDB, Kafka, and Zookeeper) manifest (`$ROOT/operator.yaml`) into:

```
_build/root/
├── deploy
│   ├── kafka.yaml
│   ├── kubedb-catalogs.yaml
│   ├── kubedb.yaml
│   └── zookeeper.yaml
└── images
```

It also updates the XDM installation docs accordingly.

This will allow multiple things:
- only deploying some operators when others are already available
- let KubeDB operator the time it needs to create the Catalog CRDs
  before applying the MongoDB and Redis Catalog CRs

**Which issue does this PR fix?**

Fixes ZENKO-3315