### PR TITLE
improvement: ZENKO-4383-remove-jabba-from-ISO

### DIFF
--- a/.github/scripts/end2end/configs/zenkoversion.yaml
+++ b/.github/scripts/end2end/configs/zenkoversion.yaml
@@ -54,9 +54,6 @@ spec:
     blobserver:
       image: '${BLOBSERVER_IMAGE}' 
       tag: '${BLOBSERVER_TAG}'
-    jabba:
-      image: '${JABBA_IMAGE}' 
-      tag: '${JABBA_TAG}'
     utapi:
       image: '${UTAPI_IMAGE}' 
       tag: '${UTAPI_TAG}'

--- a/.github/scripts/end2end/configs/zenkoversion.yaml
+++ b/.github/scripts/end2end/configs/zenkoversion.yaml
@@ -51,9 +51,6 @@ spec:
     backbeat:
       image: '${BACKBEAT_IMAGE}' 
       tag: '${BACKBEAT_TAG}'
-    blobserver:
-      image: '${BLOBSERVER_IMAGE}' 
-      tag: '${BLOBSERVER_TAG}'
     utapi:
       image: '${UTAPI_IMAGE}' 
       tag: '${UTAPI_TAG}'

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -23,11 +23,6 @@ cloudserver:
   image: cloudserver
   tag: 8.5.16
   envsubst: CLOUDSERVER_TAG
-jabba:
-  sourceRegistry: registry.scality.com/jabba
-  image: jabba
-  tag: 1.0.0
-  envsubst: JABBA_TAG
 jmx-javaagent:
   sourceRegistry: banzaicloud
   image: jmx-javaagent

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -8,11 +8,6 @@ backbeat:
   policy: backbeat-policies
   tag: 8.4.23
   envsubst: BACKBEAT_TAG
-blobserver:
-  sourceRegistry: registry.scality.com/sf-eng
-  image: blobserver
-  tag: 1.0.8
-  envsubst: BLOBSERVER_TAG
 busybox:
   image: busybox
   tag: 1.33.0

--- a/solution/zenkoversion.yaml
+++ b/solution/zenkoversion.yaml
@@ -51,9 +51,6 @@ spec:
     backbeat:
       image: backbeat
       tag: '${BACKBEAT_TAG}'
-    blobserver:
-      image: blobserver
-      tag: '${BLOBSERVER_TAG}'
     utapi:
       image: utapi
       tag: '${UTAPI_TAG}'

--- a/solution/zenkoversion.yaml
+++ b/solution/zenkoversion.yaml
@@ -54,9 +54,6 @@ spec:
     blobserver:
       image: blobserver
       tag: '${BLOBSERVER_TAG}'
-    jabba:
-      image: jabba
-      tag: '${JABBA_TAG}'
     utapi:
       image: utapi
       tag: '${UTAPI_TAG}'


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
Removed `jabba` and `blobserver` image from the Zenko ISO. This change was done as a
part of handling critical CVEs for Zenko ISO. As we do not use `jabba` and `blobserver` in
Zenko 2.x (for ARTESCA), removing `Jabba` and `blobserver` will be faster than analyzing
and fixing the CVEs

**Which issue does this PR fix?**

fixes
- OS-394
- OS-393
- OS-395
- OS-390
- OS-392
- OS-391
- OS-387
- OS-389
- OS-38
- OS-396
- OS-397
- OS-398
- OS-399
- OS-400

**Special notes for your reviewers**:
Product (@rahulreddy ) informed us via slack that `blobserver` and `jabba` images can be removed from the ISO as they will not be used in Zenko in the near future

**We expect some flakyness in lifecycle tests.
Currently unrelated to change in this PR, retrying e2e tests.**

Previous result: https://github.com/scality/Zenko/actions/runs/3264772332/jobs/5365970647
