### PR TITLE
ZENKO-3923 Adding e2e tests for iam policies on iam user

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,1 +1,0 @@
-{ "extends": "scality" }

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -374,6 +374,13 @@ stages:
         command: bash scripts/run-e2e-test.sh "end2end" ${E2E_IMAGE_NAME}:${E2E_IMAGE_TAG} "end2end" "default"
         workdir: build/eve/workers/end2end
         haltOnFailure: true
+    - ShellCommand: &run_iam_policies_test
+        name: Run iam policies tests
+        env:
+          <<: [ *kind-env, *e2e-env, *http-env, *secrets-env ]
+        command: bash scripts/run-e2e-test.sh "end2end" ${E2E_IMAGE_NAME}:${E2E_IMAGE_TAG} "iam-policies" "default"
+        workdir: build/eve/workers/end2end
+        haltOnFailure: true
     - ShellCommand: &run_smoke_test
         name: Run smoke tests
         env:
@@ -456,6 +463,10 @@ stages:
         <<: *configure_end2end_tests
         env:
           <<: [*kind-env, *e2e-env, *https-env, *secrets-env]
+    - ShellCommand:
+        <<: *run_iam_policies_test
+        env:
+          <<: [ *kind-env, *e2e-env, *http-env, *secrets-env ]
     - ShellCommand:
         <<: *run_end2end_tests
         env:
@@ -568,6 +579,10 @@ stages:
         <<: *configure_end2end_tests
         env:
           <<: [*kind-env, *e2e-env, *http-env, *secrets-env]
+    - ShellCommand:
+        <<: *run_iam_policies_test
+        env:
+          <<: [ *kind-env, *e2e-env, *http-env, *secrets-env ]
     - ShellCommand:
         <<: *run_end2end_tests
         env:

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -464,10 +464,6 @@ stages:
         env:
           <<: [*kind-env, *e2e-env, *https-env, *secrets-env]
     - ShellCommand:
-        <<: *run_iam_policies_test
-        env:
-          <<: [ *kind-env, *e2e-env, *http-env, *secrets-env ]
-    - ShellCommand:
         <<: *run_end2end_tests
         env:
           <<: [*kind-env, *e2e-env, *https-env, *secrets-env]

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -576,10 +576,6 @@ stages:
         env:
           <<: [*kind-env, *e2e-env, *http-env, *secrets-env]
     - ShellCommand:
-        <<: *run_iam_policies_test
-        env:
-          <<: [ *kind-env, *e2e-env, *http-env, *secrets-env ]
-    - ShellCommand:
         <<: *run_end2end_tests
         env:
           <<: [*kind-env, *e2e-env, *http-env, *secrets-env]

--- a/eve/workers/end2end/scripts/run-e2e-test.sh
+++ b/eve/workers/end2end/scripts/run-e2e-test.sh
@@ -78,7 +78,7 @@ run_e2e_test() {
 
 ## TODO use existing entrypoint
 if [ "$STAGE" = "end2end" ]; then
-   run_e2e_test '' 'cd node_tests && npm run test_iam_policies && npm run test_ui && npm run test_operator'
+   run_e2e_test '' 'cd node_tests && npm run test_operator && npm run test_ui'
 elif [ "$STAGE" = "debug" ]; then
    run_e2e_test '-ti' 'bash'
 elif [ "$STAGE" = "smoke" ]; then
@@ -86,4 +86,6 @@ elif [ "$STAGE" = "smoke" ]; then
 elif [ "$STAGE" = "backbeat" ]; then
    ## TODO: use node js to create and remove buckets
    run_e2e_test '' 'cd node_tests && npm run test_all_extensions && cd .. && python3 cleans3c.py'
+elif [ "$STAGE" = "iam-policies" ]; then
+     run_e2e_test '' 'cd node_tests && npm run test_iam_policies'
 fi

--- a/eve/workers/end2end/scripts/run-e2e-test.sh
+++ b/eve/workers/end2end/scripts/run-e2e-test.sh
@@ -78,7 +78,7 @@ run_e2e_test() {
 
 ## TODO use existing entrypoint
 if [ "$STAGE" = "end2end" ]; then
-   run_e2e_test '' 'cd node_tests && npm run test_operator && npm run test_ui'
+   run_e2e_test '' 'cd node_tests && npm run test_operator && npm run test_ui && npm run test_iam_policies'
 elif [ "$STAGE" = "debug" ]; then
    run_e2e_test '-ti' 'bash'
 elif [ "$STAGE" = "smoke" ]; then

--- a/eve/workers/end2end/scripts/run-e2e-test.sh
+++ b/eve/workers/end2end/scripts/run-e2e-test.sh
@@ -78,7 +78,7 @@ run_e2e_test() {
 
 ## TODO use existing entrypoint
 if [ "$STAGE" = "end2end" ]; then
-   run_e2e_test '' 'cd node_tests && npm run test_operator && npm run test_ui && npm run test_iam_policies'
+   run_e2e_test '' 'cd node_tests && npm run test_iam_policies && npm run test_ui && npm run test_operator'
 elif [ "$STAGE" = "debug" ]; then
    run_e2e_test '-ti' 'bash'
 elif [ "$STAGE" = "smoke" ]; then

--- a/eve/workers/end2end/scripts/run-e2e-test.sh
+++ b/eve/workers/end2end/scripts/run-e2e-test.sh
@@ -87,5 +87,5 @@ elif [ "$STAGE" = "backbeat" ]; then
    ## TODO: use node js to create and remove buckets
    run_e2e_test '' 'cd node_tests && npm run test_all_extensions && cd .. && python3 cleans3c.py'
 elif [ "$STAGE" = "iam-policies" ]; then
-     run_e2e_test '' 'cd node_tests && npm run test_iam_policies'
+     run_e2e_test '' 'cd node_tests && npm run lint && npm run test_iam_policies'
 fi

--- a/tests/zenko_tests/node_tests/.eslintrc
+++ b/tests/zenko_tests/node_tests/.eslintrc
@@ -1,0 +1,22 @@
+{ "extends": "scality",
+  "parser": "babel-eslint",
+  "rules": {
+    "prefer-spread" : "off",
+    "no-bitwise" : "off",
+    "class-methods-use-this" : "off",
+    "global-require" : "off",
+    "no-param-reassign" : "off",
+    "no-loop-func" : "off",
+    "padded-blocks" : "off",
+    "no-plusplus": "off",
+    "no-underscore-dangle": "off"
+  },
+  "ignorePatterns": ["backbeat/**/*", "cloudserver/**/*", "smoke_tests/**/*", "ui/**/*", "utils/**/*", "node_modules/**/*"],
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "paths": ["/tests/zenko_tests/node_tests/node_modules", "node_modules"]
+      }
+    }
+  }
+}

--- a/tests/zenko_tests/node_tests/iam_policies/cloudserver/IAMUser.js
+++ b/tests/zenko_tests/node_tests/iam_policies/cloudserver/IAMUser.js
@@ -6,7 +6,7 @@ const {makeGETRequest} = require("../../utils/request");
 const iam = require('../../s3SDK').scalityIAMClient;
 const s3 = require('../../s3SDK').scalityS3Client;
 
-const userName = "username-policy-test-metadatasearch";
+const userName = "username-policy-test-metadatasearch2";
 
 const bucketName = "bucket-test";
 const listBucketPolicyName = "listBucketPolicy";

--- a/tests/zenko_tests/node_tests/iam_policies/cloudserver/IAMUser.js
+++ b/tests/zenko_tests/node_tests/iam_policies/cloudserver/IAMUser.js
@@ -1,64 +1,62 @@
 const assert = require('assert');
 const async = require('async');
-const uuidV4 = require('uuid/v4');
-const {makeGETRequest, getResponseBody} = require("../../utils/request");
-const {stat} = require("fs");
 const { errors } = require('arsenal');
+const { makeGETRequest, getResponseBody } = require('../../utils/request');
 
 const iam = require('../../s3SDK').scalityIAMClient;
 const s3 = require('../../s3SDK').scalityS3Client;
 
-const userName = "username-policy-test-metadatasearch2wwww";
+const userName = 'username-policy-test-metadatasearch';
 
-const bucketName = "bucket-test-mdsearch1wwwww";
-const bucketName2 = "bucket-test-mdsearch2wwwww";
-const allowMdSearchPolicyName = "allowMDSearchPoliwcywwww";
-const denyMdSearchPolicyName = "denyMDSearchPolicywwwww";
+const bucketName = 'bucket-test-mdsearch1';
+const bucketName2 = 'bucket-test-mdsearch2';
+const allowMdSearchPolicyName = 'allowMDSearchPolicy';
+const denyMdSearchPolicyName = 'denyMDSearchPolicy';
 
