### PR TITLE
ZENKO-3700: fix creat-user script to fail with non-zero

### DIFF
--- a/eve/workers/end2end/scripts/configs/mongodb_init_scripts/create-app-user.sh
+++ b/eve/workers/end2end/scripts/configs/mongodb_init_scripts/create-app-user.sh
@@ -30,7 +30,10 @@ retry() {
         sleep 5
     done
 
-    [ $count -lt 10 ] || echo "Failed to create app user."
+    if [ $count -ge 10 ]; then
+        echo "Failed to create app user."
+        exit 1
+    fi
 }
 
 retry create_user

--- a/solution-base/mongodb/charts/mongodb/files/docker-entrypoint-initdb.d/create-app-user.sh
+++ b/solution-base/mongodb/charts/mongodb/files/docker-entrypoint-initdb.d/create-app-user.sh
@@ -24,7 +24,10 @@ retry() {
         sleep 5
     done
 
-    [ $count -lt 10 ] || echo "Failed to create app user."
+    if [ $count -ge 10 ]; then
+        echo "Failed to create app user."
+        exit 1
+    fi
 }
 
 retry create_user


### PR DESCRIPTION
<!--
Thank you for contributing to Zenko!

Please enter applicable information below.
-->

**What does this PR do, and why do we need it?**

update create-user script to exit with non-zero on error.
currently, the script will only soft fail, printing an error message if the user cannot be provisioned; This would allow the deployment to complete without having provisioned the required user needed by the data services.
The non-zero exit is needed to stop the deployment process when the user creation init step fails.

**Which issue does this PR fix?**

fixes ZENKO-3700

**Special notes for your reviewers**:
