### PR TITLE
bugfix: ZENKO-3592-update-vault-image-to-v8.2.4

### DIFF
--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -54,7 +54,7 @@ zenko-operator:
 vault:
   sourceRegistry: registry.scality.com/vault
   image: vault 
-  tag: 8.2.3
+  tag: 8.2.4
   envsubst: VAULT_TAG
 backbeat:
   sourceRegistry: registry.scality.com/backbeat


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
It updates vault tag to v8.2.4. The new version brings fix for ARTESCA-1908

**Which issue does this PR fix?**

fixes ZENKO-3592
