### PR TITLE
ZENKO-3840 bump cloud server to version 8.2.18

### DIFF
--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -64,7 +64,7 @@ backbeat:
 cloudserver:
   sourceRegistry: registry.scality.com/cloudserver
   image: cloudserver
-  tag: 8.2.17
+  tag: 8.2.18
   envsubst: CLOUDSERVER_TAG
 s3utils:
   sourceRegistry: registry.scality.com/s3utils


### PR DESCRIPTION
bump cloudserver to 8.2.18
