### PR TITLE
ZENKO-4069: bump pensieve api to 1.2.3

### DIFF
--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -50,7 +50,7 @@ mongodb:
 pensieve-api:
   sourceRegistry: registry.scality.com/pensieve-api
   image: pensieve-api
-  tag: 1.2.2
+  tag: 1.2.3
   envsubst: PENSIEVE_API_TAG
 redis:
   image: redis


### PR DESCRIPTION
* bump pensieve-api  version to 1.2.3