### PR TITLE
improvement: ZENKO-4224-doc-how-to-iam-policy-tests

### DIFF
--- a/tests/zenko_tests/node_tests/utils/request.js
+++ b/tests/zenko_tests/node_tests/utils/request.js
@@ -2,7 +2,7 @@ const http = require('http');
 const aws4 = require('aws4');
 
 const DEFAULT_HOST = process.env.CLOUDSERVER_HOST;
-const DEFAULT_PORT = '80';
+const DEFAULT_PORT = process.env.CLOUDSERVER_PORT || '80';
 
 const accessKeyId = process.env.ZENKO_ACCESS_KEY;
 const secretAccessKey = process.env.ZENKO_SECRET_KEY;


### PR DESCRIPTION
- explain iam policy e2e tests in Zenko
- how to add iam permission tests for future contributors 
- add how to run zenko e2e tests with local cloudserver and vault, thanks to @WillToozsScality and @williamlardier 