### PR TITLE
feature: ZENKO-3320-add-vault-end-2-end-tests

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -33,6 +33,8 @@ models:
   - env: &e2e-env
       E2E_IMAGE_NAME: registry.scality.com/zenko/zenko-e2e
       E2E_IMAGE_TAG: '%(prop:commit_short_revision)s'
+      VAULT_TEST_IMAGE_NAME: '%(prop:vault_test_image_name)s'
+      VAULT_TEST_IMAGE_TAG: '%(prop:vault_test_image_tag)s'
   - Git: &git_pull
       name: git pull
       repourl: "%(prop:git_reference)s"
@@ -97,6 +99,7 @@ stages:
         stage_names:
         - end2end-http
         - end2end-https
+        - end2end-vault
     - ShellCommand:
         name: add successful .final_status to artifacts
         command: >
@@ -372,5 +375,44 @@ stages:
         env:
           <<: [*kind-env, *e2e-env, *https-env]
     - ShellCommand: *archive_artifacts
+    - ShellCommand: *kind_cluster_cleanup
+    - Upload: *upload_artifacts
+
+  end2end-vault:
+    worker: *end2end-worker
+    steps:
+    - Git: *git_pull
+    - SetProperties: *set_operator_properties
+    - ShellCommand: *wait_docker_daemon
+    - ShellCommand: *private_registry_login
+    - ShellCommand: *bootstrap_kind
+    - ShellCommand: *ensure_cluter_running
+    - ShellCommand: *create_image_pull_secret
+    - ShellCommand:
+        <<: *install_kind_dependencies
+        env:
+          <<: [*kind-env, *http-env]
+    - ShellCommand: *patch_coredns
+    - ShellCommand: *install_shell_ui
+    - ShellCommand:
+        <<: *setup_keycloak
+        env:
+          <<: [*kind-env, *http-env]
+    - ShellCommand: *install_operator
+    - ShellCommand:
+        <<: *deploy_zenko
+        env:
+          <<: [*kind-env, *http-env]
+    - ShellCommand:
+        <<: *setup_keycloak_user
+        env:
+          <<: [*kind-env, *http-env]
+    - ShellCommand: &run_vault_end2end_test
+        name: Run vault end-2end tests
+        env:
+          <<: [*kind-env, *e2e-env, *http-env]
+        command: bash scripts/vault-e2e-test.sh
+        workdir: build/eve/workers/end2end
+        haltOnFailure: true
     - ShellCommand: *kind_cluster_cleanup
     - Upload: *upload_artifacts

--- a/eve/workers/end2end/scripts/create-pull-image-secret.sh
+++ b/eve/workers/end2end/scripts/create-pull-image-secret.sh
@@ -5,3 +5,5 @@ set -exu
 kubectl create secret generic zenko-operator-image-pull --dry-run -o yaml \
     --from-file=.dockerconfigjson=$HOME/.docker/config.json \
     --type=kubernetes.io/dockerconfigjson | kubectl apply -f -
+
+ kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "zenko-operator-image-pull"}]}'

