### PR TITLE
INTEGRATION [PR#1592 > development/2.4] Bump mongodb-exporter to 0.11.2

### DIFF
--- a/solution-base/deps.yaml
+++ b/solution-base/deps.yaml
@@ -6,7 +6,7 @@ mongodb:
   tag: 4.0.14-debian-9-r24
 mongodb-exporter:
   image: bitnami/mongodb-exporter
-  tag: 0.10.0-debian-9-r104
+  tag: 0.11.2-debian-10-r410
 mongodb-minideb:
   sourceRegistry: registry.scality.com
   image: zenko-dev/minideb


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1592.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/2.4/bugfix/ZENKO-4166`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/2.4/bugfix/ZENKO-4166
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/2.4/bugfix/ZENKO-4166
```

Please always comment pull request #1592 instead of this one.