### PR TITLE
Feature: zenko 3952 integrate new bucket key versioning format

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -369,6 +369,13 @@ stages:
         command: bash scripts/configure-e2e.sh "end2end" ${E2E_IMAGE_NAME}:${E2E_IMAGE_TAG} "default"
         workdir: build/eve/workers/end2end
         haltOnFailure: true
+    - ShellCommand: &linting_coverage
+        name: Linting
+        env:
+          <<: [*kind-env, *e2e-env, *http-env, *secrets-env]
+        command: bash scripts/run-e2e-test.sh "end2end" ${E2E_IMAGE_NAME}:${E2E_IMAGE_TAG} "lint" "default"
+        workdir: build/eve/workers/end2end
+        haltOnFailure: true
     - ShellCommand: &run_end2end_tests
         name: Run init CI test
         env:

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -383,6 +383,13 @@ stages:
         command: bash scripts/run-e2e-test.sh "end2end" ${E2E_IMAGE_NAME}:${E2E_IMAGE_TAG} "iam-policies" "default"
         workdir: build/eve/workers/end2end
         haltOnFailure: true
+    - ShellCommand: &run_cloudserver_tests
+        name: Run cloudserver tests
+        env:
+          <<: [*kind-env, *e2e-env, *http-env, *secrets-env]
+        command: bash scripts/run-e2e-test.sh "end2end" ${E2E_IMAGE_NAME}:${E2E_IMAGE_TAG} "object-api" "default"
+        workdir: build/eve/workers/end2end
+        haltOnFailure: true
     - ShellCommand: &run_smoke_test
         name: Run smoke tests
         env:

--- a/eve/workers/end2end/scripts/run-e2e-test.sh
+++ b/eve/workers/end2end/scripts/run-e2e-test.sh
@@ -124,7 +124,9 @@ elif [ "$STAGE" = "backbeat" ]; then
    ## TODO: use node js to create and remove buckets
    run_e2e_test '' 'cd node_tests && npm run test_all_extensions && cd .. && python3 cleans3c.py'
 elif [ "$STAGE" = "iam-policies" ]; then
-   run_e2e_test '' 'cd node_tests && npm run lint && npm run test_iam_policies'
+   run_e2e_test '' 'cd node_tests && npm run test_iam_policies'
 elif [ "$STAGE" = "object-api" ]; then
-   run_e2e_test '' 'cd node_tests && npm run lint && npm run test_object_api'
+   run_e2e_test '' 'cd node_tests && npm run test_object_api'
+elif [ "$STAGE" = "lint" ]; then
+   run_e2e_test '' 'cd node_tests && npm run lint'
 fi

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -5,7 +5,7 @@ backbeat:
   sourceRegistry: registry.scality.com/backbeat
   dashboard: backbeat-dashboards
   image: backbeat
-  tag: 8.3.8
+  tag: 8.3.11
   envsubst: BACKBEAT_TAG
 blobserver:
   sourceRegistry: registry.scality.com/sf-eng
@@ -20,7 +20,7 @@ cloudserver:
   sourceRegistry: registry.scality.com/cloudserver
   dashboard: cloudserver-dashboards
   image: cloudserver
-  tag: 8.4.3
+  tag: 8.4.6
   envsubst: CLOUDSERVER_TAG
 jabba:
   sourceRegistry: registry.scality.com/jabba