-function createPolicy(action, isAllow = true, resource = "*") {
+function createPolicy(action, isAllow = true, resource = '*') {
     return JSON.stringify({
-        "Version": "2012-10-17",
-        "Statement": [
+        Version: '2012-10-17',
+        Statement: [
             {
-                "Sid": "Stmt1644586763301",
-                "Action": [
+                Sid: 'Stmt1644586763301',
+                Action: [
                     action,
                 ],
-                "Effect": (isAllow ? "Allow" : "Deny"),
-                "Resource": resource
-            }
-        ]
+                Effect: (isAllow ? 'Allow' : 'Deny'),
+                Resource: resource,
+            },
+        ],
     });
 }
 
 function metadataSearchResponseCode(userCredentials, bucketName, cb) {
     return makeGETRequest(`/${bucketName}/?search=${encodeURIComponent('key LIKE "file"')}`, (err, response) => {
-        if (err)
-            return cb(err);
-        const statusCode = response.statusCode;
+        if (err) { return cb(err); }
+        const { statusCode } = response;
         return getResponseBody(response, (err, res) => {
-            const r = new RegExp('<Message>(.*)<\/Message>');
-            let message = res.match(r)
-            if (message !== null)
-                message = message[1];
-            cb(null, { statusCode, message});
+            const r = /<Message>(.*)<\/Message>/;
+            const message = res.match(r);
+            if (message !== null) {
+                return cb(null, { statusCode, message: message[1] });
+            }
+            return cb(null, { statusCode, message });
         }, true);
-    }, userCredentials)
+    }, userCredentials);
 }
 
 describe('IAM Policies MetadataSearch', () => {
 
-    let userCredentials = {
-        accessKeyId: "",
-        secretAccessKey: "",
+    const userCredentials = {
+        accessKeyId: '',
+        secretAccessKey: '',
     };
 
     before(done => {
         async.series([
-            next => s3.createBucket({Bucket: bucketName}, next),
-            next => s3.createBucket({Bucket: bucketName2}, next),
-            next => iam.createUser({UserName: userName}, next),
-            next => iam.createAccessKey({UserName: userName}, next)
+            next => s3.createBucket({ Bucket: bucketName }, next),
+            next => s3.createBucket({ Bucket: bucketName2 }, next),
+            next => iam.createUser({ UserName: userName }, next),
+            next => iam.createAccessKey({ UserName: userName }, next),
         ], (err, res) => {
             assert.ifError(err);
             userCredentials.accessKeyId = res[3].AccessKey.AccessKeyId;
@@ -69,161 +67,176 @@ describe('IAM Policies MetadataSearch', () => {
 
     after(done => {
         async.series([
-            next => iam.deleteUser({UserName: userName}, next),
-            next => s3.deleteBucket({Bucket: bucketName}, next),
-            next => s3.deleteBucket({Bucket: bucketName2}, next),
+            next => iam.deleteUser({ UserName: userName }, next),
+            next => s3.deleteBucket({ Bucket: bucketName }, next),
+            next => s3.deleteBucket({ Bucket: bucketName2 }, next),
         ], err => {
             assert.ifError(err);
             done();
         });
-    })
+    });
 
-    it('should not be able to metadata search without the permission s3:MetadataSearch', done => {
-        return metadataSearchResponseCode(userCredentials, bucketName, (err, res) => {
+    it(
+        'should not be able to metadata search without the permission s3:MetadataSearch',
+        done => metadataSearchResponseCode(userCredentials, bucketName, (err, res) => {
             if (err) {
-                assert.ifError(err)
-                return done(err)
+                assert.ifError(err);
+                return done(err);
             }
             assert.strictEqual(res.statusCode, 403);
             assert.strictEqual(res.message, errors.AccessDenied.description);
             return done();
-        });
-    });
+        }),
+    );
 
     it('should be able to metadata search with the permission s3:MetadataSearch allowed', done => {
-        async.series([
-            next => iam.createPolicy({PolicyName: allowMdSearchPolicyName, PolicyDocument: createPolicy("s3:MetadataSearch")}, (err, res) => {
-                if (err)
-                    return next(err);
-                return iam.attachUserPolicy({UserName: userName, PolicyArn: res.Policy.Arn}, next);
-            }),
-            next => metadataSearchResponseCode(userCredentials, bucketName, (err, res) => {
-                    if (err) {
-                        assert.ifError(err)
-                        return next(err)
-                    }
-                    assert.strictEqual(res.statusCode, 200);
-                    return next();
+        const policyArns = [];
+        async.series(
+            [
+                next => iam.createPolicy({
+                    PolicyName: allowMdSearchPolicyName,
+                    PolicyDocument: createPolicy('s3:MetadataSearch'),
+                }, (err, res) => {
+                    if (err) { return next(err); }
+                    policyArns.push(res.Policy.Arn);
+                    return iam.attachUserPolicy({ UserName: userName, PolicyArn: res.Policy.Arn }, next);
                 }),
-            next => iam.listPolicies({}, (err, res) => {
+                next => metadataSearchResponseCode(userCredentials, bucketName, (err, res) => {
                     if (err) {
+                        assert.ifError(err);
                         return next(err);
                     }
-                    const p = res.Policies.find(p => p.PolicyName === allowMdSearchPolicyName);
-                    if (p) {
-                        return iam.detachUserPolicy({UserName: userName, PolicyArn: p.Arn}, (err, res) => {
-                            if (err) {
-                                return next(err);
-                            }
-                            return iam.deletePolicy({PolicyArn: p.Arn}, next);
-                        })
-                    }
+                    assert.strictEqual(res.statusCode, 200);
                     return next();
                 }),
             ],
             err => {
                 assert.ifError(err);
-                done();
-            })
+                async.eachSeries(policyArns, (arn, eachCb) => iam.detachUserPolicy(
+                    { UserName: userName, PolicyArn: arn },
+                    () => iam.deletePolicy({ PolicyArn: arn }, (err, res) => {
+                        assert.ifError(err);
+                        return eachCb(err, res);
+                    }),
+                ), done);
+            },
+        );
     });
 
-    it('should be able to metadata search with the permission s3:MetadataSearch allowed' +
-        'on specific bucket but not on others', done => {
-        async.series([
-                next => iam.createPolicy({PolicyName: allowMdSearchPolicyName, PolicyDocument: createPolicy("s3:MetadataSearch", true, `arn:aws:s3:::${bucketName}`)}, (err, res) => {
-                    if (err)
-                        return next(err);
-                    return iam.attachUserPolicy({UserName: userName, PolicyArn: res.Policy.Arn}, next);
+    it('should be able to metadata search with the permission s3:MetadataSearch allowed'
+        + 'on specific bucket but not on others', done => {
+        const policyArns = [];
+        async.series(
+            [
+                next => iam.createPolicy({
+                    PolicyName: allowMdSearchPolicyName,
+                    PolicyDocument: createPolicy(
+                        's3:MetadataSearch',
+                        true,
+                        `arn:aws:s3:::${bucketName}`,
+                    ),
+                }, (err, res) => {
+                    if (err) { return next(err); }
+                    policyArns.push(res.Policy.Arn);
+                    return iam.attachUserPolicy({ UserName: userName, PolicyArn: res.Policy.Arn }, next);
                 }),
                 next => metadataSearchResponseCode(userCredentials, bucketName, (err, res) => {
                     if (err) {
-                        assert.ifError(err)
-                        return next(err)
+                        assert.ifError(err);
+                        return next(err);
                     }
                     assert.strictEqual(res.statusCode, 200);
                     return next();
                 }),
                 next => metadataSearchResponseCode(userCredentials, bucketName2, (err, res) => {
                     if (err) {
-                        assert.ifError(err)
-                        return next(err)
+                        assert.ifError(err);
+                        return next(err);
                     }
                     assert.strictEqual(res.statusCode, 403);
                     assert.strictEqual(res.message, errors.AccessDenied.description);
                     return next();
                 }),
-                next => iam.listPolicies({}, (err, res) => {
-                    if (err) {
-                        return next(err);
-                    }
-                    const p = res.Policies.find(p => p.PolicyName === allowMdSearchPolicyName);
-                    if (p)
-                        return iam.detachUserPolicy({UserName: userName, PolicyArn: p.Arn}, (err, res) => {
-                            if (err)
-                                return next(err);
-                            return iam.deletePolicy({PolicyArn: p.Arn}, next);
-                        })
-                    return next();
-                }),
             ],
             err => {
                 assert.ifError(err);
-                done();
-            })
+                async.eachSeries(policyArns, (arn, eachCb) => iam.detachUserPolicy(
+                    { UserName: userName, PolicyArn: arn },
+                    () => iam.deletePolicy({ PolicyArn: arn }, (err, res) => {
+                        assert.ifError(err);
+                        return eachCb(err, res);
+                    }),
+                ), done);
+            },
+        );
     });
 
     it('should not be able to metadata search with the permission s3:MetadataSearch denied', done => {
-        async.series([
-                next => iam.createPolicy({PolicyName: denyMdSearchPolicyName, PolicyDocument: createPolicy("s3:MetadataSearch", false)}, (err, res) => {
-                    if (err)
-                        return next(err);
-                    return iam.attachUserPolicy({UserName: userName, PolicyArn: res.Policy.Arn}, next);
-                }),
+        const policyArns = [];
+        async.series(
+            [
+                next => iam.createPolicy(
+                    {
+                        PolicyName: denyMdSearchPolicyName,
+                        PolicyDocument: createPolicy('s3:MetadataSearch', false),
+                    },
+                    (err, res) => {
+                        if (err) { return next(err); }
+                        policyArns.push(res.Policy.Arn);
+                        return iam.attachUserPolicy({ UserName: userName, PolicyArn: res.Policy.Arn }, next);
+                    },
+                ),
                 next => metadataSearchResponseCode(userCredentials, bucketName, (err, res) => {
                     if (err) {
-                        assert.ifError(err)
-                        return next(err)
+                        assert.ifError(err);
+                        return next(err);
                     }
                     assert.strictEqual(res.statusCode, 403);
                     assert.strictEqual(res.message, errors.AccessDenied.description);
                     return next();
                 }),
-                next => iam.listPolicies({}, (err, res) => {
-                    if (err) {
-                        return next(err);
-                    }
-                    const p = res.Policies.find(p => p.PolicyName === denyMdSearchPolicyName);
-                    if (p)
-                        return iam.detachUserPolicy({UserName: userName, PolicyArn: p.Arn}, (err, res) => {
-                            if (err)
-                                return next(err);
-                            return iam.deletePolicy({PolicyArn: p.Arn}, next);
-                        })
-                    return next();
-                }),
             ],
             err => {
                 assert.ifError(err);
-                done();
-            })
+                async.eachSeries(policyArns, (arn, eachCb) => iam.detachUserPolicy(
+                    { UserName: userName, PolicyArn: arn },
+                    () => iam.deletePolicy({ PolicyArn: arn }, (err, res) => {
+                        assert.ifError(err);
+                        return eachCb(err, res);
+                    }),
+                ), done);
+            },
+        );
     });
 
     it('should be able to metadata search on all buckets except for denied ones', done => {
-        async.series([
-                next => iam.createPolicy({PolicyName: allowMdSearchPolicyName, PolicyDocument: createPolicy("s3:MetadataSearch")}, (err, res) => {
-                    if (err)
-                        return next(err);
-                    return iam.attachUserPolicy({UserName: userName, PolicyArn: res.Policy.Arn}, next);
+        const policyArns = [];
+        async.series(
+            [
+                next => iam.createPolicy({
+                    PolicyName: allowMdSearchPolicyName,
+                    PolicyDocument: createPolicy('s3:MetadataSearch'),
+                }, (err, res) => {
+                    if (err) { return next(err); }
+                    policyArns.push(res.Policy.Arn);
+                    return iam.attachUserPolicy({ UserName: userName, PolicyArn: res.Policy.Arn }, next);
                 }),
-                next => iam.createPolicy({PolicyName: denyMdSearchPolicyName, PolicyDocument: createPolicy("s3:MetadataSearch", false, `arn:aws:s3:::${bucketName}`)}, (err, res) => {
-                    if (err)
-                        return next(err);
-                    return iam.attachUserPolicy({UserName: userName, PolicyArn: res.Policy.Arn}, next);
+                next => iam.createPolicy({
+                    PolicyName: denyMdSearchPolicyName,
+                    PolicyDocument: createPolicy(
+                        's3:MetadataSearch',
+                        false,
+                        `arn:aws:s3:::${bucketName}`,
+                    ),
+                }, (err, res) => {
+                    if (err) { return next(err); }
+                    policyArns.push(res.Policy.Arn);
+                    return iam.attachUserPolicy({ UserName: userName, PolicyArn: res.Policy.Arn }, next);
                 }),
                 next => metadataSearchResponseCode(userCredentials, bucketName, (err, res) => {
                     if (err) {
-                        assert.ifError(err)
-                        return next(err)
+                        assert.ifError(err);
+                        return next(err);
                     }
                     assert.strictEqual(res.statusCode, 403);
                     assert.strictEqual(res.message, errors.AccessDenied.description);
@@ -231,42 +244,23 @@ describe('IAM Policies MetadataSearch', () => {
                 }),
                 next => metadataSearchResponseCode(userCredentials, bucketName2, (err, res) => {
                     if (err) {
-                        assert.ifError(err)
-                        return next(err)
+                        assert.ifError(err);
+                        return next(err);
                     }
                     assert.strictEqual(res.statusCode, 200);
-                    return next();
-                }),
-                next => iam.listPolicies({}, (err, res) => {
-                    if (err) {
-                        return next(err);
-                    }
-                    const p = res.Policies.find(p => p.PolicyName === denyMdSearchPolicyName);
-                    if (p)
-                        return iam.detachUserPolicy({UserName: userName, PolicyArn: p.Arn}, (err, res) => {
-                            if (err)
-                                return next(err);
-                            return iam.deletePolicy({PolicyArn: p.Arn}, next);
-                        })
-                    return next();
-                }),
-                next => iam.listPolicies({}, (err, res) => {
-                    if (err) {
-                        return next(err);
-                    }
-                    const p = res.Policies.find(p => p.PolicyName === allowMdSearchPolicyName);
-                    if (p)
-                        return iam.detachUserPolicy({UserName: userName, PolicyArn: p.Arn}, (err, res) => {
-                            if (err)
-                                return next(err);
-                            return iam.deletePolicy({PolicyArn: p.Arn}, next);
-                        })
                     return next();
                 }),
             ],
             err => {
                 assert.ifError(err);
-                done();
-            })
+                async.eachSeries(policyArns, (arn, eachCb) => iam.detachUserPolicy(
+                    { UserName: userName, PolicyArn: arn },
+                    () => iam.deletePolicy({ PolicyArn: arn }, (err, res) => {
+                        assert.ifError(err);
+                        return eachCb(err, res);
+                    }),
+                ), done);
+            },
+        );
     });
 });

--- a/tests/zenko_tests/node_tests/iam_policies/cloudserver/IAMUser.js
+++ b/tests/zenko_tests/node_tests/iam_policies/cloudserver/IAMUser.js
@@ -1,0 +1,197 @@
+const assert = require('assert');
+const async = require('async');
+const uuidV4 = require('uuid/v4');
+const {makeGETRequest} = require("../../utils/request");
+
+const iam = require('../../s3SDK').scalityIAMClient;
+const s3 = require('../../s3SDK').scalityS3Client;
+
+const userName = "username-policy-test-metadatasearch";
+
+const bucketName = "bucket-test";
+const listBucketPolicyName = "listBucketPolicy";
+const allowMdSearchPolicyName = "allowMDSearchPolicy";
+const denyMdSearchPolicyName = "denyMDSearchPolicy";
+const objectKey = "file1";
+
+const listBucketPolicy = JSON.stringify({
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "Stmt1644586763301",
+            "Action": [
+                "s3:ListBucket",
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }
+    ]
+});
+
+const allowMdSearchPolicy = JSON.stringify({
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "Stmt1644586763301",
+            "Action": [
+                "s3:MetadataSearch",
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }
+    ]
+});
+
+const denyMdSearchPolicy = JSON.stringify({
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "Stmt1644586763301",
+            "Action": [
+                "s3:MetadataSearch",
+            ],
+            "Effect": "Deny",
+            "Resource": "*"
+        }
+    ]
+});
+
+function metadataSearchResponseCode(userCredentials, cb) {
+    return makeGETRequest(`/${bucketName}/?search=${encodeURIComponent('key LIKE "file"')}`, (err, res) => {
+        if (err)
+            return cb(err);
+        return cb(null, res.statusCode);
+    }, userCredentials)
+}
+
+describe('IAM Policies MetadataSearch', () => {
+
+    let userCredentials = {
+        accessKeyId: "",
+        secretAccessKey: "",
+    };
+
+    before(done => {
+        async.series([
+            next => s3.createBucket({Bucket: bucketName}, next),
+            next => iam.createUser({UserName: userName}, next),
+            next => iam.createAccessKey({UserName: userName}, next),
+            next => iam.createPolicy({PolicyName: listBucketPolicyName, PolicyDocument: listBucketPolicy}, (err, res) => {
+                if (err)
+                    return next(err);
+                return iam.attachUserPolicy({UserName: userName, PolicyArn: res.Policy.Arn}, next);
+            }),
+            next => s3.putObject({Bucket: bucketName, Key: objectKey}, next)
+        ], (err, res) => {
+            assert.ifError(err);
+            userCredentials.accessKeyId = res[2].AccessKey.AccessKeyId;
+            userCredentials.secretAccessKey = res[2].AccessKey.SecretAccessKey;
+            done();
+        });
+    });
+
+    after(done => {
+        async.series([
+            next => iam.listPolicies({}, (err, res) => {
+                if (err) {
+                    return next(err);
+                }
+                const p = res.Policies.find(p => p.PolicyName === listBucketPolicyName);
+                if (p)
+                    return iam.detachUserPolicy({UserName: userName, PolicyArn: p.Arn}, (err, res) => {
+                        if (err)
+                          return next(err);
+                        return iam.deletePolicy({PolicyArn: p.Arn}, next);
+                    })
+                return next();
+            }),
+            next => iam.deleteUser({UserName: userName}, next),
+            next => s3.deleteObject({Bucket: bucketName, Key: objectKey}, next),
+            next => s3.deleteBucket({Bucket: bucketName}, next),
+        ], err => {
+            assert.ifError(err);
+            done();
+        });
+    })
+
+    it('should not be able to metadata search without the policy s3:MetadataSearch', done => {
+        return metadataSearchResponseCode(userCredentials, (err, res) => {
+            if (err) {
+                assert.ifError(err)
+                return done(err)
+            }
+            assert.strictEqual(res, 403);
+            return done();
+        });
+    });
+
+    it('should be able to metadata search with the policy s3:MetadataSearch allowed', done => {
+        async.series([
+            next => iam.createPolicy({PolicyName: allowMdSearchPolicyName, PolicyDocument: allowMdSearchPolicy}, (err, res) => {
+                if (err)
+                    return next(err);
+                return iam.attachUserPolicy({UserName: userName, PolicyArn: res.Policy.Arn}, next);
+            }),
+            next => metadataSearchResponseCode(userCredentials, (err, res) => {
+                    if (err) {
+                        assert.ifError(err)
+                        return next(err)
+                    }
+                    assert.strictEqual(res, 200);
+                    return next();
+                }),
+            next => iam.listPolicies({}, (err, res) => {
+                    if (err) {
+                        return next(err);
+                    }
+                    const p = res.Policies.find(p => p.PolicyName === allowMdSearchPolicyName);
+                    if (p)
+                        return iam.detachUserPolicy({UserName: userName, PolicyArn: p.Arn}, (err, res) => {
+                            if (err)
+                                return next(err);
+                            return iam.deletePolicy({PolicyArn: p.Arn}, next);
+                        })
+                    return next();
+                }),
+            ],
+            err => {
+                assert.ifError(err);
+                done();
+            })
+    });
+
+    it('should not be able to metadata search with the policy s3:MetadataSearch denied', done => {
+        async.series([
+                next => iam.createPolicy({PolicyName: denyMdSearchPolicyName, PolicyDocument: denyMdSearchPolicy}, (err, res) => {
+                    if (err)
+                        return next(err);
+                    return iam.attachUserPolicy({UserName: userName, PolicyArn: res.Policy.Arn}, next);
+                }),
+                next => metadataSearchResponseCode(userCredentials, (err, res) => {
+                    if (err) {
+                        assert.ifError(err)
+                        return next(err)
+                    }
+                    assert.strictEqual(res, 403);
+                    return next();
+                }),
+                next => iam.listPolicies({}, (err, res) => {
+                    if (err) {
+                        return next(err);
+                    }
+                    const p = res.Policies.find(p => p.PolicyName === denyMdSearchPolicyName);
+                    if (p)
+                        return iam.detachUserPolicy({UserName: userName, PolicyArn: p.Arn}, (err, res) => {
+                            if (err)
+                                return next(err);
+                            return iam.deletePolicy({PolicyArn: p.Arn}, next);
+                        })
+                    return next();
+                }),
+            ],
+            err => {
+                assert.ifError(err);
+                done();
+            })
+    });
+});

--- a/tests/zenko_tests/node_tests/iam_policies/cloudserver/IAMUser.js
+++ b/tests/zenko_tests/node_tests/iam_policies/cloudserver/IAMUser.js
@@ -1,16 +1,19 @@
 const assert = require('assert');
 const async = require('async');
 const uuidV4 = require('uuid/v4');
-const {makeGETRequest} = require("../../utils/request");
+const {makeGETRequest, getResponseBody} = require("../../utils/request");
+const {stat} = require("fs");
+const { errors } = require('arsenal');
 
 const iam = require('../../s3SDK').scalityIAMClient;
 const s3 = require('../../s3SDK').scalityS3Client;
 
-const userName = "username-policy-test-metadatasearch2";
+const userName = "username-policy-test-metadatasearch2wwww";
 
-const bucketName = "bucket-test";
-const allowMdSearchPolicyName = "allowMDSearchPolicy";
-const denyMdSearchPolicyName = "denyMDSearchPolicy";
+const bucketName = "bucket-test-mdsearch1wwwww";
+const bucketName2 = "bucket-test-mdsearch2wwwww";
+const allowMdSearchPolicyName = "allowMDSearchPoliwcywwww";
+const denyMdSearchPolicyName = "denyMDSearchPolicywwwww";
 
 function createPolicy(action, isAllow = true, resource = "*") {
     return JSON.stringify({
@@ -28,11 +31,18 @@ function createPolicy(action, isAllow = true, resource = "*") {
     });
 }
 
-function metadataSearchResponseCode(userCredentials, cb) {
-    return makeGETRequest(`/${bucketName}/?search=${encodeURIComponent('key LIKE "file"')}`, (err, res) => {
+function metadataSearchResponseCode(userCredentials, bucketName, cb) {
+    return makeGETRequest(`/${bucketName}/?search=${encodeURIComponent('key LIKE "file"')}`, (err, response) => {
         if (err)
             return cb(err);
-        return cb(null, res.statusCode);
+        const statusCode = response.statusCode;
+        return getResponseBody(response, (err, res) => {
+            const r = new RegExp('<Message>(.*)<\/Message>');
+            let message = res.match(r)
+            if (message !== null)
+                message = message[1];
+            cb(null, { statusCode, message});
+        }, true);
     }, userCredentials)
 }
 
@@ -46,12 +56,13 @@ describe('IAM Policies MetadataSearch', () => {
     before(done => {
         async.series([
             next => s3.createBucket({Bucket: bucketName}, next),
+            next => s3.createBucket({Bucket: bucketName2}, next),
             next => iam.createUser({UserName: userName}, next),
             next => iam.createAccessKey({UserName: userName}, next)
         ], (err, res) => {
             assert.ifError(err);
-            userCredentials.accessKeyId = res[2].AccessKey.AccessKeyId;
-            userCredentials.secretAccessKey = res[2].AccessKey.SecretAccessKey;
+            userCredentials.accessKeyId = res[3].AccessKey.AccessKeyId;
+            userCredentials.secretAccessKey = res[3].AccessKey.SecretAccessKey;
             done();
         });
     });
@@ -60,39 +71,88 @@ describe('IAM Policies MetadataSearch', () => {
         async.series([
             next => iam.deleteUser({UserName: userName}, next),
             next => s3.deleteBucket({Bucket: bucketName}, next),
+            next => s3.deleteBucket({Bucket: bucketName2}, next),
         ], err => {
             assert.ifError(err);
             done();
         });
     })
 
-    it('should not be able to metadata search without the policy s3:MetadataSearch', done => {
-        return metadataSearchResponseCode(userCredentials, (err, res) => {
+    it('should not be able to metadata search without the permission s3:MetadataSearch', done => {
+        return metadataSearchResponseCode(userCredentials, bucketName, (err, res) => {
             if (err) {
                 assert.ifError(err)
                 return done(err)
             }
-            assert.strictEqual(res, 403);
+            assert.strictEqual(res.statusCode, 403);
+            assert.strictEqual(res.message, errors.AccessDenied.description);
             return done();
         });
     });
 
-    it('should be able to metadata search with the policy s3:MetadataSearch allowed', done => {
+    it('should be able to metadata search with the permission s3:MetadataSearch allowed', done => {
         async.series([
             next => iam.createPolicy({PolicyName: allowMdSearchPolicyName, PolicyDocument: createPolicy("s3:MetadataSearch")}, (err, res) => {
                 if (err)
                     return next(err);
                 return iam.attachUserPolicy({UserName: userName, PolicyArn: res.Policy.Arn}, next);
             }),
-            next => metadataSearchResponseCode(userCredentials, (err, res) => {
+            next => metadataSearchResponseCode(userCredentials, bucketName, (err, res) => {
                     if (err) {
                         assert.ifError(err)
                         return next(err)
                     }
-                    assert.strictEqual(res, 200);
+                    assert.strictEqual(res.statusCode, 200);
                     return next();
                 }),
             next => iam.listPolicies({}, (err, res) => {
+                    if (err) {
+                        return next(err);
+                    }
+                    const p = res.Policies.find(p => p.PolicyName === allowMdSearchPolicyName);
+                    if (p) {
+                        return iam.detachUserPolicy({UserName: userName, PolicyArn: p.Arn}, (err, res) => {
+                            if (err) {
+                                return next(err);
+                            }
+                            return iam.deletePolicy({PolicyArn: p.Arn}, next);
+                        })
+                    }
+                    return next();
+                }),
+            ],
+            err => {
+                assert.ifError(err);
+                done();
+            })
+    });
+
+    it('should be able to metadata search with the permission s3:MetadataSearch allowed' +
+        'on specific bucket but not on others', done => {
+        async.series([
+                next => iam.createPolicy({PolicyName: allowMdSearchPolicyName, PolicyDocument: createPolicy("s3:MetadataSearch", true, `arn:aws:s3:::${bucketName}`)}, (err, res) => {
+                    if (err)
+                        return next(err);
+                    return iam.attachUserPolicy({UserName: userName, PolicyArn: res.Policy.Arn}, next);
+                }),
+                next => metadataSearchResponseCode(userCredentials, bucketName, (err, res) => {
+                    if (err) {
+                        assert.ifError(err)
+                        return next(err)
+                    }
+                    assert.strictEqual(res.statusCode, 200);
+                    return next();
+                }),
+                next => metadataSearchResponseCode(userCredentials, bucketName2, (err, res) => {
+                    if (err) {
+                        assert.ifError(err)
+                        return next(err)
+                    }
+                    assert.strictEqual(res.statusCode, 403);
+                    assert.strictEqual(res.message, errors.AccessDenied.description);
+                    return next();
+                }),
+                next => iam.listPolicies({}, (err, res) => {
                     if (err) {
                         return next(err);
                     }
@@ -112,19 +172,20 @@ describe('IAM Policies MetadataSearch', () => {
             })
     });
 
-    it('should not be able to metadata search with the policy s3:MetadataSearch denied', done => {
+    it('should not be able to metadata search with the permission s3:MetadataSearch denied', done => {
         async.series([
                 next => iam.createPolicy({PolicyName: denyMdSearchPolicyName, PolicyDocument: createPolicy("s3:MetadataSearch", false)}, (err, res) => {
                     if (err)
                         return next(err);
                     return iam.attachUserPolicy({UserName: userName, PolicyArn: res.Policy.Arn}, next);
                 }),
-                next => metadataSearchResponseCode(userCredentials, (err, res) => {
+                next => metadataSearchResponseCode(userCredentials, bucketName, (err, res) => {
                     if (err) {
                         assert.ifError(err)
                         return next(err)
                     }
-                    assert.strictEqual(res, 403);
+                    assert.strictEqual(res.statusCode, 403);
+                    assert.strictEqual(res.message, errors.AccessDenied.description);
                     return next();
                 }),
                 next => iam.listPolicies({}, (err, res) => {
@@ -132,6 +193,68 @@ describe('IAM Policies MetadataSearch', () => {
                         return next(err);
                     }
                     const p = res.Policies.find(p => p.PolicyName === denyMdSearchPolicyName);
+                    if (p)
+                        return iam.detachUserPolicy({UserName: userName, PolicyArn: p.Arn}, (err, res) => {
+                            if (err)
+                                return next(err);
+                            return iam.deletePolicy({PolicyArn: p.Arn}, next);
+                        })
+                    return next();
+                }),
+            ],
+            err => {
+                assert.ifError(err);
+                done();
+            })
+    });
+
+    it('should be able to metadata search on all buckets except for denied ones', done => {
+        async.series([
+                next => iam.createPolicy({PolicyName: allowMdSearchPolicyName, PolicyDocument: createPolicy("s3:MetadataSearch")}, (err, res) => {
+                    if (err)
+                        return next(err);
+                    return iam.attachUserPolicy({UserName: userName, PolicyArn: res.Policy.Arn}, next);
+                }),
+                next => iam.createPolicy({PolicyName: denyMdSearchPolicyName, PolicyDocument: createPolicy("s3:MetadataSearch", false, `arn:aws:s3:::${bucketName}`)}, (err, res) => {
+                    if (err)
+                        return next(err);
+                    return iam.attachUserPolicy({UserName: userName, PolicyArn: res.Policy.Arn}, next);
+                }),
+                next => metadataSearchResponseCode(userCredentials, bucketName, (err, res) => {
+                    if (err) {
+                        assert.ifError(err)
+                        return next(err)
+                    }
+                    assert.strictEqual(res.statusCode, 403);
+                    assert.strictEqual(res.message, errors.AccessDenied.description);
+                    return next();
+                }),
+                next => metadataSearchResponseCode(userCredentials, bucketName2, (err, res) => {
+                    if (err) {
+                        assert.ifError(err)
+                        return next(err)
+                    }
+                    assert.strictEqual(res.statusCode, 200);
+                    return next();
+                }),
+                next => iam.listPolicies({}, (err, res) => {
+                    if (err) {
+                        return next(err);
+                    }
+                    const p = res.Policies.find(p => p.PolicyName === denyMdSearchPolicyName);
+                    if (p)
+                        return iam.detachUserPolicy({UserName: userName, PolicyArn: p.Arn}, (err, res) => {
+                            if (err)
+                                return next(err);
+                            return iam.deletePolicy({PolicyArn: p.Arn}, next);
+                        })
+                    return next();
+                }),
+                next => iam.listPolicies({}, (err, res) => {
+                    if (err) {
+                        return next(err);
+                    }
+                    const p = res.Policies.find(p => p.PolicyName === allowMdSearchPolicyName);
                     if (p)
                         return iam.detachUserPolicy({UserName: userName, PolicyArn: p.Arn}, (err, res) => {
                             if (err)

--- a/tests/zenko_tests/node_tests/iam_policies/cloudserver/IAMUser.js
+++ b/tests/zenko_tests/node_tests/iam_policies/cloudserver/IAMUser.js
@@ -9,52 +9,24 @@ const s3 = require('../../s3SDK').scalityS3Client;
 const userName = "username-policy-test-metadatasearch2";
 
 const bucketName = "bucket-test";
-const listBucketPolicyName = "listBucketPolicy";
 const allowMdSearchPolicyName = "allowMDSearchPolicy";
 const denyMdSearchPolicyName = "denyMDSearchPolicy";
-const objectKey = "file1";
 
-const listBucketPolicy = JSON.stringify({
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "Stmt1644586763301",
-            "Action": [
-                "s3:ListBucket",
-            ],
-            "Effect": "Allow",
-            "Resource": "*"
-        }
-    ]
-});
-
-const allowMdSearchPolicy = JSON.stringify({
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "Stmt1644586763301",
-            "Action": [
-                "s3:MetadataSearch",
-            ],
-            "Effect": "Allow",
-            "Resource": "*"
-        }
-    ]
-});
-
-const denyMdSearchPolicy = JSON.stringify({
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "Stmt1644586763301",
-            "Action": [
-                "s3:MetadataSearch",
-            ],
-            "Effect": "Deny",
-            "Resource": "*"
-        }
-    ]
-});
+function createPolicy(action, isAllow = true, resource = "*") {
+    return JSON.stringify({
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "Stmt1644586763301",
+                "Action": [
+                    action,
+                ],
+                "Effect": (isAllow ? "Allow" : "Deny"),
+                "Resource": resource
+            }
+        ]
+    });
+}
 
 function metadataSearchResponseCode(userCredentials, cb) {
     return makeGETRequest(`/${bucketName}/?search=${encodeURIComponent('key LIKE "file"')}`, (err, res) => {
@@ -75,13 +47,7 @@ describe('IAM Policies MetadataSearch', () => {
         async.series([
             next => s3.createBucket({Bucket: bucketName}, next),
             next => iam.createUser({UserName: userName}, next),
-            next => iam.createAccessKey({UserName: userName}, next),
-            next => iam.createPolicy({PolicyName: listBucketPolicyName, PolicyDocument: listBucketPolicy}, (err, res) => {
-                if (err)
-                    return next(err);
-                return iam.attachUserPolicy({UserName: userName, PolicyArn: res.Policy.Arn}, next);
-            }),
-            next => s3.putObject({Bucket: bucketName, Key: objectKey}, next)
+            next => iam.createAccessKey({UserName: userName}, next)
         ], (err, res) => {
             assert.ifError(err);
             userCredentials.accessKeyId = res[2].AccessKey.AccessKeyId;
@@ -92,21 +58,7 @@ describe('IAM Policies MetadataSearch', () => {
 
     after(done => {
         async.series([
-            next => iam.listPolicies({}, (err, res) => {
-                if (err) {
-                    return next(err);
-                }
-                const p = res.Policies.find(p => p.PolicyName === listBucketPolicyName);
-                if (p)
-                    return iam.detachUserPolicy({UserName: userName, PolicyArn: p.Arn}, (err, res) => {
-                        if (err)
-                          return next(err);
-                        return iam.deletePolicy({PolicyArn: p.Arn}, next);
-                    })
-                return next();
-            }),
             next => iam.deleteUser({UserName: userName}, next),
-            next => s3.deleteObject({Bucket: bucketName, Key: objectKey}, next),
             next => s3.deleteBucket({Bucket: bucketName}, next),
         ], err => {
             assert.ifError(err);
@@ -127,7 +79,7 @@ describe('IAM Policies MetadataSearch', () => {
 
     it('should be able to metadata search with the policy s3:MetadataSearch allowed', done => {
         async.series([
-            next => iam.createPolicy({PolicyName: allowMdSearchPolicyName, PolicyDocument: allowMdSearchPolicy}, (err, res) => {
+            next => iam.createPolicy({PolicyName: allowMdSearchPolicyName, PolicyDocument: createPolicy("s3:MetadataSearch")}, (err, res) => {
                 if (err)
                     return next(err);
                 return iam.attachUserPolicy({UserName: userName, PolicyArn: res.Policy.Arn}, next);
@@ -162,7 +114,7 @@ describe('IAM Policies MetadataSearch', () => {
 
     it('should not be able to metadata search with the policy s3:MetadataSearch denied', done => {
         async.series([
-                next => iam.createPolicy({PolicyName: denyMdSearchPolicyName, PolicyDocument: denyMdSearchPolicy}, (err, res) => {
+                next => iam.createPolicy({PolicyName: denyMdSearchPolicyName, PolicyDocument: createPolicy("s3:MetadataSearch", false)}, (err, res) => {
                     if (err)
                         return next(err);
                     return iam.attachUserPolicy({UserName: userName, PolicyArn: res.Policy.Arn}, next);

--- a/tests/zenko_tests/node_tests/init_test.js
+++ b/tests/zenko_tests/node_tests/init_test.js
@@ -7,15 +7,15 @@ const s3 = require('./s3SDK').scalityS3Client;
 
 const bucket = `get-bucket-${uuidV4()}`;
 const key = `object-key-${uuidV4()}`;
-const body = "testbody";
+const body = 'testbody';
 
 describe('Test Configuration', () => {
-    it("should create a bucket and upload an object", (done) => {
+    it('should create a bucket and upload an object', done => {
         async.series([
             next => s3.createBucket({
                 Bucket: bucket,
                 CreateBucketConfiguration: {
-                    LocationConstraint: "us-east-1",
+                    LocationConstraint: 'us-east-1',
                 },
             }, next),
             next => s3.listBuckets((err, res) => {
@@ -25,21 +25,23 @@ describe('Test Configuration', () => {
                 next();
             }),
             next => s3.putObject({
-                Bucket: bucket, Key: key, Body: body
+                Bucket: bucket, Key: key, Body: body,
             }, next),
-            next => s3.getObject({ Bucket: bucket, Key: key },
-                (err,  res) => {
+            next => s3.getObject(
+                { Bucket: bucket, Key: key },
+                (err, res) => {
                     assert.ifError(err);
                     assert.strictEqual(body, res.Body.toString());
-                    next()
-                }),
+                    next();
+                },
+            ),
             next => s3.listObjects({ Bucket: bucket }, (err, res) => {
                 assert.ifError(err);
                 assert.strictEqual(res.Contents.length, 1);
                 assert.strictEqual(res.Contents[0].Key, key);
                 next();
             }),
-            next => s3.deleteObject({ Bucket: bucket, Key: key}, next),
+            next => s3.deleteObject({ Bucket: bucket, Key: key }, next),
             next => s3.deleteBucket({ Bucket: bucket }, next),
         ], done);
     });

--- a/tests/zenko_tests/node_tests/package-lock.json
+++ b/tests/zenko_tests/node_tests/package-lock.json
@@ -4,6 +4,137 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
+      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+      "requires": {
+        "@babel/highlight": "^7.16.7"
+      }
+    },
+    "@babel/generator": {
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.3.tgz",
+      "integrity": "sha512-+R6Dctil/MgUsZsZAkYgK+ADNSZzJRRy0TvY65T71z/CR854xHQ1EweBYXdfT+HNeN7w0cSJJEzgxZMv40pxsg==",
+      "requires": {
+        "@babel/types": "^7.17.0",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      }
+    },
+    "@babel/helper-environment-visitor": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz",
+      "integrity": "sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==",
+      "requires": {
+        "@babel/types": "^7.16.7"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
+      "integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.16.7",
+        "@babel/template": "^7.16.7",
+        "@babel/types": "^7.16.7"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
+      "integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
+      "requires": {
+        "@babel/types": "^7.16.7"
+      }
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
+      "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
+      "requires": {
+        "@babel/types": "^7.16.7"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
+      "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
+      "requires": {
+        "@babel/types": "^7.16.7"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
+    },
+    "@babel/highlight": {
+      "version": "7.16.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
+      "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.16.7",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "@babel/parser": {
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.3.tgz",
+      "integrity": "sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA=="
+    },
+    "@babel/template": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
+      "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
+      "requires": {
+        "@babel/code-frame": "^7.16.7",
+        "@babel/parser": "^7.16.7",
+        "@babel/types": "^7.16.7"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
+      "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
+      "requires": {
+        "@babel/code-frame": "^7.16.7",
+        "@babel/generator": "^7.17.3",
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-function-name": "^7.16.7",
+        "@babel/helper-hoist-variables": "^7.16.7",
+        "@babel/helper-split-export-declaration": "^7.16.7",
+        "@babel/parser": "^7.17.3",
+        "@babel/types": "^7.17.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+      "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.16.7",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
     "@cypress/listr-verbose-renderer": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@cypress/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
@@ -15,6 +146,16 @@
         "figures": "^1.7.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -27,6 +168,14 @@
             "supports-color": "^2.0.0"
           }
         },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
@@ -35,9 +184,9 @@
       }
     },
     "@cypress/request": {
-      "version": "2.88.5",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.5.tgz",
-      "integrity": "sha512-TzEC1XMi1hJkywWpRfD2clreTa/Z+lOrXDCxxBTBPEcY5azdPi56A6Xw+O4tWJnaJH3iIE7G5aDXZC6JgRZLcA==",
+      "version": "2.88.10",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.10.tgz",
+      "integrity": "sha512-Zp7F+R93N0yZyG34GutyTNr+okam7s/Fzc1+i3kcqOP8vk6OuajuE9qZJ6Rs+10/1JFtXFYMdyarnU1rZuJesg==",
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -46,19 +195,45 @@
         "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
         "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
+        "http-signature": "~1.3.6",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
         "json-stringify-safe": "~5.0.1",
         "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
         "performance-now": "^2.1.0",
         "qs": "~6.5.2",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "http-signature": {
+          "version": "1.3.6",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.3.6.tgz",
+          "integrity": "sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==",
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^2.0.2",
+            "sshpk": "^1.14.1"
+          }
+        },
+        "jsprim": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
+          "integrity": "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.4.0",
+            "verror": "1.10.0"
+          }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
       }
     },
     "@cypress/xvfb": {
@@ -69,6 +244,50 @@
         "debug": "^3.1.0",
         "lodash.once": "^4.1.1"
       }
+    },
+    "@eslint/eslintrc": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
+      "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.1.1",
+        "espree": "^7.3.0",
+        "globals": "^13.9.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^3.13.1",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "globals": {
+          "version": "13.12.1",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
+          "integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
+          "requires": {
+            "type-fest": "^0.20.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "@gar/promisify": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+      "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="
     },
     "@google-cloud/common": {
       "version": "0.17.0",
@@ -157,6 +376,54 @@
         "@hapi/hoek": "^8.3.0"
       }
     },
+    "@humanwhocodes/config-array": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+      "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+      "requires": {
+        "@humanwhocodes/object-schema": "^1.2.0",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
+    },
+    "@npmcli/fs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
+      "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
+      "requires": {
+        "@gar/promisify": "^1.0.1",
+        "semver": "^7.3.5"
+      }
+    },
+    "@npmcli/move-file": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
+      "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
+      "requires": {
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
+      }
+    },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz",
@@ -165,20 +432,30 @@
         "any-observable": "^0.3.0"
       }
     },
+    "@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
+    },
+    "@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
+    },
     "@types/node": {
       "version": "12.12.50",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.50.tgz",
       "integrity": "sha512-5ImO01Fb8YsEOYpV+aeyGYztcYcjGsBvN4D7G5r1ef2cuQOpymjWNQi5V0rKHE6PC2ru3HkoUr/Br2/8GUA84w=="
     },
     "@types/sinonjs__fake-timers": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz",
-      "integrity": "sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg=="
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.4.tgz",
+      "integrity": "sha512-IFQTJARgMUBF+xVd2b+hIgXWrZEjND3vJtRCvIelcFB5SIXfjV4bOHbHJ0eXKh+0COrBRc8MqteKAz/j88rE0A=="
     },
     "@types/sizzle": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
-      "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg=="
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
+      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ=="
     },
     "JSONStream": {
       "version": "1.3.5",
@@ -188,6 +465,11 @@
         "jsonparse": "^1.2.0",
         "through": ">=2.2.7 <3"
       }
+    },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "abort-controller": {
       "version": "3.0.0",
@@ -207,13 +489,23 @@
       }
     },
     "accepts": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
-      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
       "requires": {
-        "mime-types": "~2.1.24",
-        "negotiator": "0.6.2"
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
       }
+    },
+    "acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+    },
+    "acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="
     },
     "after": {
       "version": "0.8.2",
@@ -229,9 +521,9 @@
       }
     },
     "agentkeepalive": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.1.4.tgz",
-      "integrity": "sha512-+V/rGa3EuU74H6wR04plBb7Ks10FbtUQgRj/FQOG7uUIEuaINI+AiqJR1k6t3SVNs7o7ZjIdus6706qqzVq8jQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.0.tgz",
+      "integrity": "sha512-0PhAp58jZNw13UJv7NVdTGb0ZcghHUb3DrZ046JiiJY/BOaTTpbwdHq2VObPCBV8M2GPh7sgrJ3AQ8Ey468LJw==",
       "requires": {
         "debug": "^4.1.0",
         "depd": "^1.1.2",
@@ -239,9 +531,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -253,10 +545,19 @@
         }
       }
     },
+    "aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      }
+    },
     "ajv": {
-      "version": "6.12.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
-      "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -264,35 +565,99 @@
         "uri-js": "^4.2.2"
       }
     },
+    "ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
+    },
     "ansi-escapes": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
       "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
     },
     "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
     "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
     },
     "any-observable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
       "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog=="
     },
+    "aproba": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
+    },
     "arch": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
       "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ=="
     },
+    "are-we-there-yet": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.0.tgz",
+      "integrity": "sha512-0GWpv50YSOcLXaN6/FAKY3vfRbllXWV2xvfA/oKJF8pzFhWXPV+yjhJXDBbjscDYowv7Yw1A3uigpzn5iEGTyw==",
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "array-includes": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
+      "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1",
+        "get-intrinsic": "^1.1.1",
+        "is-string": "^1.0.7"
+      }
+    },
     "array-uniq": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+    },
+    "array.prototype.flat": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.5.tgz",
+      "integrity": "sha512-KaYU+S+ndVqyUnignHftkwc58o3uVU1jzczILJ1tN2YaIZpFIKBiP/x/j97E5MVPsaCloPbqWLB/8qCTVvT2qg==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0"
+      }
     },
     "arraybuffer.slice": {
       "version": "0.0.7",
@@ -304,10 +669,180 @@
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
+    "arsenal": {
+      "version": "github:scality/Arsenal#3c9ab1bb99c2b3134882e7d8ad12573a073188f4",
+      "from": "github:scality/Arsenal#8.1.27",
+      "requires": {
+        "@hapi/joi": "^15.1.0",
+        "JSONStream": "^1.0.0",
+        "agentkeepalive": "^4.1.3",
+        "ajv": "6.12.2",
+        "async": "~2.6.1",
+        "aws-sdk": "2.80.0",
+        "azure-storage": "2.10.3",
+        "backo": "^1.1.0",
+        "base-x": "3.0.8",
+        "base62": "2.0.1",
+        "bson": "4.0.0",
+        "debug": "~4.1.0",
+        "diskusage": "^1.1.1",
+        "fcntl": "github:scality/node-fcntl#0.2.0",
+        "hdclient": "github:scality/hdclient#1.1.0",
+        "https-proxy-agent": "^2.2.0",
+        "ioctl": "^2.0.2",
+        "ioredis": "4.9.5",
+        "ipaddr.js": "1.9.1",
+        "level": "~5.0.1",
+        "level-sublevel": "~6.6.5",
+        "mongodb": "^3.0.1",
+        "node-forge": "^0.7.1",
+        "prom-client": "10.2.3",
+        "simple-glob": "^0.2.0",
+        "socket.io": "~2.3.0",
+        "socket.io-client": "~2.3.0",
+        "sproxydclient": "github:scality/sproxydclient#8.0.3",
+        "utf8": "3.0.0",
+        "uuid": "^3.0.1",
+        "werelogs": "github:scality/werelogs#8.1.0",
+        "xml2js": "~0.4.23"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+          "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        },
+        "aws-sdk": {
+          "version": "2.80.0",
+          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.80.0.tgz",
+          "integrity": "sha1-Yc7XR+uYFglIOuxT6NZU08ydFDU=",
+          "requires": {
+            "buffer": "4.9.1",
+            "crypto-browserify": "1.0.9",
+            "jmespath": "0.15.0",
+            "querystring": "0.2.0",
+            "sax": "1.2.1",
+            "url": "0.10.3",
+            "uuid": "3.0.1",
+            "xml2js": "0.4.17",
+            "xmlbuilder": "4.2.1"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+              "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
+            },
+            "xml2js": {
+              "version": "0.4.17",
+              "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
+              "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+              "requires": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "^4.1.0"
+              }
+            }
+          }
+        },
+        "azure-storage": {
+          "version": "2.10.3",
+          "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.3.tgz",
+          "integrity": "sha512-IGLs5Xj6kO8Ii90KerQrrwuJKexLgSwYC4oLWmc11mzKe7Jt2E5IVg+ZQ8K53YWZACtVTMBNO3iGuA+4ipjJxQ==",
+          "requires": {
+            "browserify-mime": "~1.2.9",
+            "extend": "^3.0.2",
+            "json-edm-parser": "0.1.2",
+            "md5.js": "1.3.4",
+            "readable-stream": "~2.0.0",
+            "request": "^2.86.0",
+            "underscore": "~1.8.3",
+            "uuid": "^3.0.0",
+            "validator": "~9.4.1",
+            "xml2js": "0.2.8",
+            "xmlbuilder": "^9.0.7"
+          },
+          "dependencies": {
+            "sax": {
+              "version": "0.5.8",
+              "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
+              "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE="
+            },
+            "xml2js": {
+              "version": "0.2.8",
+              "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
+              "integrity": "sha1-m4FpCTFjH/CdGVdUn69U9PmAs8I=",
+              "requires": {
+                "sax": "0.5.x"
+              }
+            },
+            "xmlbuilder": {
+              "version": "9.0.7",
+              "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+              "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+            }
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        },
+        "node-forge": {
+          "version": "0.7.6",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
+          "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+        },
+        "readable-stream": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~0.10.x",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
     "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -316,6 +851,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
     },
     "async": {
       "version": "2.1.2",
@@ -369,6 +909,15 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
           "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
+        },
+        "xml2js": {
+          "version": "0.4.17",
+          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
+          "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+          "requires": {
+            "sax": ">=0.6.0",
+            "xmlbuilder": "^4.1.0"
+          }
         }
       }
     },
@@ -392,50 +941,38 @@
       }
     },
     "azure-storage": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.3.tgz",
-      "integrity": "sha512-IGLs5Xj6kO8Ii90KerQrrwuJKexLgSwYC4oLWmc11mzKe7Jt2E5IVg+ZQ8K53YWZACtVTMBNO3iGuA+4ipjJxQ==",
+      "version": "2.10.7",
+      "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.7.tgz",
+      "integrity": "sha512-4oeFGtn3Ziw/fGs/zkoIpKKtygnCVIcZwzJ7UQzKTxhkGQqVCByOFbYqMGYR3L+wOsunX9lNfD0jc51SQuKSSA==",
       "requires": {
-        "browserify-mime": "~1.2.9",
+        "browserify-mime": "^1.2.9",
         "extend": "^3.0.2",
-        "json-edm-parser": "0.1.2",
-        "md5.js": "1.3.4",
-        "readable-stream": "~2.0.0",
+        "json-edm-parser": "~0.1.2",
+        "json-schema": "~0.4.0",
+        "md5.js": "^1.3.4",
+        "readable-stream": "^2.0.0",
         "request": "^2.86.0",
-        "underscore": "~1.8.3",
+        "underscore": "^1.12.1",
         "uuid": "^3.0.0",
-        "validator": "~9.4.1",
-        "xml2js": "0.2.8",
+        "validator": "^13.7.0",
+        "xml2js": "~0.2.8",
         "xmlbuilder": "^9.0.7"
       },
       "dependencies": {
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-        },
-        "readable-stream": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
-          }
-        },
         "sax": {
           "version": "0.5.8",
           "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
           "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE="
         },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        "underscore": {
+          "version": "1.13.2",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
+          "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g=="
+        },
+        "validator": {
+          "version": "13.7.0",
+          "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+          "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
         },
         "xml2js": {
           "version": "0.2.8",
@@ -452,6 +989,19 @@
         }
       }
     },
+    "babel-eslint": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
+      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.7.0",
+        "@babel/traverse": "^7.7.0",
+        "@babel/types": "^7.7.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "resolve": "^1.12.0"
+      }
+    },
     "backo": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/backo/-/backo-1.1.0.tgz",
@@ -466,6 +1016,19 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "base-x": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+      "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "base62": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/base62/-/base62-2.0.1.tgz",
+      "integrity": "sha512-4t4WQK7mdbcWzqEBiq6tfo2qDCeIZGXvjifJZyxHIVcjQkZJxpFtu/pa2Va69OouCkg6izZ08hKnPxroeDyzew=="
     },
     "base64-arraybuffer": {
       "version": "0.1.4",
@@ -617,9 +1180,9 @@
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "bytewise": {
       "version": "1.1.0",
@@ -636,6 +1199,46 @@
       "integrity": "sha1-P7QQx+kVWOsasiqCg0V3qmvWHUI=",
       "requires": {
         "typewise-core": "^1.2"
+      }
+    },
+    "cacache": {
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
+      "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
+      "requires": {
+        "@npmcli/fs": "^1.0.0",
+        "@npmcli/move-file": "^1.0.1",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "glob": "^7.1.4",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.1",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "mkdirp": "^1.0.3",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^8.0.1",
+        "tar": "^6.0.2",
+        "unique-filename": "^1.1.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
       }
     },
     "cachedir": {
@@ -657,6 +1260,11 @@
       "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
       "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
     },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
+    },
     "capture-stack-trace": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
@@ -668,22 +1276,13 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "requires": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        }
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "charenc": {
@@ -696,10 +1295,20 @@
       "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
       "integrity": "sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA="
     },
+    "chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
+    },
     "ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
+    },
+    "clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
     },
     "cli-cursor": {
       "version": "1.0.2",
@@ -710,12 +1319,11 @@
       }
     },
     "cli-table3": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
-      "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.1.tgz",
+      "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
       "requires": {
-        "colors": "^1.1.2",
-        "object-assign": "^4.1.0",
+        "colors": "1.4.0",
         "string-width": "^4.2.0"
       }
     },
@@ -728,6 +1336,11 @@
         "string-width": "^1.0.1"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -745,6 +1358,14 @@
             "is-fullwidth-code-point": "^1.0.0",
             "strip-ansi": "^3.0.0"
           }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
         }
       }
     },
@@ -759,17 +1380,22 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "requires": {
-        "color-name": "~1.1.4"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
     },
     "colors": {
       "version": "1.4.0",
@@ -791,9 +1417,9 @@
       "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
     },
     "common-tags": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
-      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw=="
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
+      "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA=="
     },
     "component-bind": {
       "version": "1.0.0",
@@ -847,15 +1473,25 @@
         "xdg-basedir": "^3.0.0"
       }
     },
+    "confusing-browser-globals": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
+      "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA=="
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+    },
     "cookie": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
     },
     "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "create-error-class": {
       "version": "3.0.2",
@@ -937,6 +1573,36 @@
         "yauzl": "^2.10.0"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
         "debug": {
           "version": "4.3.2",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
@@ -944,6 +1610,11 @@
           "requires": {
             "ms": "2.1.2"
           }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "ms": {
           "version": "2.1.2",
@@ -954,6 +1625,14 @@
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         },
         "url": {
           "version": "0.11.0",
@@ -967,9 +1646,9 @@
       }
     },
     "cypress-file-upload": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/cypress-file-upload/-/cypress-file-upload-5.0.6.tgz",
-      "integrity": "sha512-Zop7M8xhP9WSoc5tVYJcUUn+iPn3RpsOEzHaTUKFQPiqxD5Bz19azO/BwiyuNJ5m82zPMd0i+KY/ubVog8cyGQ=="
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/cypress-file-upload/-/cypress-file-upload-5.0.8.tgz",
+      "integrity": "sha512-+8VzNabRk3zG6x8f8BWArF/xA/W0VK4IZNx3MV0jFWrJS/qKn8eHfa5nU73P9fOQAgwHFJx7zjg4lwOnljMO8g=="
     },
     "dashdash": {
       "version": "1.14.1",
@@ -985,9 +1664,9 @@
       "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
     },
     "dayjs": {
-      "version": "1.10.4",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.4.tgz",
-      "integrity": "sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw=="
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
+      "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig=="
     },
     "debug": {
       "version": "3.1.0",
@@ -996,6 +1675,11 @@
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
     },
     "deferred-leveldown": {
       "version": "5.3.0",
@@ -1042,10 +1726,15 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
     "denque": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.0.tgz",
-      "integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw=="
     },
     "depd": {
       "version": "1.1.2",
@@ -1064,6 +1753,14 @@
       "requires": {
         "es6-promise": "^4.2.5",
         "nan": "^2.14.0"
+      }
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "requires": {
+        "esutils": "^2.0.2"
       }
     },
     "dot-prop": {
@@ -1116,6 +1813,15 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "optional": true,
+      "requires": {
+        "iconv-lite": "^0.6.2"
+      }
     },
     "encoding-down": {
       "version": "6.3.0",
@@ -1242,10 +1948,33 @@
         "has-binary2": "~1.0.2"
       }
     },
+    "enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "requires": {
+        "ansi-colors": "^4.1.1"
+      }
+    },
     "ent": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
       "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0="
+    },
+    "entities": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+    },
+    "env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="
+    },
+    "err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
     },
     "errno": {
       "version": "0.1.8",
@@ -1264,26 +1993,30 @@
       }
     },
     "es-abstract": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-      "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.1.1",
+        "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
         "has-symbols": "^1.0.2",
-        "is-callable": "^1.2.3",
+        "internal-slot": "^1.0.3",
+        "is-callable": "^1.2.4",
         "is-negative-zero": "^2.0.1",
-        "is-regex": "^1.1.2",
-        "is-string": "^1.0.5",
-        "object-inspect": "^1.9.0",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.1",
+        "is-string": "^1.0.7",
+        "is-weakref": "^1.0.1",
+        "object-inspect": "^1.11.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
         "string.prototype.trimend": "^1.0.4",
         "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.0"
+        "unbox-primitive": "^1.0.1"
       }
     },
     "es-to-primitive": {
@@ -1314,6 +2047,346 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
+    "eslint": {
+      "version": "7.32.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
+      "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
+      "requires": {
+        "@babel/code-frame": "7.12.11",
+        "@eslint/eslintrc": "^0.4.3",
+        "@humanwhocodes/config-array": "^0.5.0",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "enquirer": "^2.3.5",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^2.1.0",
+        "eslint-visitor-keys": "^2.0.0",
+        "espree": "^7.3.1",
+        "esquery": "^1.4.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.1.2",
+        "globals": "^13.6.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.0.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "progress": "^2.0.0",
+        "regexpp": "^3.1.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.0",
+        "strip-json-comments": "^3.1.0",
+        "table": "^6.0.9",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+          "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        },
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw=="
+        },
+        "globals": {
+          "version": "13.12.1",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
+          "integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
+          "requires": {
+            "type-fest": "^0.20.2"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "eslint-config-airbnb": {
+      "version": "19.0.4",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-19.0.4.tgz",
+      "integrity": "sha512-T75QYQVQX57jiNgpF9r1KegMICE94VYwoFQyMGhrvc+lB8YF2E/M/PYDaQe1AJcWaEgqLE+ErXV1Og/+6Vyzew==",
+      "requires": {
+        "eslint-config-airbnb-base": "^15.0.0",
+        "object.assign": "^4.1.2",
+        "object.entries": "^1.1.5"
+      }
+    },
+    "eslint-config-airbnb-base": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz",
+      "integrity": "sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==",
+      "requires": {
+        "confusing-browser-globals": "^1.0.10",
+        "object.assign": "^4.1.2",
+        "object.entries": "^1.1.5",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
+      }
+    },
+    "eslint-config-scality": {
+      "version": "github:scality/Guidelines#ec33dfba6137749574f80dde6193b307536a86cc",
+      "from": "github:scality/Guidelines#7.10.1.6",
+      "requires": {
+        "commander": "1.3.2",
+        "markdownlint": "0.0.8"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-1.3.2.tgz",
+          "integrity": "sha1-io8w7GcKb91kr1LxkUuQfXnq1bU=",
+          "requires": {
+            "keypress": "0.1.x"
+          }
+        }
+      }
+    },
+    "eslint-import-resolver-node": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
+      "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
+      "requires": {
+        "debug": "^3.2.7",
+        "resolve": "^1.20.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz",
+      "integrity": "sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==",
+      "requires": {
+        "debug": "^3.2.7",
+        "find-up": "^2.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.25.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.4.tgz",
+      "integrity": "sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==",
+      "requires": {
+        "array-includes": "^3.1.4",
+        "array.prototype.flat": "^1.2.5",
+        "debug": "^2.6.9",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.6",
+        "eslint-module-utils": "^2.7.2",
+        "has": "^1.0.3",
+        "is-core-module": "^2.8.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.0.4",
+        "object.values": "^1.1.5",
+        "resolve": "^1.20.0",
+        "tsconfig-paths": "^3.12.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        }
+      }
+    },
+    "eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "requires": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
+    },
+    "espree": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+      "requires": {
+        "acorn": "^7.4.0",
+        "acorn-jsx": "^5.3.1",
+        "eslint-visitor-keys": "^1.3.0"
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "esquery": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "requires": {
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
+        }
+      }
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "requires": {
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
+        }
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+    },
     "event-stream": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
@@ -1334,9 +2407,9 @@
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "eventemitter2": {
-      "version": "6.4.4",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.4.tgz",
-      "integrity": "sha512-HLU3NDY6wARrLCEwyGKRBvuWYyvW6mHYv72SJJAH3iJN3a6eVUvkjFkcxah1bcTgGVBBrFdIopBJPhCQFMLyXw=="
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.5.tgz",
+      "integrity": "sha512-bXE7Dyc1i6oQElDG0jMRZJrRAn9QR2xyyFGmBdZleNmyQX0FqGYmhZIrIrpPfm/w//LTo4tVQGOGQcGCb5q9uw=="
     },
     "execa": {
       "version": "4.1.0",
@@ -1407,6 +2480,14 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "requires": {
+            "minimist": "^1.2.5"
+          }
         }
       }
     },
@@ -1425,6 +2506,20 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+    },
+    "fcntl": {
+      "version": "github:scality/node-fcntl#ae7493da46fb353eff0c4cb79e2cce838197c066",
+      "from": "github:scality/node-fcntl#0.2.0",
+      "requires": {
+        "bindings": "^1.1.1",
+        "nan": "^2.3.2",
+        "node-gyp": "^8.0.0"
+      }
+    },
     "fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -1442,10 +2537,40 @@
         "object-assign": "^4.1.0"
       }
     },
+    "file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "requires": {
+        "flat-cache": "^3.0.4"
+      }
+    },
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+    },
+    "find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "requires": {
+        "locate-path": "^2.0.0"
+      }
+    },
+    "flat-cache": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "requires": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      }
+    },
+    "flatted": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
+      "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg=="
     },
     "follow-redirects": {
       "version": "1.5.10",
@@ -1486,6 +2611,14 @@
         "universalify": "^2.0.0"
       }
     },
