### PR TITLE
ZENKO-4006: bump pensieve-api version

### DIFF
--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -50,7 +50,7 @@ mongodb:
 pensieve-api:
   sourceRegistry: registry.scality.com/pensieve-api
   image: pensieve-api
-  tag: 1.1.0
+  tag: 1.1.1
   envsubst: PENSIEVE_API_TAG
 redis:
   image: redis


### PR DESCRIPTION
Fixes ZENKO-4006: Endpoints should not accept ip addresses as hostname