### PR TITLE
ZENKO-3657: fix incorrect key name `volumePermission` to `volumePermi…

### DIFF
--- a/solution-base/build.sh
+++ b/solution-base/build.sh
@@ -119,9 +119,9 @@ function render_mongodb_yamls()
         --set "image.registry=${MONGODB_REGISTRY}" \
         --set "image.repository=${MONGODB_IMAGE_NAME}" \
         --set "image.tag=${MONGODB_IMAGE_TAG}" \
-        --set "volumePermission.image.registry=${MONGODB_REGISTRY}" \
-        --set "volumePermission.image.repository=${MONGODB_INIT_IMAGE_NAME}" \
-        --set "volumePermission.image.tag=${MONGODB_INIT_IMAGE_TAG}" \
+        --set "volumePermissions.image.registry=${MONGODB_REGISTRY}" \
+        --set "volumePermissions.image.repository=${MONGODB_INIT_IMAGE_NAME}" \
+        --set "volumePermissions.image.tag=${MONGODB_INIT_IMAGE_TAG}" \
         --set "metrics.image.registry=${MONGODB_REGISTRY}" \
         --set "metrics.image.repository=${MONGODB_EXPORTER_IMAGE_NAME}" \
         --set "metrics.image.tag=${MONGODB_EXPORTER_IMAGE_TAG}" \


### PR DESCRIPTION
…ssions` in template

<!--
Thank you for contributing to Zenko!

Please enter applicable information below.
-->

**What does this PR do, and why do we need it?**

fixed incorrect key used in templating:
`volumePermission` to `volumePermissions`

**Which issue does this PR fix?**

fixes ZENKO-3657

**Special notes for your reviewers**:
