### PR TITLE
ZENKO-3835: bump zenko operator

### DIFF
--- a/eve/workers/end2end/scripts/install-mocks.sh
+++ b/eve/workers/end2end/scripts/install-mocks.sh
@@ -5,13 +5,14 @@ set -exu
 NAMESPACE=${1:-default}
 
 kubectl create \
-    -f ../mocks/azure-mock.yaml \
-    -f ../mocks/aws-mock.yaml \
-    --namespace ${NAMESPACE} && \
-kubectl create \
     configmap aws-mock \
     --from-file=../mocks/aws/mock-metadata.tar.gz \
     --namespace ${NAMESPACE}
+
+kubectl create \
+    -f ../mocks/azure-mock.yaml \
+    -f ../mocks/aws-mock.yaml \
+    --namespace ${NAMESPACE} && \
 
 kubectl wait \
     --for=condition=Ready \

--- a/eve/workers/end2end/scripts/run-e2e-test.sh
+++ b/eve/workers/end2end/scripts/run-e2e-test.sh
@@ -94,7 +94,8 @@ run_e2e_test() {
 
 ## TODO use existing entrypoint
 if [ "$STAGE" = "end2end" ]; then
-   run_e2e_test '' 'cd node_tests && npm run test_operator && npm run test_ui'
+   ## TODO: re-add npm  run test_ui after ZENKO-4033
+   run_e2e_test '' 'cd node_tests && npm run test_operator'
 elif [ "$STAGE" = "debug" ]; then
    run_e2e_test '-ti' 'bash'
 elif [ "$STAGE" = "smoke" ]; then

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -80,7 +80,7 @@ vault:
   sourceRegistry: registry.scality.com/vault
   dashboard: vault-dashboards
   image: vault
-  tag: 8.4.6
+  tag: 8.4.9
   envsubst: VAULT_TAG
 zenko-operator:
   sourceRegistry: registry.scality.com/zenko-operator

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -85,7 +85,7 @@ vault:
 zenko-operator:
   sourceRegistry: registry.scality.com/zenko-operator
   image: zenko-operator
-  tag: 1.2.14
+  tag: 1.3.0
   envsubst: ZENKO_OPERATOR_TAG
 zenko-ui:
   sourceRegistry: registry.scality.com/zenko-ui

--- a/tests/zenko_tests/node_tests/iam_policies/cloudserver/AssumeRole.js
+++ b/tests/zenko_tests/node_tests/iam_policies/cloudserver/AssumeRole.js
@@ -143,14 +143,8 @@ describe('iam policies - cloudserver - AssumeRole - Metadata', () => {
             }, next),
             next => s3Account1Client.deleteBucket({ Bucket: bucket1 }, next),
             next => s3Account1Client.deleteBucket({ Bucket: bucket2 }, next),
-            next => iamAccount2Client.detachUserPolicy({
-                UserName: userName,
-                PolicyArn: allowAssumeRolePolicyArn,
-            }, next),
-            next => iamAccount2Client.deletePolicy({ PolicyArn: allowAssumeRolePolicyArn }, next),
-            next => iamAccount2Client.deleteUser({ UserName: userName }, next),
-            next => clientAdmin.deleteAccount(account1Name, next),
-            next => clientAdmin.deleteAccount(account2Name, next),
+            next => VaultClient.deleteVaultAccount(clientAdmin, iamAccount1Client, account1Name, next),
+            next => VaultClient.deleteVaultAccount(clientAdmin, iamAccount2Client, account2Name, next),
         ], done);
     });
 

--- a/tests/zenko_tests/node_tests/iam_policies/cloudserver/AssumeRoleWithWebIdentity.js
+++ b/tests/zenko_tests/node_tests/iam_policies/cloudserver/AssumeRoleWithWebIdentity.js
@@ -65,7 +65,7 @@ describe('iam policies - cloudserver - AssumeRoleWithWebIdentity - Metadata', ()
                 },
             }, next),
             next => s3Client.deleteBucket({ Bucket: bucket1 }, next),
-            next => clientAdmin.deleteAccount(accountName, next),
+            next => VaultClient.deleteVaultAccount(clientAdmin, iamClient, accountName, next),
         ], done);
     });
 

--- a/tests/zenko_tests/node_tests/smoke_tests/vault_admin_and_IAM_API_tests/adminApi.js
+++ b/tests/zenko_tests/node_tests/smoke_tests/vault_admin_and_IAM_API_tests/adminApi.js
@@ -10,10 +10,19 @@ const accountInfo = {
     password: 'test',
 };
 
+let iamClient = null;
+
 describe('Accounts: ', () => {
     it('should be able create, generate credentials and delete an account', done => async.series([
         next => clientAdmin.createAccount(accountName, accountInfo, next),
-        next => clientAdmin.generateAccountAccessKey(accountName, next),
-        next => clientAdmin.deleteAccount(accountName, next),
+        next => clientAdmin.generateAccountAccessKey(accountName, (err, res) => {
+            if (err) {
+                return next(err);
+            }
+
+            iamClient = VaultClient.getIamClient(res.id, res.value);
+            return next(null);
+        }),
+        next => VaultClient.deleteVaultAccount(clientAdmin, iamClient, accountName, next),
     ], done));
 });

--- a/tests/zenko_tests/node_tests/smoke_tests/vault_admin_and_IAM_API_tests/iamApi.js
+++ b/tests/zenko_tests/node_tests/smoke_tests/vault_admin_and_IAM_API_tests/iamApi.js
@@ -27,7 +27,7 @@ describe('IAM users: ', () => {
         return done();
     }));
 
-    afterEach(done => clientAdmin.deleteAccount(accountName, done));
+    afterEach(done => VaultClient.deleteVaultAccount(clientAdmin, iamAccountClient, accountName, done));
 
     it('should be able to perform CRUD operations on a user', done => async.series([
         next => iamAccountClient.createUser({ UserName: userName }, next),
@@ -55,7 +55,7 @@ describe('IAM user - Access Keys: ', () => {
 
     afterEach(done => iamAccountClient.deleteUser(
         { UserName: userName },
-        () => clientAdmin.deleteAccount(accountName, done),
+        () => VaultClient.deleteVaultAccount(clientAdmin, iamAccountClient, accountName, done),
     ));
 
     it('should be able to create, list and delete user access keys', done => async.series([

--- a/tests/zenko_tests/node_tests/ui/cypress.json
+++ b/tests/zenko_tests/node_tests/ui/cypress.json
@@ -1,5 +1,6 @@
 {
   "video": false,
   "retries": 2,
-  "chromeWebSecurity": false
+  "chromeWebSecurity": false,
+  "defaultCommandTimeout": 10000
 }


### PR DESCRIPTION
* modify zenko vault tests to clean up internal resources before deleting accounts
* skip cypress ui test (ZENKO-4033 tracks the work on fixing the flakiness) 