### PR TITLE
INTEGRATION [PR#1393 > development/2.2] ZENKO-3727 ensure we read zenko-operator version from deps.yaml

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -72,10 +72,14 @@ models:
         echo "Could not reach Docker daemon from buildbot worker" >&2
         exit 1'
       haltOnFailure: true
-  - SetProperties: &set_operator_properties
-      properties:
-        OPERATOR_IMAGE_NAME: registry.scality.com/sf-eng/zenko-operator
-        OPERATOR_IMAGE_TAG: '1.1.6'
+  - SetPropertyFromCommand: &set_operator_image_name
+      name: Set operator image name
+      property: OPERATOR_IMAGE_NAME
+      command: yq eval '."zenko-operator" | .sourceRegistry + "/" + .image' solution/deps.yaml
+  - SetPropertyFromCommand: &set_operator_image_tag
+      name: Set operator image name
+      property: OPERATOR_IMAGE_TAG
+      command: yq eval '."zenko-operator".tag' solution/deps.yaml
   - ShellCommand: &ssh_access
       # Connect with ssh eve@ip
       name: setup team ssh credentials
@@ -230,7 +234,8 @@ stages:
     worker: *end2end-worker
     steps:
     - Git: *git_pull
-    - SetProperties: *set_operator_properties
+    - SetPropertyFromCommand: *set_operator_image_name
+    - SetPropertyFromCommand: *set_operator_image_tag
     - ShellCommand: *wait_docker_daemon
     - ShellCommand: *private_registry_login
     - ShellCommand: *ssh_access
@@ -352,7 +357,8 @@ stages:
     worker: *end2end-worker
     steps:
     - Git: *git_pull
-    - SetProperties: *set_operator_properties
+    - SetPropertyFromCommand: *set_operator_image_name
+    - SetPropertyFromCommand: *set_operator_image_tag
     - ShellCommand: *wait_docker_daemon
     - ShellCommand: *private_registry_login
     - ShellCommand: *ssh_access
@@ -398,7 +404,8 @@ stages:
     worker: *end2end-worker
     steps:
     - Git: *git_pull
-    - SetProperties: *set_operator_properties
+    - SetPropertyFromCommand: *set_operator_image_name
+    - SetPropertyFromCommand: *set_operator_image_tag
     - ShellCommand: *wait_docker_daemon
     - ShellCommand: *private_registry_login
     - ShellCommand: *ssh_access


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1393.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/2.2/bugfix/ZENKO-3727-read-zenko-operator-version-from-deps`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/2.2/bugfix/ZENKO-3727-read-zenko-operator-version-from-deps
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/2.2/bugfix/ZENKO-3727-read-zenko-operator-version-from-deps
```

Please always comment pull request #1393 instead of this one.