### PR TITLE
INTEGRATION [PR#1580 > development/2.4] Bump async from 2.1.2 to 2.6.4 in /tests/zenko_tests/node_tests

### DIFF
--- a/tests/zenko_tests/node_tests/package-lock.json
+++ b/tests/zenko_tests/node_tests/package-lock.json
@@ -719,14 +719,6 @@
             "uri-js": "^4.2.2"
           }
         },
-        "async": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-          "requires": {
-            "lodash": "^4.17.14"
-          }
-        },
         "aws-sdk": {
           "version": "2.80.0",
           "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.80.0.tgz",
@@ -914,11 +906,11 @@
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
     },
     "async": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.1.2.tgz",
-      "integrity": "sha1-YSpKtF70KnDN6Aa62G7m2wR+g4U=",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "requires": {
-        "lodash": "^4.14.0"
+        "lodash": "^4.17.14"
       }
     },
     "async-limiter": {

--- a/tests/zenko_tests/node_tests/package.json
+++ b/tests/zenko_tests/node_tests/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@google-cloud/storage": "^1.6.0",
     "arsenal": "scality/Arsenal#8.1.38",
-    "async": "2.1.2",
+    "async": "2.6.4",
     "aws-sdk": "^2.905.0",
     "aws4": "^1.11.0",
     "azure-storage": "^2.10.0",


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1580.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/2.4/dependabot/npm_and_yarn/tests/zenko_tests/node_tests/async-2.6.4`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/2.4/dependabot/npm_and_yarn/tests/zenko_tests/node_tests/async-2.6.4
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/2.4/dependabot/npm_and_yarn/tests/zenko_tests/node_tests/async-2.6.4
```

Please always comment pull request #1580 instead of this one.