### PR TITLE
INTEGRATION [PR#1347 > development/2.2] ZENKO-3614: use pinned version of minideb

### DIFF
--- a/solution-base/deps.txt
+++ b/solution-base/deps.txt
@@ -1,3 +1,3 @@
 bitnami/mongodb:4.0.14-debian-9-r24
-bitnami/minideb:stretch
+registry.scality.com/zenko-dev/minideb:base-2.1.0
 bitnami/mongodb-exporter:0.10.0-debian-9-r104


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1347.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/2.2/improvement/ZENKO-3614/usePinnedBitnamiImages`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/2.2/improvement/ZENKO-3614/usePinnedBitnamiImages
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/2.2/improvement/ZENKO-3614/usePinnedBitnamiImages
```

Please always comment pull request #1347 instead of this one.