--- a/tests/zenko_tests/node_tests/cloudserver/keyFormatVersion/tests/nonVersionedBucket.js
+++ b/tests/zenko_tests/node_tests/cloudserver/keyFormatVersion/tests/nonVersionedBucket.js
@@ -1,0 +1,194 @@
+const assert = require('assert');
+const async = require('async');
+const werelogs = require('werelogs');
+const { MetadataWrapper } = require('arsenal').storage.metadata;
+const { versioning } = require('arsenal');
+const { BucketInfo } = require('arsenal').models;
+const s3 = require('../../../s3SDK').scalityS3Client;
+
+const logger = new werelogs.Logger('keyFormatVersion', 'debug', 'debug');
+const { BucketVersioningKeyFormat } = versioning.VersioningConstants;
+
+const IMPL_NAME = 'mongodb';
+const BUCKET_NAME = {
+    v0: 'key-format-non-versioned-bucket-v0',
+    v1: 'key-format-non-versioned-bucket-v1',
+};
+const ownerInfo = {};
+
+function putObjects(bucketName, cb) {
+    async.timesSeries(10, (n, next) => {
+        s3.putObject({ Bucket: bucketName, Key: `key-${n}` }, next);
+    }, cb);
+}
+
+function emptyBucket(bucketName, cb) {
+    async.timesSeries(10, (n, next) => {
+        s3.deleteObject({ Bucket: bucketName, Key: `key-${n}` }, next);
+    }, cb);
+}
+
+function expectedKeyList(startKey, endKey) {
+    const expKeyList = [];
+    for (let i = startKey; i <= endKey; i++) {
+        expKeyList.push(`key-${i}`);
+    }
+    return expKeyList;
+}
+
+describe('Cloudserver : keyFormatVersion : non versioned bucket', () => {
+    let metadata;
+
+    function getBucketOwnerInfo(cb) {
+        async.series([
+            next => s3.createBucket({ Bucket: 'tmp-bucket' }, next),
+            next => metadata.getBucket('tmp-bucket', logger, (err, res) => {
+                if (err) {
+                    return next(err);
+                }
+                ownerInfo._owner = res._owner;
+                ownerInfo._ownerDisplayName = res._ownerDisplayName;
+                return next();
+            }),
+            next => s3.deleteBucket({ Bucket: 'tmp-bucket' }, next),
+        ], cb);
+    }
+
+    function createBucket(vFormat, cb) {
+        const bucketMD = BucketInfo.fromObj({
+            _name: BUCKET_NAME[vFormat],
+            _owner: ownerInfo._owner,
+            _ownerDisplayName: ownerInfo._ownerDisplayName,
+            _creationDate: new Date().toJSON(),
+            _acl: {
+                Canned: 'private',
+                FULL_CONTROL: [],
+                WRITE: [],
+                WRITE_ACP: [],
+                READ: [],
+                READ_ACP: [],
+            },
+            _mdBucketModelVersion: 10,
+            _transient: false,
+            _deleted: false,
+            _serverSideEncryption: null,
+            _versioningConfiguration: null,
+            _locationConstraint: 'us-east-1',
+            _readLocationConstraint: null,
+            _cors: null,
+            _replicationConfiguration: null,
+            _lifecycleConfiguration: null,
+            _uid: '',
+            _isNFS: null,
+            ingestion: null,
+        });
+        async.series([
+            next => {
+                metadata.client.defaultBucketKeyFormat = vFormat;
+                return next();
+            },
+            next => metadata.createBucket(BUCKET_NAME[vFormat], bucketMD, logger, next),
+        ], cb);
+    }
+
+    before(done => {
+        async.series([
+            next => {
+                const opts = {
+                    mongodb: {
+                        replicaSetHosts: process.env.MONGO_REPLICA_SET_HOSTS,
+                        // TODO: replace with env var
+                        replicaSet: 'rs0',
+                        writeConcern: process.env.MONGO_WRITE_CONCERN,
+                        readPreference: process.env.MONGO_READ_PREFERENCE,
+                        shardCollections: process.env.MONGO_SHARD_COLLECTION === 'true',
+                        database: process.env.MONGO_DATABASE,
+                        authCredentials: {
+                            password: process.env.MONGO_AUTH_PASSWORD,
+                            username: process.env.MONGO_AUTH_USERNAME,
+                        },
+                    },
+                };
+                metadata = new MetadataWrapper(IMPL_NAME, opts, null, logger);
+                metadata.setup(next);
+            },
+            next => getBucketOwnerInfo(next),
+            next => createBucket(BucketVersioningKeyFormat.v0, next),
+            next => createBucket(BucketVersioningKeyFormat.v1, next),
+            next => putObjects(BUCKET_NAME.v0, next),
+            next => putObjects(BUCKET_NAME.v1, next),
+        ], err => {
+            assert.ifError(err);
+            done();
+        });
+    });
+
+    after(done => {
+        async.series([
+            next => emptyBucket(BUCKET_NAME.v0, next),
+            next => emptyBucket(BUCKET_NAME.v1, next),
+            next => s3.deleteBucket({ Bucket: BUCKET_NAME.v0 }, next),
+            next => s3.deleteBucket({ Bucket: BUCKET_NAME.v1 }, next),
+            next => metadata.close(next),
+        ], err => {
+            assert.ifError(err);
+            done();
+        });
+    });
+
+    ['v0', 'v1'].forEach(vFormat => {
+        it(`Should return object metadata ${vFormat}`, done => {
+            const params = {
+                Bucket: BUCKET_NAME[vFormat],
+                Key: 'key-2',
+            };
+            s3.getObject(params, (err, data) => {
+                assert.ifError(err);
+                assert(data);
+                return done();
+            });
+        });
+
+        it(`Should list all objects in bucket ${vFormat}`, done => {
+            const params = {
+                Bucket: BUCKET_NAME[vFormat],
+            };
+            s3.listObjectsV2(params, (err, data) => {
+                assert.ifError(err);
+                const keyList = [];
+                data.Contents.forEach(object => keyList.push(object.Key));
+                assert.deepStrictEqual(keyList, expectedKeyList(0, 9));
+                return done();
+            });
+        });
+
+        it(`Should only list object with prefix ${vFormat}`, done => {
+            const params = {
+                Bucket: BUCKET_NAME[vFormat],
+                Prefix: 'key-2',
+            };
+            s3.listObjectsV2(params, (err, data) => {
+                assert.ifError(err);
+                assert.strictEqual(data.Contents.length, 1);
+                assert.strictEqual(data.Contents[0].Key, 'key-2');
+                return done();
+            });
+        });
+
+        it(`Should remove object from bucket ${vFormat}`, done => {
+            async.series([
+                next => s3.putObject({ Bucket: BUCKET_NAME[vFormat], Key: 'key-to-delete' }, next),
+                next => s3.deleteObject({ Bucket: BUCKET_NAME[vFormat], Key: 'key-to-delete' }, next),
+                next => s3.getObject({ Bucket: BUCKET_NAME[vFormat], Key: 'key-to-delete' }, err => {
+                    assert.strictEqual(err.code, 'NoSuchKey');
+                    return next();
+                }),
+                next => s3.listObjectsV2({ Bucket: BUCKET_NAME[vFormat] }, (err, data) => {
+                    assert.ifError(err);
+                    assert.strictEqual(data.Contents.length, 10);
+                    return next();
+                }),
+            ], done);
+        });
+    });
+});

