### PR TITLE
Fix cruise-control image name in ZenkoVersion

### DIFF
--- a/solution/zenkoversion.yaml
+++ b/solution/zenkoversion.yaml
@@ -51,7 +51,7 @@ spec:
         image: kafka
         tag: '${KAFKA_TAG}'
       cruiseControl:
-        image: kafka-cruise-control
+        image: cruise-control
         tag: '${KAFKA_CRUISECONTROL_TAG}'
       monitoring:
         image: jmx-javaagent


### PR DESCRIPTION
The image shipped is tagged `cruise-control` while we referenced
`kafka-cruise-control`.