+    "fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1495,6 +2628,27 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+    },
+    "gauge": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.1.tgz",
+      "integrity": "sha512-zJ4jePUHR8cceduZ53b6temRalyGpkC2Kc2r3ecNphmL+uWNoJ3YcOcUjpbG6WwoE/Ef6/+aEZz63neI2WIa1Q==",
+      "requires": {
+        "ansi-regex": "^5.0.1",
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      }
     },
     "gaxios": {
       "version": "1.8.4",
@@ -1558,6 +2712,15 @@
         }
       }
     },
+    "get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      }
+    },
     "getos": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/getos/-/getos-3.2.1.tgz",
@@ -1567,9 +2730,9 @@
       },
       "dependencies": {
         "async": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-          "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+          "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
         }
       }
     },
@@ -1582,9 +2745,9 @@
       }
     },
     "glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1594,6 +2757,14 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
     "global-dirs": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.1.0.tgz",
@@ -1601,6 +2772,11 @@
       "requires": {
         "ini": "1.3.7"
       }
+    },
+    "globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
     },
     "google-auth-library": {
       "version": "1.6.1",
@@ -1638,25 +2814,18 @@
       }
     },
     "google-p12-pem": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-1.0.4.tgz",
-      "integrity": "sha512-SwLAUJqUfTB2iS+wFfSS/G9p7bt4eWcc2LyfvmUXe7cWp6p3mpxDo6LLI29MXdU6wvPcQ/up298X7GMC5ylAlA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-1.0.5.tgz",
+      "integrity": "sha512-50rTrqYPTPPwlu9TNl/HkJbBENEpbRzTOVLFJ4YWM86njZgXHFy+FP+tLRSd9m132Li9Dqi27Z3KIWDEv5y+EA==",
       "requires": {
-        "node-forge": "^0.8.0",
+        "node-forge": "^0.10.0",
         "pify": "^4.0.0"
-      },
-      "dependencies": {
-        "node-forge": {
-          "version": "0.8.5",
-          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
-          "integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q=="
-        }
       }
     },
     "graceful-fs": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