--- a/tests/zenko_tests/node_tests/cloudserver/keyFormatVersion/tests/versionedBucket.js
+++ b/tests/zenko_tests/node_tests/cloudserver/keyFormatVersion/tests/versionedBucket.js
@@ -1,0 +1,283 @@
+const assert = require('assert');
+const async = require('async');
+const werelogs = require('werelogs');
+const { MetadataWrapper } = require('arsenal').storage.metadata;
+const { versioning } = require('arsenal');
+const { BucketInfo } = require('arsenal').models;
+const s3 = require('../../../s3SDK').scalityS3Client;
+
+const logger = new werelogs.Logger('keyFormatVersion', 'debug', 'debug');
+const { BucketVersioningKeyFormat } = versioning.VersioningConstants;
+
+const IMPL_NAME = 'mongodb';
+const BUCKET_NAME = {
+    v0: 'key-format-versioned-bucket-v0',
+    v1: 'key-format-versioned-bucket-v1',
+};
+const versionIds = {
+    v0: {
+        'first-key': [],
+        'second-key': [],
+    },
+    v1: {
+        'first-key': [],
+        'second-key': [],
+    },
+};
+const ownerInfo = {};
+
+function putObjectVersions(objName, vFormat, cb) {
+    async.timesSeries(3, (n, next) => {
+        s3.putObject({ Bucket: BUCKET_NAME[vFormat], Key: objName }, (err, res) => {
+            assert.ifError(err);
+            versionIds[vFormat][objName].push(res.VersionId);
+            return next();
+        });
+    }, cb);
+}
+
+function deleteObjectVersions(objName, vFormat, cb) {
+    async.timesSeries(3, (n, next) => {
+        s3.deleteObject({
+            Bucket: BUCKET_NAME[vFormat],
+            Key: objName,
+            VersionId: versionIds[vFormat][objName][n],
+        }, next);
+    }, cb);
+}
+
+describe('Cloudserver : keyFormatVersion : versioned bucket', () => {
+    let metadata;
+
+    function getBucketOwnerInfo(cb) {
+        async.series([
+            next => s3.createBucket({ Bucket: 'tmp-bucket' }, next),
+            next => metadata.getBucket('tmp-bucket', logger, (err, res) => {
+                if (err) {
+                    return next(err);
+                }
+                ownerInfo._owner = res._owner;
+                ownerInfo._ownerDisplayName = res._ownerDisplayName;
+                return next();
+            }),
+            next => s3.deleteBucket({ Bucket: 'tmp-bucket' }, next),
+        ], cb);
+    }
+
+    function createBucket(vFormat, cb) {
+        const bucketMD = BucketInfo.fromObj({
+            _name: BUCKET_NAME[vFormat],
+            _owner: ownerInfo._owner,
+            _ownerDisplayName: ownerInfo._ownerDisplayName,
+            _creationDate: new Date().toJSON(),
+            _acl: {
+                Canned: 'private',
+                FULL_CONTROL: [],
+                WRITE: [],
+                WRITE_ACP: [],
+                READ: [],
+                READ_ACP: [],
+            },
+            _mdBucketModelVersion: 10,
+            _transient: false,
+            _deleted: false,
+            _serverSideEncryption: null,
+            _versioningConfiguration: null,
+            _locationConstraint: 'us-east-1',
+            _readLocationConstraint: null,
+            _cors: null,
+            _replicationConfiguration: null,
+            _lifecycleConfiguration: null,
+            _uid: '',
+            _isNFS: null,
+            ingestion: null,
+        });
+        async.series([
+            next => {
+                metadata.client.defaultBucketKeyFormat = vFormat;
+                return next();
+            },
+            next => metadata.createBucket(BUCKET_NAME[vFormat], bucketMD, logger, next),
+        ], cb);
+    }
+
+    function createAndPopulateVersionedBucket(vFormat, cb) {
+        async.series([
+            next => createBucket(vFormat, next),
+            next => {
+                const params = {
+                    Bucket: BUCKET_NAME[vFormat],
+                    VersioningConfiguration: {
+                        MFADelete: 'Disabled',
+                        Status: 'Enabled',
+                    },
+                };
+                return s3.putBucketVersioning(params, next);
+            },
+            next => putObjectVersions('first-key', vFormat, next),
+            next => putObjectVersions('second-key', vFormat, next),
+        ], cb);
+    }
+
+    function emptyAndDeleteBucket(vFormat, cb) {
+        async.series([
+            next => deleteObjectVersions('first-key', vFormat, next),
+            next => deleteObjectVersions('second-key', vFormat, next),
+            next => s3.deleteBucket({ Bucket: BUCKET_NAME[vFormat] }, next),
+        ], cb);
+    }
+
+    before(done => {
+        async.series([
+            next => {
+                const opts = {
+                    mongodb: {
+                        replicaSetHosts: process.env.MONGO_REPLICA_SET_HOSTS,
+                        // TODO: replace with env var
+                        replicaSet: 'rs0',
+                        writeConcern: process.env.MONGO_WRITE_CONCERN,
+                        readPreference: process.env.MONGO_READ_PREFERENCE,
+                        shardCollections: process.env.MONGO_SHARD_COLLECTION === 'true',
+                        database: process.env.MONGO_DATABASE,
+                        authCredentials: {
+                            password: process.env.MONGO_AUTH_PASSWORD,
+                            username: process.env.MONGO_AUTH_USERNAME,
+                        },
+                    },
+                };
+                metadata = new MetadataWrapper(IMPL_NAME, opts, null, logger);
+                metadata.setup(next);
+            },
+            next => getBucketOwnerInfo(next),
+            next => createAndPopulateVersionedBucket(BucketVersioningKeyFormat.v0, next),
+            next => createAndPopulateVersionedBucket(BucketVersioningKeyFormat.v1, next),
+        ], err => {
+            assert.ifError(err);
+            done();
+        });
+    });
+
+    after(done => {
+        async.series([
+            next => emptyAndDeleteBucket(BucketVersioningKeyFormat.v0, next),
+            next => emptyAndDeleteBucket(BucketVersioningKeyFormat.v1, next),
+            next => metadata.close(next),
+        ], err => {
+            assert.ifError(err);
+            done();
+        });
+    });
+
+    ['v0', 'v1'].forEach(vFormat => {
+        it(`Should return metadata of last version ${vFormat}`, done => {
+            const params = {
+                Bucket: BUCKET_NAME[vFormat],
+                Key: 'first-key',
+            };
+            s3.getObject(params, (err, data) => {
+                assert.ifError(err);
+                assert.strictEqual(data.VersionId, versionIds[vFormat]['first-key'][2]);
+                return done();
+            });
+        });
+
+        it(`Should return metadata of specified version ${vFormat}`, done => {
+            const params = {
+                Bucket: BUCKET_NAME[vFormat],
+                Key: 'second-key',
+                VersionId: versionIds[vFormat]['second-key'][1],
+            };
+            s3.getObject(params, (err, data) => {
+                assert.ifError(err);
+                assert.strictEqual(data.VersionId, versionIds[vFormat]['second-key'][1]);
+                return done();
+            });
+        });
+
+        it(`Should only list last versions ${vFormat}`, done => {
+            const params = {
+                Bucket: BUCKET_NAME[vFormat],
+            };
+            s3.listObjectsV2(params, (err, data) => {
+                assert.ifError(err);
+                assert.strictEqual(data.Contents.length, 2);
+                const keys = data.Contents.map(object => object.Key);
+                assert(keys.includes('first-key'));
+                assert(keys.includes('second-key'));
+                return done();
+            });
+        });
+
+        it(`Should list all versions ${vFormat}`, done => {
+            const params = {
+                Bucket: BUCKET_NAME[vFormat],
+            };
+            s3.listObjectVersions(params, (err, data) => {
+                assert.ifError(err);
+                assert.strictEqual(data.Versions.length, 6);
+                const versions = data.Versions.map(object => object.VersionId);
+                assert(versionIds[vFormat]['first-key'].every(version => versions.includes(version)));
+                assert(versionIds[vFormat]['second-key'].every(version => versions.includes(version)));
+                const keyCount = {};
+                data.Versions.forEach(object => {
+                    keyCount[object.Key] = (keyCount[object.Key] | 0) + 1;
+                });
+                assert(keyCount['second-key'], 3);
+                assert(keyCount['second-key'], 3);
+                return done();
+            });
+        });
+
+        it(`Should delete specified version ${vFormat}`, done => {
+            let tmpVersionId;
+            async.series([
+                next => s3.putObject({ Bucket: BUCKET_NAME[vFormat], Key: 'first-key' }, (err, res) => {
+                    assert.ifError(err);
+                    tmpVersionId = res.VersionId;
+                    return next();
+                }),
+                next => s3.deleteObject({
+                    Bucket: BUCKET_NAME[vFormat],
+                    Key: 'first-key',
+                    VersionId: tmpVersionId,
+                }, next),
+                next => s3.getObject({
+                    Bucket: BUCKET_NAME[vFormat],
+                    Key: 'first-key',
+                    VersionId: tmpVersionId,
+                }, err => {
+                    assert.strictEqual(err.code, 'NoSuchVersion');
+                    return next();
+                }),
+            ], done);
+        });
+
+        it(`Should create a delete marker ${vFormat}`, done => {
+            let deleteMarkerVersionId;
+            async.series([
+                next => s3.deleteObject({ Bucket: BUCKET_NAME[vFormat], Key: 'first-key' }, (err, data) => {
+                    assert.ifError(err);
+                    assert(data.DeleteMarker);
+                    deleteMarkerVersionId = data.VersionId;
+                    return next();
+                }),
+                next => s3.getObject({ Bucket: BUCKET_NAME[vFormat], Key: 'first-key' }, err => {
+                    assert.strictEqual(err.code, 'NoSuchKey');
+                    return next();
+                }),
+                next => s3.listObjectVersions({ Bucket: BUCKET_NAME[vFormat] }, (err, data) => {
+                    assert.ifError(err);
+                    assert.strictEqual(data.DeleteMarkers.length, 1);
+                    assert.strictEqual(data.DeleteMarkers[0].Key, 'first-key');
+                    assert.strictEqual(data.DeleteMarkers[0].VersionId, deleteMarkerVersionId);
+                    return next();
+                }),
+                next => s3.deleteObject({
+                    Bucket: BUCKET_NAME[vFormat],
+                    Key: 'first-key',
+                    VersionId: deleteMarkerVersionId,
+                }, next),
+            ], done);
+        });
+    });
+});

