### PR TITLE
ZENKO-3623 - upgrade vault to 8.3.2

### DIFF
--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -54,7 +54,7 @@ zenko-operator:
 vault:
   sourceRegistry: registry.scality.com/vault
   image: vault 
-  tag: 8.3.0
+  tag: 8.3.2
   envsubst: VAULT_TAG
 backbeat:
   sourceRegistry: registry.scality.com/backbeat

--- a/tests/zenko_tests/node_tests/smoke_tests/vault_admin_and_IAM_API_tests/iamApi.js
+++ b/tests/zenko_tests/node_tests/smoke_tests/vault_admin_and_IAM_API_tests/iamApi.js
@@ -33,8 +33,7 @@ describe('IAM users: ', () => {
         next => iamAccountClient.createUser({ UserName: userName }, next),
         next => iamAccountClient.listUsers({}, next),
         next => iamAccountClient.getUser({ UserName: userName }, next),
-        // TODO: uncomment once update user is implemented: ZENKO-2871
-        // next => iamAccountClient.updateUser({ UserName: userName, NewPath: randomPath }, next),
+        next => iamAccountClient.updateUser({ UserName: userName, NewPath: randomPath }, next),
         next => iamAccountClient.deleteUser({ UserName: userName }, next),
     ], done));
 });


### PR DESCRIPTION
<!--
Thank you for contributing to Zenko!

Please enter applicable information below.
-->

**What does this PR do, and why do we need it?**
Vault now supports user updates in 8.3.2, so we want the update-user smoke tests activated (and a vault version bump)

**Which issue does this PR fix?**

fixes ZENKO-3623

**Special notes for your reviewers**:
¯\\_(ツ)_/¯