+      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
     },
     "growl": {
       "version": "1.10.5",
@@ -1687,19 +2856,6 @@
       "requires": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "6.12.6",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        }
       }
     },
     "has": {
@@ -1716,6 +2872,13 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
         "ansi-regex": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        }
       }
     },
     "has-bigints": {
@@ -1744,14 +2907,27 @@
       "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
     },
     "has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
       "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+    },
+    "has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "requires": {
+        "has-symbols": "^1.0.2"
+      }
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "hash-base": {
       "version": "3.1.0",
@@ -1780,6 +2956,22 @@
       "resolved": "https://registry.npmjs.org/hash-stream-validation/-/hash-stream-validation-0.2.4.tgz",
       "integrity": "sha512-Gjzu0Xn7IagXVkSu9cSFuK1fqzwtLwFhNhVL8IFJijRNMgUttFbBSIAzKuSIrsFMO1+g1RlsoN49zPIbwPDMGQ=="
     },
+    "hdclient": {
+      "version": "github:scality/hdclient#dd6d952e39ca89133019bafbb33eef6c418689f8",
+      "from": "github:scality/hdclient#1.1.0",
+      "requires": {
+        "werelogs": "github:scality/werelogs#GA7.2.0.5"
+      },
+      "dependencies": {
+        "werelogs": {
+          "version": "github:scality/werelogs#bc034589ebf7810d6e6d61932f94327976de6eef",
+          "from": "github:scality/werelogs#GA7.2.0.5",
+          "requires": {
+            "safe-json-stringify": "^1.0.3"
+          }
+        }
+      }
+    },
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
@@ -1789,6 +2981,44 @@
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
+    },
+    "http-cache-semantics": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+    },
+    "http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "requires": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+          "requires": {
+            "debug": "4"
+          }
+        },
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
     },
     "http-signature": {
       "version": "1.2.0",
@@ -1822,15 +3052,38 @@
         "ms": "^2.0.0"
       }
     },
