### PR TITLE
bugfix: ZENKO-3723-bump-vault-version

### DIFF
--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -54,7 +54,7 @@ zenko-operator:
 vault:
   sourceRegistry: registry.scality.com/vault
   image: vault
-  tag: 8.3.2
+  tag: 8.3.2.2
   envsubst: VAULT_TAG
 backbeat:
   sourceRegistry: registry.scality.com/backbeat


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
The fix is needed in ARTESCA 1.2-RC2


**Which issue does this PR fix?**

fixes ZENKO-3723


**Note to reviewers**
I have made sure that the change is not reflected in development/2.2 (checkout integration PR)
Logical changes for the new Vault version:
* VAULT-119: Vault logs WebIdentityToken of AssumeRoleWithWebIdentity calls
* VAULT-120: Ci fixes for release stage