### PR TITLE
ZENKO-3998 - fix kafka error in alert

### DIFF
--- a/monitoring/kafka/alerts.yaml
+++ b/monitoring/kafka/alerts.yaml
@@ -40,10 +40,10 @@ groups:
 
   - alert: BrokersCountCritical
     expr: |
-      count(kafka_server_replicamanager_leadercount{namespace="${namespace}",service="${service}"}) == 0
+      absent(kafka_server_replicamanager_leadercount{namespace="${namespace}",service="${service}"}) == 1
     for: 1m
     labels:
-      severity: warning
+      severity: critical
     annotations:
       summary: 'No Brokers online'
       description: 'Kafka: Broker count is 0'


### PR DESCRIPTION
When no kafka instance is running there is no metric
in prometheus. The function `count` does not return 0
when there is no metrics, instead use the function
`absent` will check that and return 1 if no metric exists.