### PR TITLE
bf: ZENKO-3796 enable ingestion tests

### DIFF
--- a/tests/zenko_tests/node_tests/backbeat/tests/ingestion/ingestionS3C.js
+++ b/tests/zenko_tests/node_tests/backbeat/tests/ingestion/ingestionS3C.js
@@ -169,8 +169,7 @@ describe('Ingesting existing data from RING S3C bucket', () => {
         ], done);
     });
 
-    // BUG: user metadata not replicating
-    it.skip('should ingest user metadata', done => {
+    it('should ingest user metadata', done => {
         return async.waterfall([
             next => ringS3CUtils.putObjectWithUserMetadata(ingestionSrcBucket, OBJ_KEY, Buffer.alloc(1),
                 next),

--- a/tests/zenko_tests/node_tests/backbeat/tests/ingestion/oobS3C.js
+++ b/tests/zenko_tests/node_tests/backbeat/tests/ingestion/oobS3C.js
@@ -51,7 +51,7 @@ describe('OOB updates for RING S3C bucket', () => {
         ], done);
     });
 
-    it.skip('should receive OOB update with tagged object', done => {
+    it('should receive OOB update with tagged object', done => {
         return async.waterfall([
             next => ringS3CUtils.putObject(ingestionSrcBucket, OBJ_KEY,
                 null, next),


### PR DESCRIPTION
Enable user metadata and object tag ingestion end to end tests.