--- a/tests/zenko_tests/node_tests/cloudserver/keyFormatVersion/tests/versioningSuspended.js
+++ b/tests/zenko_tests/node_tests/cloudserver/keyFormatVersion/tests/versioningSuspended.js
@@ -1,0 +1,293 @@
+const assert = require('assert');
+const async = require('async');
+const werelogs = require('werelogs');
+const { MetadataWrapper } = require('arsenal').storage.metadata;
+const { versioning } = require('arsenal');
+const { BucketInfo } = require('arsenal').models;
+const s3 = require('../../../s3SDK').scalityS3Client;
+
+const logger = new werelogs.Logger('keyFormatVersion', 'debug', 'debug');
+const { BucketVersioningKeyFormat } = versioning.VersioningConstants;
+
+const IMPL_NAME = 'mongodb';
+const BUCKET_NAME = {
+    v0: 'key-format-versioning-suspended-bucket-v0',
+    v1: 'key-format-versioning-suspended-bucket-v1',
+};
+const versionIds = {
+    v0: {
+        'first-key': [],
+        'second-key': [],
+    },
+    v1: {
+        'first-key': [],
+        'second-key': [],
+    },
+};
+const ownerInfo = {};
+
+function putObjectVersions(objName, vFormat, cb) {
+    async.timesSeries(3, (n, next) => {
+        s3.putObject({ Bucket: BUCKET_NAME[vFormat], Key: objName }, (err, res) => {
+            assert.ifError(err);
+            versionIds[vFormat][objName].push(res.VersionId);
+            return next();
+        });
+    }, cb);
+}
+
+function deleteObjectVersions(objName, vFormat, cb) {
+    async.timesSeries(3, (n, next) => {
+        s3.deleteObject({
+            Bucket: BUCKET_NAME[vFormat],
+            Key: objName,
+            VersionId: versionIds[vFormat][objName][n],
+        }, next);
+    }, cb);
+}
+
+describe('Cloudserver : keyFormatVersion : versioning suspended bucket', () => {
+    let metadata;
+
+    function getBucketOwnerInfo(cb) {
+        async.series([
+            next => s3.createBucket({ Bucket: 'tmp-bucket' }, next),
+            next => metadata.getBucket('tmp-bucket', logger, (err, res) => {
+                if (err) {
+                    return next(err);
+                }
+                ownerInfo._owner = res._owner;
+                ownerInfo._ownerDisplayName = res._ownerDisplayName;
+                return next();
+            }),
+            next => s3.deleteBucket({ Bucket: 'tmp-bucket' }, next),
+        ], cb);
+    }
+
+    function createBucket(vFormat, cb) {
+        const bucketMD = BucketInfo.fromObj({
+            _name: BUCKET_NAME[vFormat],
+            _owner: ownerInfo._owner,
+            _ownerDisplayName: ownerInfo._ownerDisplayName,
+            _creationDate: new Date().toJSON(),
+            _acl: {
+                Canned: 'private',
+                FULL_CONTROL: [],
+                WRITE: [],
+                WRITE_ACP: [],
+                READ: [],
+                READ_ACP: [],
+            },
+            _mdBucketModelVersion: 10,
+            _transient: false,
+            _deleted: false,
+            _serverSideEncryption: null,
+            _versioningConfiguration: null,
+            _locationConstraint: 'us-east-1',
+            _readLocationConstraint: null,
+            _cors: null,
+            _replicationConfiguration: null,
+            _lifecycleConfiguration: null,
+            _uid: '',
+            _isNFS: null,
+            ingestion: null,
+        });
+        async.series([
+            next => {
+                metadata.client.defaultBucketKeyFormat = vFormat;
+                return next();
+            },
+            next => metadata.createBucket(BUCKET_NAME[vFormat], bucketMD, logger, next),
+        ], cb);
+    }
+
+    function createAndPopulateVersionedBucket(vFormat, cb) {
+        async.series([
+            next => createBucket(vFormat, next),
+            next => {
+                const params = {
+                    Bucket: BUCKET_NAME[vFormat],
+                    VersioningConfiguration: {
+                        MFADelete: 'Disabled',
+                        Status: 'Enabled',
+                    },
+                };
+                return s3.putBucketVersioning(params, next);
+            },
+            next => putObjectVersions('first-key', vFormat, next),
+            next => putObjectVersions('second-key', vFormat, next),
+        ], cb);
+    }
+
+    function suspendBucketVersioning(vFormat, cb) {
+        const params = {
+            Bucket: BUCKET_NAME[vFormat],
+            VersioningConfiguration: {
+                MFADelete: 'Disabled',
+                Status: 'Suspended',
+            },
+        };
+        return s3.putBucketVersioning(params, cb);
+    }
+
+    function emptyAndDeleteBucket(vFormat, cb) {
+        async.series([
+            next => deleteObjectVersions('first-key', vFormat, next),
+            next => deleteObjectVersions('second-key', vFormat, next),
+            next => s3.deleteBucket({ Bucket: BUCKET_NAME[vFormat] }, next),
+        ], cb);
+    }
+
+    before(done => {
+        async.series([
+            next => {
+                const opts = {
+                    mongodb: {
+                        replicaSetHosts: process.env.MONGO_REPLICA_SET_HOSTS,
+                        // TODO: replace with env var
+                        replicaSet: 'rs0',
+                        writeConcern: process.env.MONGO_WRITE_CONCERN,
+                        readPreference: process.env.MONGO_READ_PREFERENCE,
+                        shardCollections: process.env.MONGO_SHARD_COLLECTION === 'true',
+                        database: process.env.MONGO_DATABASE,
+                        authCredentials: {
+                            password: process.env.MONGO_AUTH_PASSWORD,
+                            username: process.env.MONGO_AUTH_USERNAME,
+                        },
+                    },
+                };
+                metadata = new MetadataWrapper(IMPL_NAME, opts, null, logger);
+                metadata.setup(next);
+            },
+            next => getBucketOwnerInfo(next),
+            next => createAndPopulateVersionedBucket(BucketVersioningKeyFormat.v0, next),
+            next => createAndPopulateVersionedBucket(BucketVersioningKeyFormat.v1, next),
+            next => suspendBucketVersioning(BucketVersioningKeyFormat.v0, next),
+            next => suspendBucketVersioning(BucketVersioningKeyFormat.v1, next),
+        ], err => {
+            assert.ifError(err);
+            done();
+        });
+    });
+
+    after(done => {
+        async.series([
+            next => emptyAndDeleteBucket(BucketVersioningKeyFormat.v0, next),
+            next => emptyAndDeleteBucket(BucketVersioningKeyFormat.v1, next),
+            next => metadata.close(next),
+        ], err => {
+            assert.ifError(err);
+            done();
+        });
+    });
+
+    ['v0', 'v1'].forEach(vFormat => {
+        it(`Should create new null version ${vFormat}`, done => {
+            async.series([
+                next => s3.putObject({ Bucket: BUCKET_NAME[vFormat], Key: 'first-key' }, next),
+                next => s3.getObject(
+                    { Bucket: BUCKET_NAME[vFormat], Key: 'first-key', VersionId: 'null' },
+                    (err, data) => {
+                        assert.ifError(err);
+                        assert.strictEqual(data.VersionId, 'null');
+                        return next();
+                    },
+                ),
+                next => s3.deleteObject({ Bucket: BUCKET_NAME[vFormat], Key: 'first-key', VersionId: 'null' }, next),
+            ], done);
+        });
+
+        it(`Should return metadata of last version ${vFormat}`, done => {
+            const params = {
+                Bucket: BUCKET_NAME[vFormat],
+                Key: 'first-key',
+            };
+            s3.getObject(params, (err, data) => {
+                assert.ifError(err);
+                assert.strictEqual(data.VersionId, versionIds[vFormat]['first-key'][2]);
+                return done();
+            });
+        });
+
+        it(`Should return metadata of specified version ${vFormat}`, done => {
+            const params = {
+                Bucket: BUCKET_NAME[vFormat],
+                Key: 'second-key',
+                VersionId: versionIds[vFormat]['second-key'][1],
+            };
+            s3.getObject(params, (err, data) => {
+                assert.ifError(err);
+                assert.strictEqual(data.VersionId, versionIds[vFormat]['second-key'][1]);
+                return done();
+            });
+        });
+
+        it(`Should only list last versions ${vFormat}`, done => {
+            const params = {
+                Bucket: BUCKET_NAME[vFormat],
+            };
+            s3.listObjectsV2(params, (err, data) => {
+                assert.ifError(err);
+                assert.strictEqual(data.Contents.length, 2);
+                const keys = data.Contents.map(object => object.Key);
+                assert(keys.includes('first-key'));
+                assert(keys.includes('second-key'));
+                return done();
+            });
+        });
+
+        it(`Should list all versions ${vFormat}`, done => {
+            const params = {
+                Bucket: BUCKET_NAME[vFormat],
+            };
+            s3.listObjectVersions(params, (err, data) => {
+                assert.ifError(err);
+                assert.strictEqual(data.Versions.length, 6);
+                const versions = data.Versions.map(object => object.VersionId);
+                assert(versionIds[vFormat]['first-key'].every(version => versions.includes(version)));
+                assert(versionIds[vFormat]['second-key'].every(version => versions.includes(version)));
+                return done();
+            });
+        });
+
+        it(`Should delete specified version ${vFormat}`, done => {
+            let tmpVersionId;
+            async.series([
+                next => s3.putObject({ Bucket: BUCKET_NAME[vFormat], Key: 'first-key' }, (err, res) => {
+                    assert.ifError(err);
+                    tmpVersionId = res.VersionId;
+                    return next();
+                }),
+                next => s3.deleteObject({
+                    Bucket: BUCKET_NAME[vFormat],
+                    Key: 'first-key',
+                    VersionId: tmpVersionId,
+                }, next),
+                next => s3.getObject({
+                    Bucket: BUCKET_NAME[vFormat],
+                    Key: 'first-key',
+                    VersionId: tmpVersionId,
+                }, err => {
+                    assert.strictEqual(err.code, 'NoSuchKey');
+                    return next();
+                }),
+            ], done);
+        });
+
+        it(`Should create a delete marker with null versionId ${vFormat}`, done => {
+            async.series([
+                next => s3.deleteObject({ Bucket: BUCKET_NAME[vFormat], Key: 'first-key' }, (err, data) => {
+                    assert.ifError(err);
+                    assert(data.DeleteMarker);
+                    assert.strictEqual(data.VersionId, 'null');
+                    return next();
+                }),
+                next => s3.getObject({ Bucket: BUCKET_NAME[vFormat], Key: 'first-key' }, err => {
+                    assert.strictEqual(err.code, 'NoSuchKey');
+                    return next();
+                }),
+                next => s3.deleteObject({ Bucket: BUCKET_NAME[vFormat], Key: 'first-key', VersionId: 'null' }, next),
+            ], done);
+        });
+    });
+});

