### PR TITLE
INTEGRATION [PR#1691 > development/2.4] ZKNKO-4297: bump zenko ui to 1.4.16

### DIFF
--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -96,7 +96,7 @@ zenko-operator:
 zenko-ui:
   sourceRegistry: registry.scality.com/zenko-ui
   image: zenko-ui
-  tag: 1.4.15
+  tag: 1.4.16
   envsubst: ZENKO_UI_TAG
 zookeeper:
   sourceRegistry: pravega


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1691.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/2.4/feature/ZENKO-4297-bump-zenko-ui-version`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/2.4/feature/ZENKO-4297-bump-zenko-ui-version
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/2.4/feature/ZENKO-4297-bump-zenko-ui-version
```

Please always comment pull request #1691 instead of this one.