+    "iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "optional": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      }
+    },
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
+    },
     "immediate": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
       "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
+    },
+    "import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -1838,14 +3091,19 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
     "indent-string": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-      "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
     },
     "indexof": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
       "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
+    },
+    "infer-owner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -1866,14 +3124,24 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
       "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ=="
     },
+    "internal-slot": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "requires": {
+        "get-intrinsic": "^1.1.0",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.4"
+      }
+    },
     "ioctl": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ioctl/-/ioctl-2.0.1.tgz",
-      "integrity": "sha1-6cBe4W5XVNfRWGvsWnNKgZEXWto=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ioctl/-/ioctl-2.0.2.tgz",
+      "integrity": "sha512-GPEiU99bJb3Z50JDRujQ9t+q4JaRvc1UrD7F5/kHDVWlRA3L4TMwqbMw/XIu/BzqccFP8OfsK+JIXmlAvJDs1g==",
       "optional": true,
       "requires": {
-        "bindings": "^1.1.1",
-        "nan": "^2.3.2"
+        "bindings": "^1.5.0",
+        "nan": "^2.14.0"
       }
     },
     "ioredis": {
@@ -1892,6 +3160,11 @@
         "standard-as-callback": "^2.0.1"
       }
     },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+    },
     "ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -1908,16 +3181,20 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-bigint": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