--- a/tests/zenko_tests/node_tests/package-lock.json
+++ b/tests/zenko_tests/node_tests/package-lock.json
@@ -670,8 +670,8 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
     "arsenal": {
-      "version": "github:scality/Arsenal#3c9ab1bb99c2b3134882e7d8ad12573a073188f4",
-      "from": "github:scality/Arsenal#8.1.27",
+      "version": "github:scality/Arsenal#d18f4d10bdfec6c3d211036490c9de5f5e97219c",
+      "from": "github:scality/Arsenal#8.1.38",
       "requires": {
         "@hapi/joi": "^15.1.0",
         "JSONStream": "^1.0.0",
@@ -686,11 +686,12 @@
         "bson": "4.0.0",
         "debug": "~4.1.0",
         "diskusage": "^1.1.1",
+        "eslint-plugin-import": "^2.25.4",
         "fcntl": "github:scality/node-fcntl#0.2.0",
         "hdclient": "github:scality/hdclient#1.1.0",
         "https-proxy-agent": "^2.2.0",
         "ioctl": "^2.0.2",
-        "ioredis": "4.9.5",
+        "ioredis": "^4.28.5",
         "ipaddr.js": "1.9.1",
         "level": "~5.0.1",
         "level-sublevel": "~6.6.5",
@@ -804,6 +805,39 @@
             "ms": "^2.1.1"
           }
         },
