### PR TITLE
zenko-3747 bump cloudserver version, embed dashboards

### DIFF
--- a/eve/workers/build-iso/Dockerfile
+++ b/eve/workers/build-iso/Dockerfile
@@ -2,6 +2,7 @@ FROM centos:7
 WORKDIR /workdir
 
 ENV PATH=$PATH:/usr/local/go/bin
+ENV GO_VERSION 1.14.3
 ENV HELM_VERSION v3.2.3
 ENV YQ_VERSION v4.6.3
 ENV YQ_BINARY yq_linux_amd64
@@ -13,11 +14,11 @@ RUN yum install -y yum-utils gettext && \
         --add-repo \
         https://download.docker.com/linux/centos/docker-ce.repo
 RUN yum install -y python3 make skopeo wget mkisofs git docker-ce docker-ce-cli isomd5sum
-RUN wget https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz
+RUN curl --fail -LO https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz
 RUN tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz
-RUN curl -sSL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz | \
+RUN curl --fail -sSL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz | \
     tar -xvz && install linux-amd64/helm /usr/local/bin
-RUN wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/${YQ_BINARY} -O /usr/bin/yq && \
+RUN curl --fail -L https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/${YQ_BINARY} -o /usr/bin/yq && \
     chmod +x /usr/bin/yq
 RUN curl -sSL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz | \
     tar xzvf - && mv kustomize /usr/local/bin

--- a/eve/workers/build-iso/Dockerfile
+++ b/eve/workers/build-iso/Dockerfile
@@ -14,7 +14,7 @@ RUN yum install -y yum-utils gettext epel-release && \
     yum-config-manager \
         --add-repo \
         https://download.docker.com/linux/centos/docker-ce.repo
-RUN yum install -y python3 make wget mkisofs git docker-ce docker-ce-cli isomd5sum
+RUN yum install -y python3 make wget mkisofs git docker-ce docker-ce-cli isomd5sum jq
 RUN curl --fail -LO https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz
 RUN tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz
 RUN curl --fail -sSL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz | \

--- a/eve/workers/build-iso/Dockerfile
+++ b/eve/workers/build-iso/Dockerfile
@@ -8,12 +8,13 @@ ENV YQ_VERSION v4.6.3
 ENV YQ_BINARY yq_linux_amd64
 ENV KUSTOMIZE_VERSION v4.4.1
 ENV GO_VERSION 1.16.12
+ENV SKOPEO_VERSION v1.5.2
 
-RUN yum install -y yum-utils gettext && \
+RUN yum install -y yum-utils gettext epel-release && \
     yum-config-manager \
         --add-repo \
         https://download.docker.com/linux/centos/docker-ce.repo
-RUN yum install -y python3 make skopeo wget mkisofs git docker-ce docker-ce-cli isomd5sum
+RUN yum install -y python3 make wget mkisofs git docker-ce docker-ce-cli isomd5sum
 RUN curl --fail -LO https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz
 RUN tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz
 RUN curl --fail -sSL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz | \
@@ -22,6 +23,11 @@ RUN curl --fail -L https://github.com/mikefarah/yq/releases/download/${YQ_VERSIO
     chmod +x /usr/bin/yq
 RUN curl -sSL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz | \
     tar xzvf - && mv kustomize /usr/local/bin
+RUN yum install -y gcc gpgme-devel libassuan-devel btrfs-progs-devel device-mapper-devel
+RUN git clone --depth 1 --branch ${SKOPEO_VERSION} https://github.com/containers/skopeo $GOPATH/src/github.com/containers/skopeo && \
+    cd  $GOPATH/src/github.com/containers/skopeo && \
+    DISABLE_DOCS=1 make bin/skopeo && \
+    DISABLE_DOCS=1 make install
 
 # install python + buildbot worker
 RUN pip3 install buildbot-worker

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -1,12 +1,59 @@
+# Please keep the first level keys sorted
+# to sort keys, use the following command
+# yq eval 'sortKeys(.)' -i deps.yaml
+backbeat:
+  sourceRegistry: registry.scality.com/backbeat
+  image: backbeat
+  tag: 8.3.1
+  envsubst: BACKBEAT_TAG
+blobserver:
+  sourceRegistry: registry.scality.com/sf-eng
+  image: blobserver
+  tag: 1.0.8
+  envsubst: BLOBSERVER_TAG
+busybox:
+  image: busybox
+  tag: 1.33.0
+  envsubst: BUSYBOX_TAG
+cloudserver:
+  sourceRegistry: registry.scality.com/cloudserver
+  image: cloudserver
+  tag: 8.3.2
+  envsubst: CLOUDSERVER_TAG
+jabba:
+  sourceRegistry: registry.scality.com/jabba
+  image: jabba
+  tag: 1.0.0
+  envsubst: JABBA_TAG
 jmx-javaagent:
   sourceRegistry: banzaicloud
   image: jmx-javaagent
   tag: 0.14.0
   envsubst: JMX_JAVAAGENT_TAG