-      "integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "requires": {
+        "has-bigints": "^1.0.1"
+      }
     },
     "is-boolean-object": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
-      "integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
       "requires": {
-        "call-bind": "^1.0.0"
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -1926,9 +3203,9 @@
       "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
     },
     "is-callable": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-      "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ=="
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
     },
     "is-ci": {
       "version": "2.0.0",
@@ -1939,22 +3216,38 @@
       }
     },
     "is-core-module": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.3.0.tgz",
-      "integrity": "sha512-xSphU2KG9867tsYdLD4RWQ1VqdFl4HTO9Thf3I/3dLEfr0dbPTWKsuCKrgqMljg4nPE+Gq0VCnzT3gr0CyBmsw==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
       "requires": {
         "has": "^1.0.3"
       }
     },
     "is-date-object": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
     },
     "is-installed-globally": {
       "version": "0.3.2",
@@ -1965,15 +3258,23 @@
         "is-path-inside": "^3.0.1"
       }
     },
+    "is-lambda": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+      "integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU="
+    },
     "is-negative-zero": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA=="
     },
     "is-number-object": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
-      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
+      "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
     },
     "is-obj": {
       "version": "1.0.1",
@@ -1999,18 +3300,23 @@
       "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
     },
     "is-regex": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-      "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
       "requires": {
         "call-bind": "^1.0.2",
-        "has-symbols": "^1.0.1"
+        "has-tostringtag": "^1.0.0"
       }
     },
+    "is-shared-array-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
+      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA=="
+    },
     "is-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
     },
     "is-stream-ended": {
       "version": "0.1.4",
@@ -2018,16 +3324,19 @@
       "integrity": "sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw=="
     },
     "is-string": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
     },
     "is-symbol": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
       "requires": {
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.2"
       }
     },
     "is-typedarray": {
@@ -2039,6 +3348,14 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="
+    },
+    "is-weakref": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "requires": {
+        "call-bind": "^1.0.2"
+      }
     },
     "isarray": {
       "version": "1.0.0",
@@ -2060,10 +3377,29 @@
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
     "json-edm-parser": {
       "version": "0.1.2",
@@ -2074,19 +3410,32 @@
       }
     },
     "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "json5": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "requires": {
+        "minimist": "^1.2.0"
+      }
     },
     "jsonfile": {
       "version": "6.1.0",
@@ -2103,13 +3452,13 @@
       "integrity": "sha1-XAxWhRBxYOcv50ib3eoLRMK8Z70="
     },
     "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
       }
     },
@@ -2131,6 +3480,11 @@
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "keypress": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz",
+      "integrity": "sha1-SjGI1CkbZrT2XtuZ+AaqmuKTWSo="
     },
     "lazy-ass": {
       "version": "1.6.0",
@@ -2381,6 +3735,23 @@
         "xtend": "~4.0.0"
       }
     },
+    "levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "requires": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      }
+    },
+    "linkify-it": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-1.2.4.tgz",
+      "integrity": "sha1-B3NSbDF8j9E71TTuHRgP+Iq/iBo=",
+      "requires": {
+        "uc.micro": "^1.0.1"
+      }
+    },
     "listr": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz",
@@ -2401,6 +3772,11 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
           "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+        },
+        "p-map": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+          "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
         }
       }
     },
@@ -2424,6 +3800,16 @@
         "strip-ansi": "^3.0.1"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -2436,12 +3822,25 @@
             "supports-color": "^2.0.0"
           }
         },
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
+        },
         "log-symbols": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
           "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
           "requires": {
             "chalk": "^1.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -2462,24 +3861,6 @@
         "figures": "^2.0.0"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
         "cli-cursor": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -2488,19 +3869,6 @@
             "restore-cursor": "^2.0.0"
           }
         },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-        },
         "figures": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -2508,11 +3876,6 @@
           "requires": {
             "escape-string-regexp": "^1.0.5"
           }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "mimic-fn": {
           "version": "1.2.0",
@@ -2535,14 +3898,6 @@
             "onetime": "^2.0.0",
             "signal-exit": "^3.0.2"
           }
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
         }
       }
     },
@@ -2562,6 +3917,15 @@
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         }
+      }
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "requires": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
@@ -2589,10 +3953,20 @@
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
+    "lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM="
     },
     "lodash.union": {
       "version": "4.6.0",
@@ -2611,6 +3985,51 @@
       "requires": {
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "log-update": {
@@ -2694,10 +4113,98 @@
         }
       }
     },
+    "make-fetch-happen": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
+      "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
+      "requires": {
+        "agentkeepalive": "^4.1.3",
+        "cacache": "^15.2.0",
+        "http-cache-semantics": "^4.1.0",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "is-lambda": "^1.0.1",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.3",
+        "minipass-collect": "^1.0.2",
+        "minipass-fetch": "^1.3.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.2",
+        "promise-retry": "^2.0.1",
+        "socks-proxy-agent": "^6.0.0",
+        "ssri": "^8.0.0"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+          "requires": {
+            "debug": "4"
+          }
+        },
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+          "requires": {
+            "agent-base": "6",
+            "debug": "4"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
     "map-stream": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
       "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
+    },
+    "markdown-it": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-4.4.0.tgz",
+      "integrity": "sha1-PfNz2+pYepp/7z5WMRtokI91xBQ=",
+      "requires": {
+        "argparse": "~1.0.2",
+        "entities": "~1.1.1",
+        "linkify-it": "~1.2.0",
+        "mdurl": "~1.0.0",
+        "uc.micro": "^1.0.0"
+      }
+    },
+    "markdownlint": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.0.8.tgz",
+      "integrity": "sha1-7SoPxsujquavCa4Ivb+k3heKRnc=",
+      "requires": {
+        "markdown-it": "^4.4.0"
+      }
     },
     "md5": {
       "version": "2.3.0",
@@ -2725,6 +4232,11 @@
         "inherits": "^2.0.1"
       }
     },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
+    },
     "memory-pager": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
@@ -2742,21 +4254,21 @@
       "integrity": "sha1-6AomYY5S9cQiKGG7dIUQvRDikIk="
     },
     "mime": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
-      "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="
     },
     "mime-db": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
-      "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw=="
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
+      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g=="
     },
     "mime-types": {
-      "version": "2.1.30",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
-      "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
+      "version": "2.1.34",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
+      "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
       "requires": {
-        "mime-db": "1.47.0"
+        "mime-db": "1.51.0"
       }
     },
     "mimic-fn": {
@@ -2765,9 +4277,9 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -2777,13 +4289,84 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
-    "mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+    "minipass": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+      "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
       "requires": {
-        "minimist": "^1.2.5"
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
       }
+    },
+    "minipass-collect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
+    "minipass-fetch": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
+      "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
+      "requires": {
+        "encoding": "^0.1.12",
+        "minipass": "^3.1.0",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.0.0"
+      }
+    },
+    "minipass-flush": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
+      "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
+    "minipass-pipeline": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
+    "minipass-sized": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "requires": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
+    "mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
     "mocha": {
       "version": "5.2.0",
@@ -2821,10 +4404,13 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
         },
         "minimist": {
           "version": "0.0.8",
@@ -2874,6 +4460,14 @@
             "ms": "2.0.0"
           }
         },
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -2894,9 +4488,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -2940,14 +4534,14 @@
       "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "mongodb": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.6.tgz",
-      "integrity": "sha512-WlirMiuV1UPbej5JeCMqE93JRfZ/ZzqE7nJTwP85XzjAF4rRSeq2bGCb1cjfoHLOF06+HxADaPGqT0g3SbVT1w==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.3.tgz",
+      "integrity": "sha512-Psm+g3/wHXhjBEktkxXsFMZvd3nemI0r3IPsE0bU+4//PnvNWKkzhZcEsbPcYiWqe8XqXJJEg4Tgtr7Raw67Yw==",
       "requires": {
         "bl": "^2.2.1",
         "bson": "^1.1.4",
         "denque": "^1.4.1",
-        "optional-require": "^1.0.2",
+        "optional-require": "^1.1.8",
         "safe-buffer": "^5.1.2",
         "saslprep": "^1.0.0"
       },