+        "ioredis": {
+          "version": "4.28.5",
+          "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.5.tgz",
+          "integrity": "sha512-3GYo0GJtLqgNXj4YhrisLaNNvWSNwSS2wS4OELGfGxH8I69+XfNdnmV1AyN+ZqMh0i7eX+SWjrwFKDBDgfBC1A==",
+          "requires": {
+            "cluster-key-slot": "^1.1.0",
+            "debug": "^4.3.1",
+            "denque": "^1.1.0",
+            "lodash.defaults": "^4.2.0",
+            "lodash.flatten": "^4.4.0",
+            "lodash.isarguments": "^3.1.0",
+            "p-map": "^2.1.0",
+            "redis-commands": "1.7.0",
+            "redis-errors": "^1.2.0",
+            "redis-parser": "^3.0.0",
+            "standard-as-callback": "^2.1.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.3.4",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+              "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+              "requires": {
+                "ms": "2.1.2"
+              }
+            },
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            }
+          }
+        },
         "ms": {
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -813,6 +847,11 @@
           "version": "0.7.6",
           "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
           "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
+        },
+        "p-map": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+          "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
         },
         "process-nextick-args": {
           "version": "1.0.7",
@@ -832,10 +871,27 @@
             "util-deprecate": "~1.0.1"
           }
         },