-busybox:
-  image: busybox
-  tag: 1.33.0
-  envsubst: BUSYBOX_TAG
+kafka:
+  sourceRegistry: ghcr.io/banzaicloud
+  image: kafka
+  tag: 2.13-2.7.0-bzc.1
+  envsubst: KAFKA_TAG
+kafka-cruise-control:
+  sourceRegistry: ghcr.io/banzaicloud
+  image: cruise-control
+  tag: 2.5.37
+  envsubst: KAFKA_CRUISECONTROL_TAG
+mongodb:
+  sourceRegistry: kubedb
+  image: mongo
+  tag: 4.0-v1
+  envsubst: MONGODB_TAG
+pensieve-api:
+  sourceRegistry: registry.scality.com/pensieve-api
+  image: pensieve-api
+  tag: 1.1.0
+  envsubst: PENSIEVE_API_TAG
+redis:
+  image: redis
+  tag: 5.0.3
+  envsubst: REDIS_TAG
 redis-kubedb:
   sourceRegistry: kubedb
   image: redis
@@ -17,77 +64,33 @@ redis_exporter:
   image: redis_exporter
   tag: v1.29.0
   envsubst: REDIS_EXPORTER_TAG
-zookeeper:
-  sourceRegistry: pravega
-  image: zookeeper
-  tag: 0.2.13
-  envsubst: ZOOKEEPER_TAG
-redis:
-  image: redis
-  tag: 5.0.3
-  envsubst: REDIS_TAG
-blobserver:
-  sourceRegistry: registry.scality.com/sf-eng
-  image: blobserver
-  tag: 1.0.8
-  envsubst: BLOBSERVER_TAG
-jabba:
-  sourceRegistry: registry.scality.com/jabba
-  image: jabba
-  tag: 1.0.0
-  envsubst: JABBA_TAG
-pensieve-api:
-  sourceRegistry: registry.scality.com/pensieve-api
-  image: pensieve-api
-  tag: 1.1.0
-  envsubst: PENSIEVE_API_TAG
-utapi:
-  sourceRegistry: registry.scality.com/sf-eng
-  image: utapi
-  tag: zenko-1.0.0
-  envsubst: UTAPI_TAG
-zenko-operator:
-  sourceRegistry: registry.scality.com/zenko-operator
-  image: zenko-operator
-  tag: 1.2.5
-  envsubst: ZENKO_OPERATOR_TAG
-vault:
-  sourceRegistry: registry.scality.com/vault
-  image: vault
-  tag: 8.3.8
-  envsubst: VAULT_TAG
-backbeat:
-  sourceRegistry: registry.scality.com/backbeat
-  image: backbeat
-  tag: 8.3.1
-  envsubst: BACKBEAT_TAG
-cloudserver:
-  sourceRegistry: registry.scality.com/cloudserver
-  image: cloudserver
-  tag: 8.3.2
-  envsubst: CLOUDSERVER_TAG
 s3utils:
   sourceRegistry: registry.scality.com/s3utils
   image: s3utils
   tag: 1.10.1
   envsubst: S3UTILS_TAG
-kafka-cruise-control:
-  sourceRegistry: ghcr.io/banzaicloud
-  image: cruise-control
-  tag: 2.5.37
-  envsubst: KAFKA_CRUISECONTROL_TAG
+utapi:
+  sourceRegistry: registry.scality.com/sf-eng
+  image: utapi
+  tag: zenko-1.0.0
+  envsubst: UTAPI_TAG
+vault:
+  sourceRegistry: registry.scality.com/vault
+  image: vault
+  tag: 8.3.8
+  envsubst: VAULT_TAG
+zenko-operator:
+  sourceRegistry: registry.scality.com/zenko-operator
+  image: zenko-operator
+  tag: 1.2.5
+  envsubst: ZENKO_OPERATOR_TAG
 zenko-ui:
   sourceRegistry: registry.scality.com/zenko-ui
   image: zenko-ui
   tag: 1.1.1
   envsubst: ZENKO_UI_TAG
-kafka:
-  sourceRegistry: ghcr.io/banzaicloud
-  image: kafka
-  tag: 2.13-2.7.0-bzc.1
-  envsubst: KAFKA_TAG
-mongodb:
-  sourceRegistry: kubedb
-  image: mongo
-  tag: 4.0-v1
-  envsubst: MONGODB_TAG
+zookeeper:
+  sourceRegistry: pravega
+  image: zookeeper
+  tag: 0.2.13
+  envsubst: ZOOKEEPER_TAG

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -18,7 +18,7 @@ busybox:
 cloudserver:
   sourceRegistry: registry.scality.com/cloudserver
   image: cloudserver
-  tag: 8.3.2
+  tag: 8.3.3
   envsubst: CLOUDSERVER_TAG
 jabba:
   sourceRegistry: registry.scality.com/jabba

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -17,6 +17,7 @@ busybox:
   envsubst: BUSYBOX_TAG
 cloudserver:
   sourceRegistry: registry.scality.com/cloudserver
+  dashboard: cloudserver-dashboards
   image: cloudserver
   tag: 8.3.3
   envsubst: CLOUDSERVER_TAG


### PR DESCRIPTION
- Bump cloudserver version
- Using new version, deploy dashboard
- In order to deploy dashboard use skopeo to pull dashboard from registry and deploy it as OCI image
- update skopeo version to handle OCI image
- upgrade the `build-iso` dockerfile to use `curl` only (remove use of `wget`).
- sort the list of dependencies so it is easier to find an entry by looking at it.