--- a/eve/workers/end2end/scripts/vault-e2e-test.sh
+++ b/eve/workers/end2end/scripts/vault-e2e-test.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+set -exu
+
+DIR=$(dirname $0)
+
+. "$DIR/common.sh"
+
+ZENKO_RESOURCE=${1:-end2end}
+NAMESPACE=${2:-default}
+
+POD_NAME="${ZENKO_RESOURCE}-vault-test"
+
+# set environment vars
+VAULT_ENDPOINT="http://${ZENKO_RESOURCE}-management-vault-iam-admin-api:80"
+VAULT_STS_ENDPOINT="http://${ZENKO_RESOURCE}-connector-vault-sts-api:80"
+VAULT_AUTH_ENDPOINT="http://${ZENKO_RESOURCE}-connector-vault-auth-api:80"
+ADMIN_ACCESS_KEY_ID=$(kubectl get secret $ZENKO_RESOURCE-management-vault-admin-creds.v1 -n $NAMESPACE -o  jsonpath='{.data.accessKey}' | base64 -d)
+ADMIN_SECRET_ACCESS_KEY=$(kubectl get secret $ZENKO_RESOURCE-management-vault-admin-creds.v1 -n $NAMESPACE -o  jsonpath='{.data.secretKey}' | base64 -d)
+MONGODB_TEST_HOST="${ZENKO_RESOURCE}-base-db"
+MONGODB_TEST_PORT="27017"
+MONGODB_TEST_USER=$(kubectl get secret $ZENKO_RESOURCE-base-db-auth -n $NAMESPACE -o jsonpath='{.data.username}' | base64 -d)
+MONGODB_TEST_PASSWORD=$(kubectl get secret $ZENKO_RESOURCE-base-db-auth -n $NAMESPACE -o jsonpath='{.data.password}' | base64 -d)
+MONGODB_TEST_DATABASE=$(kubectl get zenko $ZENKO_RESOURCE -n $NAMESPACE -o jsonpath='{.status.instanceID}')
+REDIS_TEST_HOST="${ZENKO_RESOURCE}-base-cache"
+REDIS_TEST_PORT="6379"
+REDIS_TEST_PASSWORD=$(kubectl get secret $ZENKO_RESOURCE-base-cache-creds.v1 -n $NAMESPACE -o jsonpath='{.data.password}' | base64 -d)
+ZENKO_VERSION=$(kubectl get zenko $ZENKO_RESOURCE -n $NAMESPACE -o jsonpath='{.spec.version}')
+VAULT_TEST_TAG=$(kubectl get zenkoversion $ZENKO_VERSION  -n $NAMESPACE -o jsonpath='{.spec.versions.vault.tag}')
+VAULT_TEST_IMAGE="registry.scality.com/vault/vault-test"
+
+
+# in case of force builds image and tag can be specified using "Extra properties":
+# 'vault_test_image_name' and 'vault_test_image_tag'
+if [ ! -z "$VAULT_TEST_IMAGE_NAME" ] ; then
+  VAULT_TEST_IMAGE=$VAULT_TEST_IMAGE_NAME
+fi
+if [ ! -z "$VAULT_TEST_IMAGE_TAG" ] ; then
+  VAULT_TEST_TAG=$VAULT_TEST_IMAGE_TAG
+fi
+
+kubectl run $POD_NAME \
+  --image $VAULT_TEST_IMAGE:$VAULT_TEST_TAG \
+  --rm \
+  --attach=True \
+  --restart=Never \
+  --namespace=$NAMESPACE \
+  --env="VAULT_ENDPOINT=${VAULT_ENDPOINT}" \
+  --env="VAULT_STS_ENDPOINT=${VAULT_STS_ENDPOINT}" \
+  --env="VAULT_AUTH_ENDPOINT=${VAULT_AUTH_ENDPOINT}" \
+  --env="ADMIN_ACCESS_KEY_ID=${ADMIN_ACCESS_KEY_ID}" \
+  --env="ADMIN_SECRET_ACCESS_KEY=${ADMIN_SECRET_ACCESS_KEY}" \
+  --env="MONGODB_TEST_HOST=${MONGODB_TEST_HOST}" \
+  --env="MONGODB_TEST_PORT=${MONGODB_TEST_PORT}" \
+  --env="MONGODB_TEST_USER=${MONGODB_TEST_USER}" \
+  --env="MONGODB_TEST_PASSWORD=${MONGODB_TEST_PASSWORD}" \
+  --env="MONGODB_TEST_DATABASE=${MONGODB_TEST_DATABASE}" \
+  --env="REDIS_TEST_HOST=${REDIS_TEST_HOST}" \
+  --env="REDIS_TEST_PORT=${REDIS_TEST_PORT}" \
+  --env="REDIS_TEST_PASSWORD=${REDIS_TEST_PASSWORD}" \
+  --command -- yarn ft_test

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -54,7 +54,7 @@ zenko-operator:
 vault:
   sourceRegistry: registry.scality.com/vault
   image: vault 
-  tag: 8.2.1 
+  tag: 8.2.3
   envsubst: VAULT_TAG
 backbeat:
   sourceRegistry: registry.scality.com/backbeat


### PR DESCRIPTION
**What does this PR do, and why do we need it?**

- Updated vault tag to 8.2.3
- Introduces Vault E2E tests on zenko


**Which issue does this PR fix?**

fixes ZENKO-3320	