+        "redis-commands": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+          "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
+        },
+        "safe-json-stringify": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz",
+          "integrity": "sha1-PLZxdmCghtB8tb2bemh1vPZ70F4="
+        },
         "string_decoder": {
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "werelogs": {
+          "version": "github:scality/werelogs#e8f828725642c54c511cdbe580b18f43d3589313",
+          "from": "github:scality/werelogs#8.1.0",
+          "requires": {
+            "safe-json-stringify": "1.0.3"
+          }
         }
       }
     },
@@ -3964,6 +4020,11 @@
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
     },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+    },
     "lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
@@ -5722,6 +5783,18 @@
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
           "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
+        },
+        "safe-json-stringify": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz",
+          "integrity": "sha1-PLZxdmCghtB8tb2bemh1vPZ70F4="
+        },
+        "werelogs": {
+          "version": "github:scality/werelogs#e8f828725642c54c511cdbe580b18f43d3589313",
+          "from": "github:scality/werelogs#8.1.0",
+          "requires": {
+            "safe-json-stringify": "1.0.3"
+          }
         }
       }
     },
@@ -6476,6 +6549,20 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         },
+        "werelogs": {
+          "version": "github:scality/werelogs#e8f828725642c54c511cdbe580b18f43d3589313",
+          "from": "github:scality/werelogs#8.1.0",
+          "requires": {
+            "safe-json-stringify": "1.0.3"
+          },
+          "dependencies": {
+            "safe-json-stringify": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz",
+              "integrity": "sha1-PLZxdmCghtB8tb2bemh1vPZ70F4="
+            }
+          }
+        },
         "xml2js": {
           "version": "0.4.19",
           "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
@@ -6517,17 +6604,10 @@
       "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
     },
     "werelogs": {
-      "version": "github:scality/werelogs#e8f828725642c54c511cdbe580b18f43d3589313",
-      "from": "github:scality/werelogs#8.1.0",
+      "version": "github:scality/werelogs#5664f19d0308b9d9abfb8c45c815093a3ca56b90",
+      "from": "github:scality/werelogs",
       "requires": {
-        "safe-json-stringify": "1.0.3"
-      },
-      "dependencies": {
-        "safe-json-stringify": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz",
-          "integrity": "sha1-PLZxdmCghtB8tb2bemh1vPZ70F4="
-        }
+        "safe-json-stringify": "^1.2.0"
       }
     },
     "whatwg-url": {

--- a/tests/zenko_tests/node_tests/package.json
+++ b/tests/zenko_tests/node_tests/package.json
@@ -12,7 +12,7 @@
   ],
   "dependencies": {
     "@google-cloud/storage": "^1.6.0",
-    "arsenal": "scality/Arsenal#8.1.27",
+    "arsenal": "scality/Arsenal#8.1.38",
     "async": "2.1.2",
     "aws-sdk": "^2.905.0",
     "aws4": "^1.11.0",
@@ -31,7 +31,8 @@
     "npm-run-all": "~4.0.2",
     "request": "^2.87.0",
     "uuid": "^3.0.1",
-    "vaultclient": "scality/vaultclient#b9452a526daf5627ecae9528c941375a208e79f3"
+    "vaultclient": "scality/vaultclient#b9452a526daf5627ecae9528c941375a208e79f3",
+    "werelogs": "github:scality/werelogs"
   },
   "scripts": {
     "test_ui": "cypress run --config baseUrl=${UI_ENDPOINT} --project ./ui",
@@ -53,6 +54,7 @@
     "test_smoke": "mocha --tags ${MOCHA_TAGS} --exit -t 10000 --reporter mocha-multi-reporters --reporter-options configFile=config.json --recursive smoke_tests",
     "test_iam_policies": "mocha --tags ${MOCHA_TAGS} --exit -t 10000 --reporter mocha-multi-reporters --reporter-options configFile=config.json --recursive iam_policies",
     "test_all_extensions": "npm-run-all test_aws_crr test_expiration",
+    "test_object_api": "mocha --tags ${MOCHA_TAGS} --exit -t 10000 --reporter mocha-multi-reporters --reporter-options configFile=config.json --recursive cloudserver/keyFormatVersion/tests",
     "lint": "eslint $(find . -name '*.js' -not -path '*/node_modules/*')"
   },
   "author": ""


### PR DESCRIPTION
- Bumped Cloudserver & Backbeat to include v1 metadata version format
- Added E2E Cloudserver tests to ensure basic bucket and object operations function for different states of a bucket (non versioned, versioned, versioning suspended) in both version formats.