### PR TITLE
Bump kafka lag exporter to 0.7.1

### DIFF
--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -44,9 +44,9 @@ kafka-cruise-control:
   tag: 2.5.86
   envsubst: KAFKA_CRUISECONTROL_TAG
 kafka-lag-exporter:
-  sourceRegistry: lightbend
+  sourceRegistry: seglo
   image: kafka-lag-exporter
-  tag: 0.6.8
+  tag: 0.7.1
   envsubst: KAFKA_LAGEXPORTER_TAG
 mongodb:
   sourceRegistry: kubedb


### PR DESCRIPTION
Despite the name change, this is actually still the same image: as the development was moved a company (lightblend) to the auther (seglo) : see https://github.com/seglo/kafka-lag-exporter/issues/316

Issue: ZENKO-4353
