### PR TITLE
INTEGRATION [PR#1338 > development/2.2] ZENKO-3659 use latest Cloudserver image 8.2.15

### DIFF
--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -64,7 +64,7 @@ backbeat:
 cloudserver:
   sourceRegistry: registry.scality.com/cloudserver
   image: cloudserver
-  tag: 8.2.14
+  tag: 8.2.15
   envsubst: CLOUDSERVER_TAG
 s3utils:
   sourceRegistry: registry.scality.com/s3utils


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1338.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/2.2/improvement/ZENKO-3659/bump`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/2.2/improvement/ZENKO-3659/bump
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/2.2/improvement/ZENKO-3659/bump
```

Please always comment pull request #1338 instead of this one.