### PR TITLE
INTEGRATION [PR#1375 > development/2.2] Improvement/zenko 3661 setup dependency mocks for replication tests

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -39,6 +39,22 @@ models:
       E2E_IMAGE_TAG: '%(prop:commit_short_revision)s'
       VAULT_TEST_IMAGE_NAME: '%(prop:vault_test_image_name)s'
       VAULT_TEST_IMAGE_TAG: '%(prop:vault_test_image_tag)s'
+  - env: &secrets_env # contains values used for test config
+      AWS_BACKEND_SOURCE_LOCATION: awsbackend
+      AWS_BACKEND_DESTINATION_LOCATION: awsbackendmismatch
+      GCP_BACKEND_DESTINATION_LOCATION: gcpbackendmismatch
+      AZURE_BACKEND_DESTINATION_LOCATION: azurebackendmismatch
+      LOCATION_QUOTA_BACKEND: quotabackend
+
+      AWS_BUCKET_NAME: ci-zenko-aws-target-bucket
+      AWS_BUCKET_NAME_2: ci-zenko-aws-target-bucket-2
+      AWS_CRR_BUCKET_NAME: ci-zenko-aws-crr-target-bucket
+      AWS_CRR_SRC_BUCKET_NAME: 'ci-zenko-aws-crr-src-bucket-%(prop:bootstrap)s-%(prop:stage_name)s'
+
+      AZURE_BUCKET_NAME: ci-zenko-azure-target-bucket
+      AZURE_BUCKET_NAME_2: ci-zenko-azure-target-bucket-2
+      AZURE_CRR_BUCKET_NAME: ci-zenko-azure-crr-target-bucket
+      AZURE_CRR_SRC_BUCKET_NAME: 'ci-zenko-azure-crr-src-bucket-%(prop:bootstrap)s-%(prop:stage_name)s'
   - env: &mock-env
       AZURE_ACCOUNT_NAME: devstoreaccount1
       AZURE_BACKEND_ENDPOINT: http://azure-mock/devstoreaccount1
@@ -344,6 +360,13 @@ stages:
         env:
           <<: [*kind-env, *e2e-env, *http-env]
         command: bash scripts/run-e2e-test.sh "end2end" ${E2E_IMAGE_NAME}:${E2E_IMAGE_TAG} "smoke" "default"
+        workdir: build/eve/workers/end2end
+        haltOnFailure: true
+    - ShellCommand: &run_backbeat_end2end_tests
+        name: Run backbeat end to end tests
+        env:
+          <<: [*kind-env, *e2e-env, *http-env, *mock-env, *secrets_env]
+        command: bash scripts/run-e2e-test.sh "end2end" ${E2E_IMAGE_NAME}:${E2E_IMAGE_TAG} "backbeat" "default"
         workdir: build/eve/workers/end2end
         haltOnFailure: true
     - ShellCommand: &archive_artifacts

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -39,6 +39,16 @@ models:
       E2E_IMAGE_TAG: '%(prop:commit_short_revision)s'
       VAULT_TEST_IMAGE_NAME: '%(prop:vault_test_image_name)s'
       VAULT_TEST_IMAGE_TAG: '%(prop:vault_test_image_tag)s'
+  - env: &mock-env
+      AZURE_ACCOUNT_NAME: devstoreaccount1
+      AZURE_BACKEND_ENDPOINT: http://azure-mock/devstoreaccount1
+      AZURE_SECRET_KEY: Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==
+      AWS_ENDPOINT: http://aws-mock
+      AWS_ACCESS_KEY: accessKey1
+      AWS_SECRET_KEY: verySecretKey1
+      AWS_ACCESS_KEY_2: accessKey2
+      AWS_SECRET_KEY_2: verySecretKey2
+      VERIFY_CERTIFICATES: "false"
   - Git: &git_pull
       name: git pull
       repourl: "%(prop:git_reference)s"
@@ -306,6 +316,13 @@ stages:
         env:
           <<: [*kind-env, *http-env]
         command: bash scripts/keycloak-helper.sh add-user default
+        workdir: build/eve/workers/end2end
+        haltOnFailure: true
+    - ShellCommand: &install-mocks
+        name: Start external service mocks
+        env:
+          <<: [*kind-env, *e2e-env, *http-env]
+        command: bash scripts/install-mocks.sh "default"
         workdir: build/eve/workers/end2end
         haltOnFailure: true
     - ShellCommand: &configure_end2end_tests

--- a/eve/workers/end2end/scripts/install-mocks.sh
+++ b/eve/workers/end2end/scripts/install-mocks.sh
@@ -1,0 +1,24 @@
+#! /bin/sh
+
+set -exu
+
+NAMESPACE=${1:-default}
+
+kubectl create \
+    -f ../mocks/azure-mock.yaml \
+    -f ../mocks/aws-mock.yaml \
+    --namespace ${NAMESPACE} && \
+kubectl create \
+    configmap aws-mock \
+    --from-file=../mocks/aws/mock-metadata.tar.gz \
+    --namespace ${NAMESPACE}
+
+kubectl wait \
+    --for=condition=Ready \
+    --timeout=10m \
+    pod -l component=mock \
+    --namespace ${NAMESPACE}
+
+kubectl get \
+    pod -l component=mock \
+    --namespace ${NAMESPACE}

--- a/eve/workers/end2end/scripts/run-e2e-test.sh
+++ b/eve/workers/end2end/scripts/run-e2e-test.sh
@@ -50,6 +50,31 @@ run_e2e_test() {
         --env=CYPRESS_KEYCLOAK_CLIENT_ID=${OIDC_CLIENT_ID} \
         --env=CYPRESS_KEYCLOAK_REALM=${OIDC_REALM} \
         --env=UI_ENDPOINT=${UI_ENDPOINT} \
+        --env=AZURE_ACCOUNT_NAME_2=${AZURE_ACCOUNT_NAME_2} \
+        --env=AZURE_BACKEND_ENDPOINT_2=${AZURE_BACKEND_ENDPOINT_2} \
+        --env=AZURE_SECRET_KEY_2=${AZURE_SECRET_KEY_2} \
+        --env=AWS_BACKEND_SOURCE_LOCATION=${AWS_BACKEND_SOURCE_LOCATION} \
+        --env=AWS_BACKEND_DESTINATION_LOCATION=${AWS_BACKEND_DESTINATION_LOCATION} \
+        --env=GCP_BACKEND_DESTINATION_LOCATION=${GCP_BACKEND_DESTINATION_LOCATION} \
+        --env=AZURE_BACKEND_DESTINATION_LOCATION=${AZURE_BACKEND_DESTINATION_LOCATION} \
+        --env=LOCATION_QUOTA_BACKEND=${LOCATION_QUOTA_BACKEND} \
+        --env=AWS_BUCKET_NAME=${AWS_BUCKET_NAME} \
+        --env=AWS_BUCKET_NAME_2=${AWS_BUCKET_NAME_2} \
+        --env=AWS_CRR_BUCKET_NAME=${AWS_CRR_BUCKET_NAME} \
+        --env=AWS_CRR_SRC_BUCKET_NAME=${AWS_CRR_SRC_BUCKET_NAME} \
+        --env=AZURE_BUCKET_NAME=${AZURE_BUCKET_NAME} \
+        --env=AZURE_BUCKET_NAME_2=${AZURE_BUCKET_NAME_2} \
+        --env=AZURE_CRR_BUCKET_NAME=${AZURE_CRR_BUCKET_NAME} \
+        --env=AZURE_CRR_SRC_BUCKET_NAME=${AZURE_CRR_SRC_BUCKET_NAME} \
+        --env=AZURE_ACCOUNT_NAME=${AZURE_ACCOUNT_NAME} \
+        --env=AZURE_BACKEND_ENDPOINT=${AZURE_BACKEND_ENDPOINT} \
+        --env=AZURE_SECRET_KEY=${AZURE_SECRET_KEY} \
+        --env=AWS_ENDPOINT=${AWS_ENDPOINT} \
+        --env=AWS_ACCESS_KEY=${AWS_ACCESS_KEY} \
+        --env=AWS_SECRET_KEY=${AWS_SECRET_KEY} \
+        --env=AWS_ACCESS_KEY_2=${AWS_ACCESS_KEY_2} \
+        --env=AWS_SECRET_KEY_2=${AWS_SECRET_KEY_2} \
+        --env=VERIFY_CERTIFICATES=${VERIFY_CERTIFICATES} \
         --command -- sh -c "${2}"
 }
 
@@ -60,4 +85,6 @@ elif [ "$STAGE" = "debug" ]; then
    run_e2e_test '-ti' 'bash'
 elif [ "$STAGE" = "smoke" ]; then
    run_e2e_test '' 'cd node_tests && npm run test_smoke'
+elif [ "$STAGE" = "backbeat" ]; then
+   run_e2e_test '' 'cd node_tests && npm-run-all run test_aws_crr test_azure_crr'
 fi

--- a/eve/workers/mocks/aws-mock.yaml
+++ b/eve/workers/mocks/aws-mock.yaml
@@ -17,6 +17,7 @@ metadata:
   name: aws-mock-pod
   labels:
     name: aws-mock
+    component: mock
 spec:
   initContainers:
   - image: zenko/cloudserver:latest
@@ -60,4 +61,4 @@ spec:
     emptyDir: {}
   - name: configmap
     configMap:
-      name: aws-mock  
+      name: aws-mock

--- a/eve/workers/mocks/azure-mock.yaml
+++ b/eve/workers/mocks/azure-mock.yaml
@@ -17,6 +17,7 @@ metadata:
   name: azure-mock-pod
   labels:
     name: azure-mock
+    component: mock
 spec:
   hostname: devstoreaccount1
   subdomain: azure-mock

--- a/tests/zenko_tests/configuration.py
+++ b/tests/zenko_tests/configuration.py
@@ -124,7 +124,8 @@ def main():
                                     namespace=NAMESPACE)
 
         for endpoint in e2e_config["endpoints"]:
-            endpoints.create_endpoint(client, UUID, endpoint)
+            endpoints.create_endpoint(client, UUID, endpoint["hostname"],
+                                      endpoint["locationName"])
 
         for location in e2e_config["locations"]:
             locations.create_location(client, UUID, location)

--- a/tests/zenko_tests/e2e-config.yaml
+++ b/tests/zenko_tests/e2e-config.yaml
@@ -1,8 +1,25 @@
 accounts:
   - "zenko"
-endpoints: []
-locations: []
+endpoints:
+  - hostname: "http://aws-mock"
+    locationName: "awsbackendmismatch"
+  - hostname: "http://azure-mock/devstoreaccount1"
+    locationName: "azurebackendmismatch"
+locations:
+  - name: "awsbackendmismatch"
+    locationType: "location-aws-s3-v1"
+    details:
+      bucketName: "ci-zenko-aws-crr-target-bucket"
+      endpoint: "http://aws-mock"
+      accessKey: "accessKey1"
+      secretKey: "verySecretKey1"
+  - name: "azurebackendmismatch"
+    locationType: "location-azure-v1"
+    details:
+      bucketName: "ci-zenko-azure-crr-target-bucket"
+      endpoint: "http://azure-mock/devstoreaccount1"
+      accessKey: "devstoreaccount1"
+      secretKey: "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
 workflows:
   replication: []
   lifecycle: []
-  ingestion: []

--- a/tests/zenko_tests/e2e_config/endpoints.py
+++ b/tests/zenko_tests/e2e_config/endpoints.py
@@ -4,5 +4,27 @@ import logging
 
 _log = logging.getLogger("end2end configuration")
 
-def create_endpoint(client, UUID, endpoint):
-    pass
+def create_endpoint(client, uuid, host, location):
+    """
+    Creates an endpoint for a location
+    :param client: swagger client
+    :param uuid: zenko instance uuid
+    :param host: hostname
+    :param location: location name
+    """
+    try:
+        Endpoint_V1 = client.get_model('endpoint-v1')
+        ep = Endpoint_V1(hostname=host, locationName=location)
+
+        res = (
+            client.ui_facing
+            .createConfigurationOverlayEndpoint(endpoint=ep, uuid=uuid)
+            .response()
+            .result
+        )
+
+        _log.info(res)
+        _log.info("endpoint created")
+    except Exception as e:
+        raise Exception(
+            "Failed to create endpoint for location '%s': %s" % (location, e))

--- a/tests/zenko_tests/e2e_config/locations.py
+++ b/tests/zenko_tests/e2e_config/locations.py
@@ -4,5 +4,28 @@ import logging
 
 _log = logging.getLogger("end2end configuration")
 
-def create_locations(client, UUID, location):
-    pass
+def create_location(client, uuid, location):
+    """
+    Creates a location
+    :param client: swagger client
+    :param uuid: zenko instance uuid
+    :param location: location details
+    """
+    try:
+        Location_V1 = client.get_model('location-v1')
+        loc = Location_V1(name=location["name"],
+                            locationType=location["locationType"],
+                            details=location["details"])
+
+        res = (
+            client.ui_facing
+            .createConfigurationOverlayLocation(location=loc, uuid=uuid)
+            .response()
+            .result
+        )
+
+        _log.info(res)
+        _log.info("location created")
+    except Exception as e:
+        raise Exception(
+            "Failed to create location '%s': %s" % (location["name"], e))

--- a/tests/zenko_tests/e2e_config/schema.py
+++ b/tests/zenko_tests/e2e_config/schema.py
@@ -12,7 +12,7 @@ properties:
         items:
             type: object
             properties:
-                host:
+                hostname:
                     type: string
                 locationName:
                     type: string
@@ -25,6 +25,17 @@ properties:
                     type: string
                 locationType:
                     type: string
+                details:
+                    type: object
+                    properties:
+                        bucketName:
+                            type: string
+                        endpoint:
+                            type: string
+                        accessKey:
+                            type: string
+                        secretKey:
+                            type: string
     workflows:
         type: object
         properties:
@@ -41,4 +52,3 @@ properties:
                 items:
                     type: object
 """
-


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1375.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/2.2/improvement/ZENKO-3661-setup-dependency-mocks-for-replication-tests`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/2.2/improvement/ZENKO-3661-setup-dependency-mocks-for-replication-tests
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/2.2/improvement/ZENKO-3661-setup-dependency-mocks-for-replication-tests
```

Please always comment pull request #1375 instead of this one.