### PR TITLE
Enable mongodb metrics capture by prometheus

### DIFF
--- a/solution-base/mongodb/charts/mongodb/custom-values.yaml
+++ b/solution-base/mongodb/charts/mongodb/custom-values.yaml
@@ -493,7 +493,8 @@ metrics:
 
     ## Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
-    additionalLabels: {}
+    additionalLabels:
+      metalk8s.scality.com/monitor: ''
 
     ## Specify Metric Relabellings to add to the scrape endpoint
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint


### PR DESCRIPTION
Since we are using metalk8s' prometheus stack, we must set the
`metalk8s.scality.com/monitor: ''` label on the ServiceMonitor.

Issue: ZENKO-3691