### PR TITLE
INTEGRATION [PR#1280 > development/2.1] ZENKO-3620 docker upgrade now requires double quote on volumes

### DIFF
--- a/eve/workers/end2end.yaml
+++ b/eve/workers/end2end.yaml
@@ -4,6 +4,18 @@ kind: Pod
 metadata:
   name: "zenko-operator-worker-smoke"
 spec:
+  initContainers:
+  - name: workaround
+    image: k8s.gcr.io/build-image/debian-iptables-amd64:buster-v1.6.7
+    command:
+    - sh
+    - -c
+    - "iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu"
+    securityContext:
+      capabilities:
+        add:
+        - NET_ADMIN
+      privileged: true
   automountServiceAccountToken: false
   containers:
   - name: worker

--- a/eve/workers/end2end/Dockerfile
+++ b/eve/workers/end2end/Dockerfile
@@ -8,7 +8,7 @@ ENV HELM_VERSION v3.2.3
 ENV YQ_VERSION v4.6.3
 ENV YQ_BINARY yq_linux_amd64
 
-VOLUME ['/artifacts', '/home/eve/workspace']
+VOLUME ["/artifacts", "/home/eve/workspace"]
 
 # install base dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1280.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/2.1/bugfix/ZENKO-3620-ci-worker-spawn-issue`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/2.1/bugfix/ZENKO-3620-ci-worker-spawn-issue
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/2.1/bugfix/ZENKO-3620-ci-worker-spawn-issue
```

Please always comment pull request #1280 instead of this one.