### PR TITLE
ZENKO-4374 update bitnami/mongodb-exporter

### DIFF
--- a/.github/scripts/end2end/configs/mongodb_options.yaml
+++ b/.github/scripts/end2end/configs/mongodb_options.yaml
@@ -437,7 +437,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mongodb-exporter
-    tag: 0.10.0-debian-9-r104
+    tag: 0.34.0-debian-11-r24
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/.github/scripts/end2end/kustomization.yaml
+++ b/.github/scripts/end2end/kustomization.yaml
@@ -43,7 +43,7 @@ images:
   newTag: 10-debian-10-r293
 - name: metalk8s-registry-from-config.invalid/zenko-base-2.3.11/mongodb-exporter
   newName: docker.io/bitnami/mongodb-exporter
-  newTag: 0.11.2-debian-10-r382
+  newTag: 0.34.0-debian-11-r24
 - name: metalk8s-registry-from-config.invalid/zenko-base-2.3.11/mongodb-sharded
   newName: docker.io/bitnami/mongodb-sharded
   newTag: 4.0.27-debian-9-r111
@@ -52,7 +52,7 @@ images:
   newTag: 10-debian-10-r293
 - name: metalk8s-registry-from-config.invalid/zenko-base-2.3.18/mongodb-exporter
   newName: docker.io/bitnami/mongodb-exporter
-  newTag: 0.11.2-debian-10-r382
+  newTag: 0.34.0-debian-11-r24
 - name: metalk8s-registry-from-config.invalid/zenko-base-2.3.18/mongodb-sharded
   newName: docker.io/bitnami/mongodb-sharded
   newTag: 4.0.27-debian-9-r111

--- a/solution-base/deps.yaml
+++ b/solution-base/deps.yaml
@@ -6,7 +6,7 @@ mongodb:
   tag: 4.0.14-debian-9-r24
 mongodb-exporter:
   image: bitnami/mongodb-exporter
-  tag: 0.11.2-debian-10-r410
+  tag: 0.34.0-debian-11-r24
 mongodb-minideb:
   sourceRegistry: registry.scality.com
   image: zenko-dev/minideb
@@ -16,7 +16,7 @@ mongodb-sharded:
   tag: 4.0.27-debian-9-r111
 mongodb-sharded-exporter:
   image: bitnami/mongodb-exporter
-  tag: 0.11.2-debian-10-r382
+  tag: 0.34.0-debian-11-r24
 mongodb-sharded-shell:
   image: bitnami/bitnami-shell
   tag: 10-debian-10-r293

--- a/solution-base/mongodb/charts/mongodb-sharded/values.yaml
+++ b/solution-base/mongodb/charts/mongodb-sharded/values.yaml
@@ -1132,7 +1132,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mongodb-exporter
-    tag: 0.11.2-debian-10-r382
+    tag: 0.34.0-debian-11-r24
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/solution-base/mongodb/charts/mongodb/custom-values.yaml
+++ b/solution-base/mongodb/charts/mongodb/custom-values.yaml
@@ -441,7 +441,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mongodb-exporter
-    tag: 0.10.0-debian-9-r104
+    tag: 0.34.0-debian-11-r24
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/solution-base/mongodb/charts/mongodb/values-production.yaml
+++ b/solution-base/mongodb/charts/mongodb/values-production.yaml
@@ -437,7 +437,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mongodb-exporter
-    tag: 0.10.0-debian-9-r104
+    tag: 0.34.0-debian-11-r24
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/solution-base/mongodb/charts/mongodb/values.yaml
+++ b/solution-base/mongodb/charts/mongodb/values.yaml
@@ -439,7 +439,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mongodb-exporter
-    tag: 0.10.0-debian-9-r104
+    tag: 0.34.0-debian-11-r24
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Run `docker scan --severity high bitnami/mongodb-exporter:0.11.2-debian-10-r41`  and found 49 vulnerabilities including the CVE ones listed .

Run `docker scan --severity high bitnami/mongodb-exporter:0.34.0-debian-11-r24` and no vulnerable paths were found. “According to our scan, you are currently using the most secure version of the selected base image”.