### PR TITLE
ZKNKO-4297: bump zenko ui to 1.4.16

### DIFF
--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -96,7 +96,7 @@ zenko-operator:
 zenko-ui:
   sourceRegistry: registry.scality.com/zenko-ui
   image: zenko-ui
-  tag: 1.4.15
+  tag: 1.4.16
   envsubst: ZENKO_UI_TAG
 zookeeper:
   sourceRegistry: pravega


### PR DESCRIPTION
<!--
Thank you for contributing to Zenko!

Please enter applicable information below.
-->

**What does this PR do, and why do we need it?**
bump zenko ui to 1.4.16 
which fixes the metasearch and small regression of account and role modal selection.

**Which issue does this PR fix?**

fixes #<ISSUE>

**Special notes for your reviewers**:
