### PR TITLE
INTEGRATION [PR#1366 > development/2.2] ZENKO-3700: fix creat-user script to fail with non-zero

### DIFF
--- a/eve/workers/end2end/scripts/configs/mongodb_init_scripts/create-app-user.sh
+++ b/eve/workers/end2end/scripts/configs/mongodb_init_scripts/create-app-user.sh
@@ -30,7 +30,12 @@ retry() {
         sleep 5
     done
 
-    [ $count -lt 10 ] || echo "Failed to create app user."
+    if [ $count -ge 10 ]; then
+        echo "Failed to create app user."
+        exit 1
+    fi
+
+    exit 0
 }
 
 retry create_user

--- a/solution-base/mongodb/charts/mongodb/files/docker-entrypoint-initdb.d/create-app-user.sh
+++ b/solution-base/mongodb/charts/mongodb/files/docker-entrypoint-initdb.d/create-app-user.sh
@@ -24,7 +24,12 @@ retry() {
         sleep 5
     done
 
-    [ $count -lt 10 ] || echo "Failed to create app user."
+    if [ $count -ge 10 ]; then
+        echo "Failed to create app user."
+        exit 1
+    fi
+
+    exit 0
 }
 
 retry create_user


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1366.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/2.2/bugfix/ZENKO-3700/fixMongoDBCreateUser`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/2.2/bugfix/ZENKO-3700/fixMongoDBCreateUser
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/2.2/bugfix/ZENKO-3700/fixMongoDBCreateUser
```

Please always comment pull request #1366 instead of this one.