### PR TITLE
ZENKO-3614: use pinned version of minideb

### DIFF
--- a/solution-base/deps.txt
+++ b/solution-base/deps.txt
@@ -1,3 +1,3 @@
 bitnami/mongodb:4.0.14-debian-9-r24
-bitnami/minideb:stretch
+registry.scality.com/zenko-dev/minideb:base-2.1.0
 bitnami/mongodb-exporter:0.10.0-debian-9-r104


### PR DESCRIPTION
use `registry.scality.com/zenko-dev/minideb:base-2.1.0` that snapshots
bitnami/minideb:stretch@sha256:43d6f5bf896d1cedce1097151eace002fdbec4e7968f6c88812a5f94a5e938f7

<!--
Thank you for contributing to Zenko!

Please enter applicable information below.
-->

**What does this PR do, and why do we need it?**

**Which issue does this PR fix?**

fixes #<ISSUE>

**Special notes for your reviewers**:
