### PR TITLE
INTEGRATION [PR#1383 > development/2.2] Fix unicode object keys through zenko-ui

### DIFF
--- a/tests/zenko_tests/node_tests/ui/cypress/fixtures/éléphant.txt
+++ b/tests/zenko_tests/node_tests/ui/cypress/fixtures/éléphant.txt
@@ -1,0 +1,1 @@
+énormément

--- a/tests/zenko_tests/node_tests/ui/cypress/integration/object_spec.js
+++ b/tests/zenko_tests/node_tests/ui/cypress/integration/object_spec.js
@@ -3,6 +3,7 @@ describe('Object', () => {
         const accountName = 'account2';
         const bucketName = 'mybucket6';
         const smallFileName = 'fivehundredandtwelvekb';
+        const unicodeFileName = 'éléphant.txt';
         const mpuFileName = 'fifteenmb';
 
         beforeEach(() => {
@@ -15,6 +16,12 @@ describe('Object', () => {
             cy.uploadObject(bucketName, smallFileName);
             cy.get('table tbody tr').should('have.length', 1);
             cy.get('table tbody tr').contains(smallFileName).should('be.visible');
+        });
+
+        it('should upload an object with an escaped name to a bucket', () => {
+            cy.uploadObject(bucketName, unicodeFileName);
+            cy.get('table tbody tr').should('have.length', 1);
+            cy.get('table tbody tr').contains(unicodeFileName).should('be.visible');
         });
 
         it('should multipart upload an object to a bucket (15 mb)', () => {

--- a/tests/zenko_tests/python_tests/zenko_e2e/cloudserver/test_crud.py
+++ b/tests/zenko_tests/python_tests/zenko_e2e/cloudserver/test_crud.py
@@ -1,0 +1,11 @@
+from ..fixtures import *
+
+
+def test_put_unicode(zenko_bucket, testfile, objkey_unicode):
+    util.mark_test('CRUD')
+    bucket = zenko_bucket  # pylint: disable=unused-variable
+    bucket.put_object(
+        Body=testfile,
+        Key=objkey
+    )
+    assert util.check_object(objkey, testfile, bucket)

--- a/tests/zenko_tests/python_tests/zenko_e2e/fixtures/object.py
+++ b/tests/zenko_tests/python_tests/zenko_e2e/fixtures/object.py
@@ -4,6 +4,11 @@ import zenko_e2e.util as util
 
 
 @pytest.fixture(scope='function')
+def objkey_unicode():
+    return '/'.join([conf.OBJ_PREFIX, util.make_name('éléphant')])
+
+
+@pytest.fixture(scope='function')
 def objkey():
     return '/'.join([conf.OBJ_PREFIX, util.make_name('test-object')])
 


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1383.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/2.2/bugfix/ZENKO-3724-fix-zenko-ui-proxy-path-encoding`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/2.2/bugfix/ZENKO-3724-fix-zenko-ui-proxy-path-encoding
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/2.2/bugfix/ZENKO-3724-fix-zenko-ui-proxy-path-encoding
```

Please always comment pull request #1383 instead of this one.