### PR TITLE
INTEGRATION [PR#1577 > development/2.3] ZENKO-4132: Remove mention of port 443 and 4443

### DIFF
--- a/docs/docsource/operation/location_management/add_a_storage_location.rst
+++ b/docs/docsource/operation/location_management/add_a_storage_location.rst
@@ -164,9 +164,9 @@ to name endpoints. Services for which |product| requests endpoint names may have
 additional naming requirements. For these requirements, review your cloud
 storage service provider's documentation.
 
-For Ceph RADOS Gateway endpoints, you can nominate a secure port, such as 443 or
-4443. If you do not, the default is port 80. Whichever port you assign, make
-sure it is accessible to |product| (firewall open, etc.).
+For Ceph RADOS Gateway endpoints, you can nominate a secure port. 
+If you do not nominate a secure port, the default is port 80. 
+Whichever port you assign, make sure it is accessible to |product| (firewall open, etc.).
 
 Bucket Match
 ~~~~~~~~~~~~


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1577.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/2.3/documentation/ZENKO-4132-change-port-for-storage-location`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/2.3/documentation/ZENKO-4132-change-port-for-storage-location
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/2.3/documentation/ZENKO-4132-change-port-for-storage-location
```

Please always comment pull request #1577 instead of this one.