### PR TITLE
ZENKO-4099: set mongodb default write concern to majority

### DIFF
--- a/eve/workers/end2end/kustomization.yaml
+++ b/eve/workers/end2end/kustomization.yaml
@@ -37,3 +37,13 @@ patchesStrategicMerge:
            requests:
              storage: "8Gi"
          storageClassName: standard
+images:
+- name: metalk8s-registry-from-config.invalid/zenko-base-2.3.11/bitnami-shell
+  newName: docker.io/bitnami/bitnami-shell
+  newTag: 10-debian-10-r293
+- name: metalk8s-registry-from-config.invalid/zenko-base-2.3.11/mongodb-exporter
+  newName: docker.io/bitnami/mongodb-exporter
+  newTag: 0.11.2-debian-10-r382
+- name: metalk8s-registry-from-config.invalid/zenko-base-2.3.11/mongodb-sharded
+  newName: docker.io/bitnami/mongodb-sharded
+  newTag: 4.0.27-debian-9-r111

--- a/eve/workers/end2end/scripts/configs/mongodb_init_scripts/set-default-write-concern-majority.sh
+++ b/eve/workers/end2end/scripts/configs/mongodb_init_scripts/set-default-write-concern-majority.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set_default_majority() {
+    mongo --host "mongodb://127.0.0.1/?replicaSet=${MONGODB_REPLICA_SET_NAME}"  -u 'root' -p "$MONGODB_ROOT_PASSWORD" <<EOF
+conf = rs.config()
+
+defaultWriteConcern = conf.settings.getLastErrorDefaults
+
+if (!defaultWriteConcern || defaultWriteConcern.w !== 'majority') {
+    defaultWriteConcern.w = 'majority'
+    rs.reconfig(conf)
+}
+EOF
+}
+
+set_default_majority

--- a/solution-base/mongodb/charts/mongodb-sharded/files/docker-entrypoint-initdb.d/set-default-write-concern-majority.sh
+++ b/solution-base/mongodb/charts/mongodb-sharded/files/docker-entrypoint-initdb.d/set-default-write-concern-majority.sh
@@ -1,0 +1,1 @@
+../../../../../../eve/workers/end2end/scripts/configs/mongodb_init_scripts/set-default-write-concern-majority.sh

--- a/solution-base/mongodb/charts/mongodb/files/docker-entrypoint-initdb.d/set-default-write-concern-majority.sh
+++ b/solution-base/mongodb/charts/mongodb/files/docker-entrypoint-initdb.d/set-default-write-concern-majority.sh
@@ -1,0 +1,1 @@
+../../../../../../eve/workers/end2end/scripts/configs/mongodb_init_scripts/set-default-write-concern-majority.sh


### PR DESCRIPTION
set mongodb deployment default write concern to majority. 