### PR TITLE
INTEGRATION [PR#1589 > development/2.4] ZENKO-4162: Bump Vault to 8.4.15

### DIFF
--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -81,7 +81,7 @@ vault:
   sourceRegistry: registry.scality.com/vault
   dashboard: vault-dashboards
   image: vault
-  tag: 8.4.14
+  tag: 8.4.15
   envsubst: VAULT_TAG
 zenko-operator:
   sourceRegistry: registry.scality.com/zenko-operator


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1589.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/2.4/improvement/ZENKO-4162-bump-vault-version`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/2.4/improvement/ZENKO-4162-bump-vault-version
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/2.4/improvement/ZENKO-4162-bump-vault-version
```

Please always comment pull request #1589 instead of this one.