### PR TITLE
ZENKO-3861 - disabled backbeat dashbards

### DIFF
--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -3,7 +3,6 @@
 # yq eval 'sortKeys(.)' -i deps.yaml
 backbeat:
   sourceRegistry: registry.scality.com/backbeat
-  dashboard: backbeat-dashboards
   image: backbeat
   tag: 8.3.4
   envsubst: BACKBEAT_TAG


### PR DESCRIPTION
Backbeat dashboards are not compatible with artesca.
disable them until they are fixed