@@ -2974,34 +4568,67 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "nan": {
-      "version": "2.14.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
     },
     "napi-macros": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
       "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg=="
     },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+    },
     "negotiator": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
     },
     "node-forge": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
-      "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
+    },
+    "node-gyp": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
+      "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
+      "requires": {
+        "env-paths": "^2.2.0",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^9.1.0",
+        "nopt": "^5.0.0",
+        "npmlog": "^6.0.0",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.2",
+        "which": "^2.0.2"
+      }
     },
     "node-gyp-build": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.1.1.tgz",
       "integrity": "sha512-dSq1xmcPDKPZ2EED2S6zw/b9NKsqzXRE6dVr8TVQnI3FJOTteUMuqF3Qqs6LZg+mLGYJWqQzMbIjMtJqTv87nQ=="
+    },
+    "nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "requires": {
+        "abbrev": "1"
+      }
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -3012,6 +4639,13 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
       }
     },
     "npm-run-all": {
@@ -3028,6 +4662,16 @@
         "string.prototype.padend": "^3.0.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -3063,6 +4707,14 @@
           "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
           "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
         },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
@@ -3086,6 +4738,17 @@
         "path-key": "^3.0.0"
       }
     },
+    "npmlog": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.1.tgz",
+      "integrity": "sha512-BTHDvY6nrRHuRfyjt1MAufLxYdVXZfd099H4+i1f0lPywNQyI4foeNXJRObB/uy+TYqUW0vAD9gbdSOXPst7Eg==",
+      "requires": {
+        "are-we-there-yet": "^3.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^4.0.0",
+        "set-blocking": "^2.0.0"
+      }
+    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -3107,9 +4770,9 @@
       "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
     },
     "object-inspect": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.2.tgz",
-      "integrity": "sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA=="
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g=="
     },
     "object-keys": {
       "version": "1.1.1",
@@ -3125,6 +4788,26 @@
         "define-properties": "^1.1.3",
         "has-symbols": "^1.0.1",
         "object-keys": "^1.1.1"
+      }
+    },
+    "object.entries": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
+      "integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
+      }
+    },
+    "object.values": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
+      "integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
       }
     },
     "once": {
@@ -3146,19 +4829,67 @@
       "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q=="
     },
     "optional-require": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.0.3.tgz",
-      "integrity": "sha512-RV2Zp2MY2aeYK5G+B/Sps8lW5NHAzE5QClbFP15j+PWmP+T9PxlJXBOOLoSAdgwFvS4t0aMR4vpedMkbHfh0nA=="
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
+      "integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
+      "requires": {
+        "require-at": "^1.0.6"
+      }
+    },
+    "optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "requires": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      }
     },
     "ospath": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
       "integrity": "sha1-EnZjl3Sj+O8lcvf+QoDg6kVQwHs="
     },
+    "p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "requires": {
+        "p-try": "^1.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "requires": {
+        "p-limit": "^1.1.0"
+      }
+    },
     "p-map": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "requires": {
+        "aggregate-error": "^3.0.0"
+      }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "requires": {
+        "callsites": "^3.0.0"
+      }
     },
     "parse-json": {
       "version": "2.2.0",
@@ -3184,6 +4915,11 @@
         "better-assert": "~1.0.0"
       }
     },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -3195,9 +4931,9 @@
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-type": {
       "version": "2.0.0",
@@ -3237,6 +4973,11 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
     },
+    "prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
+    },
     "pretty-bytes": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
@@ -3247,12 +4988,31 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
+    },
     "prom-client": {
       "version": "10.2.3",
       "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-10.2.3.tgz",
       "integrity": "sha512-Xboq5+TdUwuQtSSDRZRNnb5NprINlgQN999VqUjZxnLKydUNLeIPx6Eiahg6oJua3XBg2TGnh5Cth1s4I6+r7g==",
       "requires": {
         "tdigest": "^0.1.1"
+      }
+    },
+    "promise-inflight": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
+    },
+    "promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "requires": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
       }
     },
     "prr": {
@@ -3354,9 +5114,9 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
     },
     "querystring": {
       "version": "0.2.0",
@@ -3364,9 +5124,9 @@
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "ramda": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
-      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw=="
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
+      "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA=="
     },
     "read-pkg": {
       "version": "2.0.0",
@@ -3417,6 +5177,11 @@
         "redis-errors": "^1.0.0"
       }
     },
+    "regexpp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg=="
+    },
     "request": {
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
@@ -3452,14 +5217,30 @@
         "throttleit": "^1.0.0"
       }
     },
+    "require-at": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
+      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g=="
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+    },
     "resolve": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
       "requires": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
+        "is-core-module": "^2.8.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
       }
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
     },
     "restore-cursor": {
       "version": "1.0.1",
@@ -3469,6 +5250,11 @@
         "exit-hook": "^1.0.0",
         "onetime": "^1.0.0"
       }
+    },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
     "retry-axios": {
       "version": "0.3.2",
@@ -3506,9 +5292,9 @@
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "safe-json-stringify": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz",
-      "integrity": "sha1-PLZxdmCghtB8tb2bemh1vPZ70F4="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
+      "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -3530,9 +5316,32 @@
       "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -3548,14 +5357,24 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
     "shell-quote": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
-      "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg=="
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
+      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw=="
+    },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
     },
     "signal-exit": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "simple-glob": {
       "version": "0.2.0",
@@ -3572,6 +5391,11 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
+    },
+    "smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
     },
     "snakeize": {
       "version": "0.1.0",
@@ -3754,6 +5578,53 @@
         }
       }
     },
+    "socks": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz",
+      "integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
+      "requires": {
+        "ip": "^1.1.5",
+        "smart-buffer": "^4.2.0"
+      }
+    },
+    "socks-proxy-agent": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz",
+      "integrity": "sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==",
+      "requires": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.1",
+        "socks": "^2.6.1"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+          "requires": {
+            "debug": "4"
+          }
+        },
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+    },
     "sparse-bitfield": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
@@ -3787,9 +5658,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
-      "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ=="
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
+      "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g=="
     },
     "split": {
       "version": "0.3.3",
@@ -3818,10 +5689,30 @@
         }
       }
     },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "sproxydclient": {
+      "version": "github:scality/sproxydclient#1377ae00e2fd6fff322bc604648abe8971f8a800",
+      "from": "github:scality/sproxydclient#8.0.3",
+      "requires": {
+        "async": "^3.2.0",
+        "werelogs": "github:scality/werelogs#8.1.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+          "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
+        }
+      }
+    },
     "sshpk": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+      "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -3832,6 +5723,14 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
+      }
+    },
+    "ssri": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+      "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+      "requires": {
+        "minipass": "^3.1.1"
       }
     },
     "standard-as-callback": {
@@ -3882,38 +5781,23 @@
       "integrity": "sha512-Mm+sROy+pHJmx0P/0Bs1uxIX6UhGJGj6xDGQZ5zh9v/SZRmLGevp+p0VJxV7lirrkAmQ2mvva/gHKpnF/pTb+Q=="
     },
     "string-width": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
-        },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
-        }
+        "strip-ansi": "^6.0.1"
       }
     },
     "string.prototype.padend": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.2.tgz",
-      "integrity": "sha512-/AQFLdYvePENU3W5rgurfWSMU6n+Ww8n/3cUt7E+vPBB/D7YDG8x+qjoFs4M/alR2bW7Qg6xMjVwWUOvuQ0XpQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.3.tgz",
+      "integrity": "sha512-jNIIeokznm8SD/TZISQsZKYu7RJyheFNt84DUPrh482GC8RVp2MKqm2O5oBRdGxbDQoXrhhWtPIWQOiy20svUg==",
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.2"
+        "es-abstract": "^1.19.1"
       }
     },
     "string.prototype.trimend": {
@@ -3950,11 +5834,11 @@
       }
     },
     "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "^5.0.1"
       }
     },
     "strip-bom": {
@@ -3967,23 +5851,114 @@
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
     },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
+    },
     "stubs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls="
     },
     "supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
-        "has-flag": "^4.0.0"
+        "has-flag": "^3.0.0"
       }
+    },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
       "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+    },
+    "table": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
+      "integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
+      "requires": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.10.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
+          "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        },
+        "slice-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+          "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
+          }
+        }
+      }
+    },
+    "tar": {
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+      "requires": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^3.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
     },
     "tdigest": {
       "version": "0.1.1",
@@ -3992,6 +5967,11 @@
       "requires": {
         "bintrees": "1.0.1"
       }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
     "throttleit": {
       "version": "1.0.0",
@@ -4025,6 +6005,11 @@
       "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
       "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
     },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+    },
     "tough-cookie": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -4032,6 +6017,22 @@
       "requires": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
+      }
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
+    "tsconfig-paths": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz",
+      "integrity": "sha512-e5adrnOYT6zqVnWqZu7i/BQ3BnhzvGbjEjejFXO20lKIKpwTaupkCPgEfv4GZK1IBciJUEhYs3J3p75FdaTFVg==",
+      "requires": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
+        "minimist": "^1.2.0",
+        "strip-bom": "^3.0.0"
       }
     },
     "tslib": {
@@ -4051,6 +6052,19 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
+    "type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "requires": {
+        "prelude-ls": "^1.2.1"
+      }
+    },
+    "type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
     },
     "typedarray": {
       "version": "0.0.6",
@@ -4083,6 +6097,11 @@
       "resolved": "https://registry.npmjs.org/typewiselite/-/typewiselite-1.0.0.tgz",
       "integrity": "sha1-yIgvobsQksBgBal/NO9chQjjZk4="
     },
+    "uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
+    },
     "unbox-primitive": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -4098,6 +6117,22 @@
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+    },
+    "unique-filename": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+      "requires": {
+        "unique-slug": "^2.0.0"
+      }
+    },
+    "unique-slug": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+      "requires": {
+        "imurmurhash": "^0.1.4"
+      }
     },
     "unique-string": {
       "version": "1.0.0",
@@ -4156,6 +6191,11 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
+    "v8-compile-cache": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA=="
+    },
     "validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -4171,32 +6211,46 @@
       "integrity": "sha512-YV5KjzvRmSyJ1ee/Dm5UED0G+1L4GZnLN3w6/T+zZm8scVua4sOhYKWTUrKa0H/tMiJyO9QLHMPN+9mB/aMunA=="
     },
     "vaultclient": {
-      "version": "github:scality/vaultclient#5617b9b1b5a8ed10e4ef1f2aff6a64f5bb5e57e4",
-      "from": "github:scality/vaultclient#5617b9b",
+      "version": "github:scality/vaultclient#b9452a526daf5627ecae9528c941375a208e79f3",
+      "from": "github:scality/vaultclient#b9452a526daf5627ecae9528c941375a208e79f3",
       "requires": {
         "agentkeepalive": "^4.1.3",
-        "arsenal": "github:scality/Arsenal#8ed8478",
+        "arsenal": "github:scality/Arsenal#8.1.13",
         "commander": "2.20.0",
-        "werelogs": "github:scality/werelogs#4e0d97c",
+        "werelogs": "github:scality/werelogs#8.1.0",
         "xml2js": "0.4.19"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.12.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+          "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
         "arsenal": {
-          "version": "github:scality/Arsenal#8ed84786fce31f603b1e8cd641b3b44b8f715b0b",
-          "from": "github:scality/Arsenal#8ed8478",
+          "version": "github:scality/Arsenal#e912617f025f33d74cf7ccb985d17c192dbc724e",
+          "from": "github:scality/Arsenal#8.1.13",
           "requires": {
             "@hapi/joi": "^15.1.0",
             "JSONStream": "^1.0.0",
+            "agentkeepalive": "^4.1.3",
             "ajv": "6.12.2",
             "async": "~2.6.1",
             "aws-sdk": "2.80.0",
-            "azure-storage": "^2.1.0",
+            "azure-storage": "2.10.3",
             "backo": "^1.1.0",
+            "base-x": "3.0.8",
+            "base62": "2.0.1",
             "bson": "4.0.0",
             "debug": "~4.1.0",
             "diskusage": "^1.1.1",
             "fcntl": "github:scality/node-fcntl",
-            "hdclient": "github:scality/hdclient#5145e04e5ed33e85106765b1caa90cd245ef482b",
+            "hdclient": "github:scality/hdclient#489db2106570b9ea41bdacdf56131324d0db6a58",
             "https-proxy-agent": "^2.2.0",
             "ioctl": "2.0.1",
             "ioredis": "4.9.5",
@@ -4209,20 +6263,13 @@
             "simple-glob": "^0.2.0",
             "socket.io": "~2.3.0",
             "socket.io-client": "~2.3.0",
-            "sproxydclient": "github:scality/sproxydclient#30e7115",
+            "sproxydclient": "github:scality/sproxydclient#8.0.2",
             "utf8": "3.0.0",
             "uuid": "^3.0.1",
-            "werelogs": "github:scality/werelogs#0ff7ec82",
+            "werelogs": "github:scality/werelogs#8.1.0",
             "xml2js": "~0.4.23"
           },
           "dependencies": {
-            "werelogs": {
-              "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
-              "from": "github:scality/werelogs#0ff7ec82",
-              "requires": {
-                "safe-json-stringify": "1.0.3"
-              }
-            },
             "xml2js": {
               "version": "0.4.23",
               "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
@@ -4279,6 +6326,44 @@
             }
           }
         },
+        "azure-storage": {
+          "version": "2.10.3",
+          "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.3.tgz",
+          "integrity": "sha512-IGLs5Xj6kO8Ii90KerQrrwuJKexLgSwYC4oLWmc11mzKe7Jt2E5IVg+ZQ8K53YWZACtVTMBNO3iGuA+4ipjJxQ==",
+          "requires": {
+            "browserify-mime": "~1.2.9",
+            "extend": "^3.0.2",
+            "json-edm-parser": "0.1.2",
+            "md5.js": "1.3.4",
+            "readable-stream": "~2.0.0",
+            "request": "^2.86.0",
+            "underscore": "~1.8.3",
+            "uuid": "^3.0.0",
+            "validator": "~9.4.1",
+            "xml2js": "0.2.8",
+            "xmlbuilder": "^9.0.7"
+          },
+          "dependencies": {
+            "sax": {
+              "version": "0.5.8",
+              "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
+              "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE="
+            },
+            "xml2js": {
+              "version": "0.2.8",
+              "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
+              "integrity": "sha1-m4FpCTFjH/CdGVdUn69U9PmAs8I=",
+              "requires": {
+                "sax": "0.5.x"
+              }
+            },
+            "xmlbuilder": {
+              "version": "9.0.7",
+              "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+              "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+            }
+          }
+        },
         "commander": {
           "version": "2.20.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
@@ -4293,16 +6378,17 @@
           }
         },
         "fcntl": {
-          "version": "github:scality/node-fcntl#9108603d8881d7762dcadfde1db927a1653dfda5",
+          "version": "github:scality/node-fcntl#ed31a05368cf3c1d18fac426e010977ac44f6815",
           "from": "github:scality/node-fcntl",
           "requires": {
             "bindings": "^1.1.1",
-            "nan": "^2.3.2"
+            "nan": "^2.3.2",
+            "node-gyp": "^8.0.0"
           }
         },
         "hdclient": {
-          "version": "github:scality/hdclient#5145e04e5ed33e85106765b1caa90cd245ef482b",
-          "from": "github:scality/hdclient#5145e04e5ed33e85106765b1caa90cd245ef482b",
+          "version": "github:scality/hdclient#489db2106570b9ea41bdacdf56131324d0db6a58",
+          "from": "github:scality/hdclient#489db2106570b9ea41bdacdf56131324d0db6a58",
           "requires": {
             "werelogs": "github:scality/werelogs#GA7.2.0.5"
           },
@@ -4316,39 +6402,63 @@
             }
           }
         },
