### PR TITLE
ZENKO-4348 Integration in Zenko is broken since 8.4.20

### DIFF
--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -6,7 +6,7 @@ backbeat:
   dashboard: backbeat-dashboards
   image: backbeat
   policy: backbeat-policies
-  tag: 8.4.19
+  tag: 8.4.22
   envsubst: BACKBEAT_TAG
 blobserver:
   sourceRegistry: registry.scality.com/sf-eng

--- a/tests/zenko_tests/node_tests/backbeat/tests/lifecycle/transition.js
+++ b/tests/zenko_tests/node_tests/backbeat/tests/lifecycle/transition.js
@@ -88,7 +88,8 @@ const testsToRun = [{
 }];
 
 testsToRun.forEach(test => {
-    describe(`Lifecycle transition from ${test.from} to ${test.to}`, () => {
+    // eslint-disable-next-line prefer-arrow-callback
+    describe(`Lifecycle transition from ${test.from} to ${test.to}`, function () {
         const srcBucket = `transition-bucket-${uuid()}`;
         const keyPrefix = uuid();
         const cloudServer = new LifecycleUtility(scalityS3Client)
@@ -98,6 +99,13 @@ testsToRun.forEach(test => {
         const fromLoc = locationParams[test.from];
         const toLoc = locationParams[test.to];
         const prefix = `${keyPrefix}-from-${test.from}-to-${test.to}-`;
+
+        // GC comsumer might take a long time to consume its entries.
+        // If it is the case, timeout after 5 minutes and retry.
+        if (toLoc.isCold) {
+            this.retries(3);
+            this.timeout(360000);
+        }
 
         before(() => {
             cloudServer.setSourceLocation(fromLoc.name);


### PR DESCRIPTION
The following Backbeat commit: [7e11b95d5c7d0701827c63d83d23753dfd5d6119](https://github.com/scality/backbeat/commit/7e11b95d5c7d0701827c63d83d23753dfd5d6119) is introducing an asynchronous call from lifecycle processor to GC through Kafka.

GC entries take a few minutes to get consumed by the GC consumer introducing some flakiness from the archive tests.

Adding a retry seems to help reducing the flakiness.