### PR TITLE
INTEGRATION [PR#1296 > development/2.0] improvement: ZENKO-3597 bump cloudserver to 8.2.14

### DIFF
--- a/kubernetes/zenko/charts/cloudserver/values.yaml
+++ b/kubernetes/zenko/charts/cloudserver/values.yaml
@@ -101,7 +101,7 @@ replicaFactor: 1
 
 image:
   repository: registry.scality.com/cloudserver/cloudserver
-  tag: 8.2.9
+  tag: 8.2.14
   pullPolicy: IfNotPresent
 
 proxy:


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1296.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/2.0/improvement/ZENKO-3597-bump-cloudserver-8-2-13`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/2.0/improvement/ZENKO-3597-bump-cloudserver-8-2-13
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/2.0/improvement/ZENKO-3597-bump-cloudserver-8-2-13
```

Please always comment pull request #1296 instead of this one.