+        "ioctl": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/ioctl/-/ioctl-2.0.1.tgz",
+          "integrity": "sha1-6cBe4W5XVNfRWGvsWnNKgZEXWto=",
+          "optional": true,
+          "requires": {
+            "bindings": "^1.1.1",
+            "nan": "^2.3.2"
+          }
+        },
         "ms": {
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
+        "node-forge": {
+          "version": "0.7.6",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
+          "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+        },
+        "readable-stream": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~0.10.x",
+            "util-deprecate": "~1.0.1"
+          }
+        },
         "sproxydclient": {
-          "version": "github:scality/sproxydclient#30e7115668bc7e10b4ec3cfdbaa7a124cdc21cc5",
-          "from": "github:scality/sproxydclient#30e7115",
+          "version": "github:scality/sproxydclient#e45c547833f03b1fa0409e0499433dcb386442f5",
+          "from": "github:scality/sproxydclient#8.0.2",
           "requires": {
             "async": "^3.1.0",
-            "werelogs": "github:scality/werelogs#351a2a3"
+            "werelogs": "github:scality/werelogs#8.1.0"
           },
           "dependencies": {
             "async": {
-              "version": "3.2.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-              "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
-            },
-            "werelogs": {
-              "version": "github:scality/werelogs#351a2a339e9673301cb45777e1b6d70ae9a73d67",
-              "from": "github:scality/werelogs#351a2a3",
-              "requires": {
-                "safe-json-stringify": "1.0.3"
-              }
+              "version": "3.2.3",
+              "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+              "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
             }
           }
         },
-        "werelogs": {
-          "version": "github:scality/werelogs#4e0d97cf69ea7ed60bea90756278513e7e7ea9b1",
-          "from": "github:scality/werelogs#4e0d97c",
-          "requires": {
-            "safe-json-stringify": "1.0.3"
-          }
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         },
         "xml2js": {
           "version": "0.4.19",
@@ -4376,6 +6486,41 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      },
+      "dependencies": {
+        "core-util-is": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        }
+      }
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "werelogs": {
+      "version": "github:scality/werelogs#e8f828725642c54c511cdbe580b18f43d3589313",
+      "from": "github:scality/werelogs#8.1.0",
+      "requires": {
+        "safe-json-stringify": "1.0.3"
+      },
+      "dependencies": {
+        "safe-json-stringify": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz",
+          "integrity": "sha1-PLZxdmCghtB8tb2bemh1vPZ70F4="
+        }
+      }
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "which": {
@@ -4397,6 +6542,19 @@
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
       }
+    },
+    "wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "requires": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
     },
     "wrap-ansi": {
       "version": "3.0.1",
@@ -4452,9 +6610,9 @@
       }
     },
     "ws": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
-      "integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g=="
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
+      "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A=="
     },
     "xdg-basedir": {
       "version": "3.0.0",
@@ -4467,12 +6625,19 @@
       "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
     },
     "xml2js": {
-      "version": "0.4.17",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
-      "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
       "requires": {
         "sax": ">=0.6.0",
-        "xmlbuilder": "^4.1.0"
+        "xmlbuilder": "~11.0.0"
+      },
+      "dependencies": {
+        "xmlbuilder": {
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+          "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+        }
       }
     },
     "xmlbuilder": {

--- a/tests/zenko_tests/node_tests/package.json
+++ b/tests/zenko_tests/node_tests/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Test-dependencies",
   "engines": {
-    "node": ">6.9.5"
+    "node": ">=16"
   },
   "version": "1.0.0-zenko",
   "description": "Test dependencies",
@@ -12,11 +12,17 @@
   ],
   "dependencies": {
     "@google-cloud/storage": "^1.6.0",
+    "arsenal": "scality/Arsenal#8.1.27",
     "async": "2.1.2",
     "aws-sdk": "2.60.0",
     "azure-storage": "^2.10.0",
+    "babel-eslint": "^10.1.0",
     "cypress": "^6.5.0",
     "cypress-file-upload": "^5.0.2",
+    "eslint": "7.32.0",
+    "eslint-config-airbnb": "^19.0.4",
+    "eslint-config-scality": "scality/Guidelines#7.10.1.6",
+    "eslint-plugin-import": "^2.25.4",
     "mocha": "^5.2.0",
     "mocha-junit-reporter": "^1.23.1",
     "mocha-multi-reporters": "^1.1.7",
@@ -44,7 +50,8 @@
     "test_operator": "mocha --tags ${MOCHA_TAGS} --exit -t 10000 --reporter mocha-multi-reporters --reporter-options configFile=config.json ./init_test.js",
     "test_smoke": "mocha --tags ${MOCHA_TAGS} --exit -t 10000 --reporter mocha-multi-reporters --reporter-options configFile=config.json --recursive smoke_tests",
     "test_iam_policies": "mocha --tags ${MOCHA_TAGS} --exit -t 10000 --reporter mocha-multi-reporters --reporter-options configFile=config.json --recursive iam_policies",
-    "test_all_extensions": "npm-run-all test_aws_crr test_ingestion_oob_s3c"
+    "test_all_extensions": "npm-run-all test_aws_crr test_ingestion_oob_s3c",
+    "lint": "eslint $(find . -name '*.js' -not -path '*/node_modules/*')"
   },
   "author": ""
 }

--- a/tests/zenko_tests/node_tests/package.json
+++ b/tests/zenko_tests/node_tests/package.json
@@ -43,6 +43,7 @@
     "test_bucket_policy": "mocha --tags ${MOCHA_TAGS} --exit -t 10000 --reporter mocha-multi-reporters --reporter-options configFile=config.json --recursive cloudserver/bucketPolicy/tests",
     "test_operator": "mocha --tags ${MOCHA_TAGS} --exit -t 10000 --reporter mocha-multi-reporters --reporter-options configFile=config.json ./init_test.js",
     "test_smoke": "mocha --tags ${MOCHA_TAGS} --exit -t 10000 --reporter mocha-multi-reporters --reporter-options configFile=config.json --recursive smoke_tests",
+    "test_iam_policies": "mocha --tags ${MOCHA_TAGS} --exit -t 10000 --reporter mocha-multi-reporters --reporter-options configFile=config.json --recursive iam_policies",
     "test_all_extensions": "npm-run-all test_aws_crr test_ingestion_oob_s3c"
   },
   "author": ""

--- a/tests/zenko_tests/node_tests/s3SDK.js
+++ b/tests/zenko_tests/node_tests/s3SDK.js
@@ -1,4 +1,5 @@
 const S3 = require('aws-sdk').S3;
+const IAM = require('aws-sdk').IAM;
 
 const scalityS3Client = new S3({
     accessKeyId: process.env.ZENKO_ACCESS_KEY,
@@ -6,6 +7,26 @@ const scalityS3Client = new S3({
     sessionToken: process.env.ZENKO_SESSION_TOKEN,
     sslEnabled: false,
     endpoint: process.env.CLOUDSERVER_ENDPOINT,
+    apiVersions: { s3: '2006-03-01' },
+    signatureCache: false,
+    signatureVersion: 'v4',
+    region: 'us-east-1',
+    s3ForcePathStyle: true,
+    // disable node sdk retries and timeout to prevent InvalidPart
+    // and SocketHangUp errors. If retries are allowed, sdk will send
+    // another request after first request has already deleted parts,
+    // causing InvalidPart. Meanwhile, if request takes too long to finish,
+    // sdk will create SocketHangUp error before response.
+    maxRetries: 0,
+    httpOptions: { timeout: 0 },
+});
+
+const scalityIAMClient = new IAM({
+    accessKeyId: process.env.ZENKO_ACCESS_KEY,
+    secretAccessKey: process.env.ZENKO_SECRET_KEY,
+    sessionToken: process.env.ZENKO_SESSION_TOKEN,
+    sslEnabled: false,
+    endpoint: process.env.VAULT_ENDPOINT,
     apiVersions: { s3: '2006-03-01' },
     signatureCache: false,
     signatureVersion: 'v4',
@@ -70,4 +91,5 @@ module.exports = {
     awsS3Client,
     ringS3Client,
     altScalityS3Client,
+    scalityIAMClient
 };

--- a/tests/zenko_tests/node_tests/s3SDK.js
+++ b/tests/zenko_tests/node_tests/s3SDK.js
@@ -1,5 +1,5 @@
-const S3 = require('aws-sdk').S3;
-const IAM = require('aws-sdk').IAM;
+const { S3 } = require('aws-sdk');
+const { IAM } = require('aws-sdk');
 
 const scalityS3Client = new S3({
     accessKeyId: process.env.ZENKO_ACCESS_KEY,
@@ -40,8 +40,8 @@ const scalityIAMClient = new IAM({
     httpOptions: { timeout: 0 },
 });
 
-const verifyCerts = process.env.VERIFY_CERTIFICATES ?
-                      process.env.VERIFY_CERTIFICATES : true;
+const verifyCerts = process.env.VERIFY_CERTIFICATES
+    ? process.env.VERIFY_CERTIFICATES : true;
 
 const awsS3Client = new S3({
     accessKeyId: process.env.AWS_ACCESS_KEY,
@@ -90,5 +90,5 @@ module.exports = {
     awsS3Client,
     ringS3Client,
     altScalityS3Client,
-    scalityIAMClient
+    scalityIAMClient,
 };

--- a/tests/zenko_tests/node_tests/s3SDK.js
+++ b/tests/zenko_tests/node_tests/s3SDK.js
@@ -31,7 +31,6 @@ const scalityIAMClient = new IAM({
     signatureCache: false,
     signatureVersion: 'v4',
     region: 'us-east-1',
-    s3ForcePathStyle: true,
     // disable node sdk retries and timeout to prevent InvalidPart
     // and SocketHangUp errors. If retries are allowed, sdk will send
     // another request after first request has already deleted parts,

--- a/tests/zenko_tests/node_tests/utils/request.js
+++ b/tests/zenko_tests/node_tests/utils/request.js
@@ -41,11 +41,7 @@ function makeGETRequest(path, cb, userCredentials) {
         method: 'GET',
         path,
     });
-    if (userCredentials) {
-        options = aws4.sign(options, userCredentials);
-    } else {
-        options = aws4.sign(options, credentials);
-    }
+    options = aws4.sign(options, userCredentials ? userCredentials : credentials);
 
     const req = http.request(options, res => cb(null, res));
     req.on('error', err => cb(err));

--- a/tests/zenko_tests/node_tests/utils/request.js
+++ b/tests/zenko_tests/node_tests/utils/request.js
@@ -36,12 +36,16 @@ function getResponseBody(res, cb) {
  * @param {Function} cb - callback(error, response)
  * @return {undefined}
  */
-function makeGETRequest(path, cb) {
+function makeGETRequest(path, cb, userCredentials) {
     let options = Object.assign({}, defaultOptions, {
         method: 'GET',
         path,
     });
-    options = aws4.sign(options, credentials);
+    if (userCredentials) {
+        options = aws4.sign(options, userCredentials);
+    } else {
+        options = aws4.sign(options, credentials);
+    }
 
     const req = http.request(options, res => cb(null, res));
     req.on('error', err => cb(err));

--- a/tests/zenko_tests/node_tests/utils/request.js
+++ b/tests/zenko_tests/node_tests/utils/request.js
@@ -15,13 +15,13 @@ const defaultOptions = {
 };
 const credentials = { accessKeyId, secretAccessKey, sessionToken };
 
-function getResponseBody(res, cb) {
+function getResponseBody(res, cb, isXml = false) {
     res.setEncoding('utf8');
     const resBody = [];
     res.on('data', chunk => resBody.push(chunk));
     res.on('end', () => {
         try {
-            const parsedBody = JSON.parse(resBody.join(''));
+            const parsedBody = isXml ? resBody.join('') : JSON.parse(resBody.join(''));
             return cb(null, parsedBody);
         } catch (e) {
             return cb(e);
@@ -41,7 +41,7 @@ function makeGETRequest(path, cb, userCredentials) {
         method: 'GET',
         path,
     });
-    options = aws4.sign(options, userCredentials ? userCredentials : credentials);
+    options = aws4.sign(options, userCredentials || credentials);
 
     const req = http.request(options, res => cb(null, res));
     req.on('error', err => cb(err));


### PR DESCRIPTION
e2e tests for iam policies over metadatasearch
We are only testing if call is authorized or not with the policy.
The real ft_tests are already tested in cloudserver

We won't add our tests in end2end_https is because we can see in Zenko main.yaml, the only difference between HTTP tests and HTTPS test is if keycloak is HTTP or not, we already have keycloak https tests in Vault. And the main objective here is to test cloudserver and vault interact correctly with each other, so we don't need the whole test to run again in https mode.