### PR TITLE
ZENKO-4374 update bitnami/mongodb-exporter

### DIFF
--- a/.github/scripts/end2end/configs/mongodb_options.yaml
+++ b/.github/scripts/end2end/configs/mongodb_options.yaml
@@ -437,7 +437,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mongodb-exporter
-    tag: 0.10.0-debian-9-r104
+    tag: 0.34.0-debian-11-r24
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -448,7 +448,10 @@ metrics:
 
   ## String with extra arguments to the metrics exporter
   ## ref: https://github.com/percona/mongodb_exporter/blob/master/mongodb_exporter.go
-  extraArgs: ""
+  ##
+  ## We use "--compatible-mode" flag to export old metric: "mongodb_mongod_replset_oplog_head_timestamp"
+  ## for mongoDB and backbeat dashboards.
+  extraArgs: "--collector.diagnosticdata --collector.replicasetstatus --collector.dbstats --collector.topmetrics --compatible-mode"
 
   ## Metrics exporter resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/.github/scripts/end2end/kustomization.yaml
+++ b/.github/scripts/end2end/kustomization.yaml
@@ -43,7 +43,7 @@ images:
   newTag: 10-debian-10-r293
 - name: metalk8s-registry-from-config.invalid/zenko-base-2.3.11/mongodb-exporter
   newName: docker.io/bitnami/mongodb-exporter
-  newTag: 0.11.2-debian-10-r382
+  newTag: 0.34.0-debian-11-r24
 - name: metalk8s-registry-from-config.invalid/zenko-base-2.3.11/mongodb-sharded
   newName: docker.io/bitnami/mongodb-sharded
   newTag: 4.0.27-debian-9-r111
@@ -52,7 +52,7 @@ images:
   newTag: 10-debian-10-r293
 - name: metalk8s-registry-from-config.invalid/zenko-base-2.3.18/mongodb-exporter
   newName: docker.io/bitnami/mongodb-exporter
-  newTag: 0.11.2-debian-10-r382
+  newTag: 0.34.0-debian-11-r24
 - name: metalk8s-registry-from-config.invalid/zenko-base-2.3.18/mongodb-sharded
   newName: docker.io/bitnami/mongodb-sharded
   newTag: 4.0.27-debian-9-r111

--- a/monitoring/mongodb/alerts.test.yaml
+++ b/monitoring/mongodb/alerts.test.yaml
@@ -30,7 +30,7 @@ tests:
 
   - interval: 1m
     input_series:
-      - series: mongodb_mongod_replset_member_state{namespace="zenko",pod="mongodb-0",state="PRIMARY"}
+      - series: mongodb_rs_members_state{namespace="zenko",pod="mongodb-0",member_state="PRIMARY"}
         values: 1 _
 
     alert_rule_test:
@@ -52,23 +52,23 @@ tests:
 
   - interval: 30s
     input_series:
-      - series: mongodb_mongod_replset_member_health{namespace="zenko",pod="mongodb-0", name="mongodb-0", state="PRIMARY"}
+      - series: mongodb_rs_members_health{namespace="zenko",pod="mongodb-0", member_idx="mongodb-0", member_state="PRIMARY"}
         values: 1 1 1 1
-      - series: mongodb_mongod_replset_member_health{namespace="zenko",pod="mongodb-0", name="mongodb-1", state="SECONDARY"}
+      - series: mongodb_rs_members_health{namespace="zenko",pod="mongodb-0", member_idx="mongodb-1", member_state="SECONDARY"}
         values: 1 1 1 1
-      - series: mongodb_mongod_replset_member_health{namespace="zenko",pod="mongodb-0", name="mongodb-2", state="SECONDARY"}
+      - series: mongodb_rs_members_health{namespace="zenko",pod="mongodb-0", member_idx="mongodb-2", member_state="SECONDARY"}
         values: 1 1 0 0
-      - series: mongodb_mongod_replset_member_health{namespace="zenko",pod="mongodb-1", name="mongodb-0", state="PRIMARY"}
+      - series: mongodb_rs_members_health{namespace="zenko",pod="mongodb-1", member_idx="mongodb-0", member_state="PRIMARY"}
         values: 1 1 1 1
-      - series: mongodb_mongod_replset_member_health{namespace="zenko",pod="mongodb-1", name="mongodb-1", state="SECONDARY"}
+      - series: mongodb_rs_members_health{namespace="zenko",pod="mongodb-1", member_idx="mongodb-1", member_state="SECONDARY"}
         values: 1 1 1 1
-      - series: mongodb_mongod_replset_member_health{namespace="zenko",pod="mongodb-1", name="mongodb-2", state="SECONDARY"}
+      - series: mongodb_rs_members_health{namespace="zenko",pod="mongodb-1", member_idx="mongodb-2", member_state="SECONDARY"}
         values: 1 1 0 0
-      - series: mongodb_mongod_replset_member_health{namespace="zenko",pod="mongodb-2", name="mongodb-0", state="PRIMARY"}
+      - series: mongodb_rs_members_health{namespace="zenko",pod="mongodb-2", member_idx="mongodb-0", member_state="PRIMARY"}
         values: 1 1 _ _
-      - series: mongodb_mongod_replset_member_health{namespace="zenko",pod="mongodb-2", name="mongodb-1", state="SECONDARY"}
+      - series: mongodb_rs_members_health{namespace="zenko",pod="mongodb-2", member_idx="mongodb-1", member_state="SECONDARY"}
         values: 1 1 _ _
-      - series: mongodb_mongod_replset_member_health{namespace="zenko",pod="mongodb-2", name="mongodb-2", state="SECONDARY"}
+      - series: mongodb_rs_members_health{namespace="zenko",pod="mongodb-2", member_idx="mongodb-2", member_state="SECONDARY"}
         values: 1 1 _ _
 
     alert_rule_test:
@@ -88,7 +88,7 @@ tests:
 
   - interval: 30s
     input_series:
-      - series: mongodb_mongod_replset_member_election_date{namespace="zenko", pod="mongodb", set="rs0"}
+      - series: mongodb_rs_members_electionDate{namespace="zenko", pod="mongodb", set="rs0"}
         values: 1+0x9 10+1x10
 
     alert_rule_test:
@@ -107,10 +107,12 @@ tests:
 
   - interval: 1m
     input_series:
-      - series: mongodb_mongod_replset_member_replication_lag{namespace="zenko",pod="mongodb-0", name="mongo-0"}
-        values: 8 12 15
-      - series: mongodb_mongod_replset_member_replication_lag{namespace="zenko",pod="mongodb-1", name="mongo-1"}
-        values: 4 9 12
+      - series: mongodb_rs_members_optimeDate{namespace="zenko",pod="mongodb-0", member_idx="mongo-0", member_state="PRIMARY"}
+        values: 5 25 35
+      - series: mongodb_rs_members_optimeDate{namespace="zenko",pod="mongodb-1", member_idx="mongo-1", member_state="SECONDARY"}
+        values: 0 12 29
+      - series: mongodb_rs_members_optimeDate{namespace="zenko",pod="mongodb-2", member_idx="mongo-2", member_state="SECONDARY"}
+        values: 2 2 31
 
     alert_rule_test:
       - alertname: ReplicationLagWarning
@@ -121,29 +123,16 @@ tests:
         exp_alerts:
           - exp_labels:
               severity: warning
-              name: mongo-0
             exp_annotations:
-              description: Mongodb replication lag is more than 10s on mongo-0
+              description: Mongodb replication lag is more than 10s
               summary: MongoDB replication lag
       - alertname: ReplicationLagWarning
         eval_time: 3m
-        exp_alerts:
-          - exp_labels:
-              severity: warning
-              name: mongo-0
-            exp_annotations:
-              description: Mongodb replication lag is more than 10s on mongo-0
-              summary: MongoDB replication lag
-          - exp_labels:
-              severity: warning
-              name: mongo-1
-            exp_annotations:
-              description: Mongodb replication lag is more than 10s on mongo-1
-              summary: MongoDB replication lag
+        exp_alerts: []
 
   - interval: 1m
     input_series:
-      - series: mongodb_connections{namespace="zenko",pod="mongodb-0",state="current"}
+      - series: mongodb_ss_connections{namespace="zenko",pod="mongodb-0",conn_type="current"}
         values: 90 98 110 110
 
     alert_rule_test:

--- a/monitoring/mongodb/alerts.yaml
+++ b/monitoring/mongodb/alerts.yaml
@@ -35,7 +35,7 @@ groups:
 
   - alert: NoPrimary
     expr: |
-      absent_over_time(mongodb_mongod_replset_member_state{namespace="${namespace}",pod=~"${service}.*",state="PRIMARY"}[1m]) == 1
+      absent_over_time(mongodb_rs_members_state{namespace="${namespace}",pod=~"${service}.*",member_state="PRIMARY"}[1m]) == 1
     for: 0m
     labels:
       severity: critical
@@ -45,17 +45,17 @@ groups:
 
   - alert: UnhealthyMemberWarning
     expr: |
-      group by(name, state) (mongodb_mongod_replset_member_health{namespace="${namespace}",pod=~"${service}.*"} != 1)
+      group by(name, state) (mongodb_rs_members_health{namespace="${namespace}",pod=~"${service}.*"} != 1)
     for: 30s
     labels:
       severity: warning
     annotations:
-      description: "Member {{ $labels.name }} ({{ $labels.state }}) is not healthy"
+      description: "Member {{ $labels.member_idx }} ({{ $labels.member_state }}) is not healthy"
       summary: Unhealthy MongoDb member
 
   - alert: TooManyElectionsWarning
     expr: |
-      sum by(set) (changes(mongodb_mongod_replset_member_election_date{namespace="${namespace}",pod=~"${service}.*"}[10m]))
+      sum by(set) (changes(mongodb_rs_members_electionDate{namespace="${namespace}",pod=~"${service}.*"}[10m]))
         > ${tooManyElectionsWarningThreshold}
     for: 0s
     labels:
@@ -66,18 +66,18 @@ groups:
 
   - alert: ReplicationLagWarning
     expr: |
-      sum by(name) (mongodb_mongod_replset_member_replication_lag{namespace="${namespace}",pod=~"${service}.*"})
-        > 10
+      max(mongodb_rs_members_optimeDate{namespace="${namespace}",pod=~"${service}.*",member_state="PRIMARY"}) -
+        min(mongodb_rs_members_optimeDate{namespace="${namespace}",pod=~"${service}.*",member_state="SECONDARY"}) > 10
     for: 30s
     labels:
       severity: warning
     annotations:
-      description: "Mongodb replication lag is more than 10s on {{ $labels.name }}"
+      description: "Mongodb replication lag is more than 10s"
       summary: MongoDB replication lag
 
   - alert: TooManyClientConnectionsWarning
     expr: |
-      sum(mongodb_connections{namespace="${namespace}",pod=~"${service}.*",state="current"})
+      sum(mongodb_ss_connections{namespace="${namespace}",pod=~"${service}.*",conn_type="current"})
         > ${tooManyClientConnectionsWarningThreshold}
     for: 2m
     labels:

--- a/monitoring/mongodb/dashboard.json
+++ b/monitoring/mongodb/dashboard.json
@@ -139,7 +139,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "mongodb_instance_uptime_estimate_seconds{pod=\"${pod}\", namespace=\"${namespace}\"}",
+          "expr": "mongodb_ss_uptime{pod=\"${pod}\", namespace=\"${namespace}\"}",
           "format": "time_series",
           "instant": true,
           "interval": "",
@@ -218,13 +218,13 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by(pod) (mongodb_connections{pod=\"${pod}\", namespace=\"${namespace}\", state=\"available\"})",
+          "expr": "sum by(pod) (mongodb_ss_connections{pod=\"${pod}\", namespace=\"${namespace}\", conn_type=\"available\"})",
           "format": "time_series",
           "interval": "",
           "instant": false,
           "intervalFactor": 2,
           "legendFormat": "",
-          "metric": "mongodb_connections",
+          "metric": "mongodb_ss_connections",
           "refId": "A",
           "step": 1800
         }
@@ -299,13 +299,13 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by(pod) (mongodb_connections{pod=\"${pod}\", namespace=\"${namespace}\", state=\"current\"})",
+          "expr": "sum by(pod) (mongodb_ss_connections{pod=\"${pod}\", namespace=\"${namespace}\", conn_type=\"current\"})",
           "format": "time_series",
           "interval": "",
           "instant": false,
           "intervalFactor": 2,
           "legendFormat": "",
-          "metric": "mongodb_connections",
+          "metric": "mongodb_ss_connections",
           "refId": "A",
           "step": 1800
         }
@@ -358,11 +358,11 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(mongodb_op_counters_total{pod=\"${pod}\", namespace=\"${namespace}\"}[$__rate_interval])",
+          "expr": "rate(mongodb_ss_opcounters{pod=\"${pod}\", namespace=\"${namespace}\"}[$__rate_interval])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "{{type}}",
+          "legendFormat": "{{legacy_op_type}}",
           "refId": "A",
           "step": 240
         }
@@ -477,11 +477,11 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(mongodb_mongod_metrics_document_total{pod=\"${mongod}\", namespace=\"${namespace}\"}[$__rate_interval])",
+          "expr": "rate(mongodb_ss_metrics_document{pod=\"${mongod}\", namespace=\"${namespace}\"}[$__rate_interval])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "{{state}}",
+          "legendFormat": "{{doc_op_type}}",
           "refId": "A",
           "step": 240
         }
@@ -571,12 +571,12 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(mongodb_mongod_metrics_query_executor_total{pod=\"${mongod}\", namespace=\"${namespace}\"}[$__rate_interval])",
+          "expr": "rate(mongodb_ss_metrics_queryExecutor_scanned{pod=\"${mongod}\", namespace=\"${namespace}\"}[$__rate_interval])",
           "format": "time_series",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "{{state}}",
+          "legendFormat": "",
           "refId": "A",
           "step": 600
         }
@@ -666,11 +666,11 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by(type) (rate(mongodb_op_counters_repl_total{pod=\"${mongod}\", namespace=\"${namespace}\"}[$__rate_interval]))",
+          "expr": "sum by(legacy_op_type) (rate(mongodb_ss_opcountersRepl{pod=\"${mongod}\", namespace=\"${namespace}\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "{{type}}",
+          "legendFormat": "{{legacy_op_type}}",
           "refId": "A",
           "step": 600
         }
@@ -785,7 +785,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(mongodb_mongod_replset_member_health{pod=\"${mongod}\", namespace=\"${namespace}\"})",
+          "expr": "sum(mongodb_rs_members_health{pod=\"${mongod}\", namespace=\"${namespace}\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -884,11 +884,11 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "mongodb_mongod_replset_member_state{pod=\"${mongod}\", namespace=\"${namespace}\"}",
+          "expr": "mongodb_rs_members_state{pod=\"${mongod}\", namespace=\"${namespace}\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "{{state}}",
+          "legendFormat": "{{member_state}}",
           "refId": "A",
           "step": 240,
           "instant": true
@@ -1084,11 +1084,11 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "mongodb_mongod_replset_oplog_size_bytes{pod=~\"${mongod}\", namespace=\"${namespace}\"}",
+          "expr": "mongodb_oplog_stats_size{pod=~\"${mongod}\", namespace=\"${namespace}\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "{{type}}",
+          "legendFormat": "{{rs_nm}}",
           "metric": "mongodb_locks_time_acquiring_global_microseconds_total",
           "refId": "A",
           "step": 240
@@ -1197,12 +1197,22 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "mongodb_memory{pod=~\"${pod}\", namespace=\"${namespace}\",type=~\"resident|virtual\"}",
+          "expr": "mongodb_ss_mem_resident{pod=~\"${pod}\", namespace=\"${namespace}\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "{{pod}}: {{type}}",
+          "legendFormat": "{{pod}}: Resident",
           "refId": "A",
+          "step": 240
+        },
+        {
+          "exemplar": true,
+          "expr": "mongodb_ss_mem_virtual{pod=~\"${pod}\", namespace=\"${namespace}\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}: Virtual",
+          "refId": "B",
           "step": 240
         }
       ],
@@ -1386,13 +1396,24 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(mongodb_network_bytes_total{pod=~\"${pod}\", namespace=\"${namespace}\"}[$__rate_interval])",
+          "expr": "rate(mongodb_ss_network_bytesIn{pod=~\"${pod}\", namespace=\"${namespace}\"}[$__rate_interval])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "{{pod}}: {{state}}",
-          "metric": "mongodb_metrics_operation_total",
+          "legendFormat": "{{pod}}: In",
+          "metric": "mongodb_ss_network_bytesIn",
           "refId": "A",
+          "step": 240
+        },
+        {
+          "exemplar": true,
+          "expr": "rate(mongodb_ss_network_bytesOut{pod=~\"${pod}\", namespace=\"${namespace}\"}[$__rate_interval])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}: Out",
+          "metric": "mongodb_ss_network_bytesOut",
+          "refId": "B",
           "step": 240
         }
       ],
@@ -1480,7 +1501,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by(pod) (rate(container_fs_writes_total{namespace=\"${namespace}\", pod=~\"${pod}\"}[$__rate_interval]))",
+          "expr": "sum by(pod) (rate(container_fs_reads_total{namespace=\"${namespace}\", pod=~\"${pod}\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{pod}}",
@@ -1638,7 +1659,7 @@
           "value": "$__all"
         },
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "label_values(mongodb_connections{namespace=\"${namespace}\"}, pod)",
+        "definition": "label_values(mongodb_ss_connections{namespace=\"${namespace}\"}, pod)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1648,7 +1669,7 @@
         "name": "pod",
         "options": [],
         "query": {
-          "query": "label_values(mongodb_connections{namespace=\"${namespace}\"}, pod)",
+          "query": "label_values(mongodb_ss_connections{namespace=\"${namespace}\"}, pod)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -1666,7 +1687,7 @@
           "value": "$__all"
         },
         "datasource": "${DS_PROMETHEUS}",
-        "definition": "label_values(mongodb_mongod_metrics_document_total{namespace=\"${namespace}\", pod=~\"$pod\"}, pod)",
+        "definition": "label_values(mongodb_ss_metrics_document{namespace=\"${namespace}\", pod=~\"$pod\"}, pod)",
         "description": null,
         "error": null,
         "hide": 2,
@@ -1676,7 +1697,7 @@
         "name": "mongod",
         "options": [],
         "query": {
-          "query": "label_values(mongodb_mongod_metrics_document_total{namespace=\"${namespace}\", pod=~\"$pod\"}, pod)",
+          "query": "label_values(mongodb_ss_metrics_document{namespace=\"${namespace}\", pod=~\"$pod\"}, pod)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -1720,5 +1741,5 @@
   "timezone": "browser",
   "title": "MongoDB",
   "uid": null,
-  "version": 20
+  "version": 21
 }

--- a/monitoring/mongodb/mongodb-exporter0.34.0-debian-11-r24_metrics_with_compatible_mode.example
+++ b/monitoring/mongodb/mongodb-exporter0.34.0-debian-11-r24_metrics_with_compatible_mode.example
@@ -1,0 +1,4859 @@
+# HELP collector_scrape_time_ms Time taken for scrape by collector
+# TYPE collector_scrape_time_ms gauge
+collector_scrape_time_ms{collector="dbstats",exporter="mongodb"} 5
+collector_scrape_time_ms{collector="diagnostic_data",exporter="mongodb"} 49
+collector_scrape_time_ms{collector="general",exporter="mongodb"} 0
+collector_scrape_time_ms{collector="replset_status",exporter="mongodb"} 1
+collector_scrape_time_ms{collector="top",exporter="mongodb"} 9
+# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 2.3825e-05
+go_gc_duration_seconds{quantile="0.25"} 4.876e-05
+go_gc_duration_seconds{quantile="0.5"} 7.2076e-05
+go_gc_duration_seconds{quantile="0.75"} 0.000108437
+go_gc_duration_seconds{quantile="1"} 0.001284713
+go_gc_duration_seconds_sum 1.613051251
+go_gc_duration_seconds_count 5602
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 18
+# HELP go_info Information about the Go environment.
+# TYPE go_info gauge
+go_info{version="go1.17.12"} 1
+# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+# TYPE go_memstats_alloc_bytes gauge
+go_memstats_alloc_bytes 4.636536e+06
+# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+# TYPE go_memstats_alloc_bytes_total counter
+go_memstats_alloc_bytes_total 2.1166470264e+10
+# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+go_memstats_buck_hash_sys_bytes 1.926931e+06
+# HELP go_memstats_frees_total Total number of frees.
+# TYPE go_memstats_frees_total counter
+go_memstats_frees_total 1.36017016e+08
+# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+# TYPE go_memstats_gc_sys_bytes gauge
+go_memstats_gc_sys_bytes 5.27468e+06
+# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+# TYPE go_memstats_heap_alloc_bytes gauge
+go_memstats_heap_alloc_bytes 4.636536e+06
+# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+# TYPE go_memstats_heap_idle_bytes gauge
+go_memstats_heap_idle_bytes 1.2967936e+07
+# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+# TYPE go_memstats_heap_inuse_bytes gauge
+go_memstats_heap_inuse_bytes 6.889472e+06
+# HELP go_memstats_heap_objects Number of allocated objects.
+# TYPE go_memstats_heap_objects gauge
+go_memstats_heap_objects 56407
+# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
+# TYPE go_memstats_heap_released_bytes gauge
+go_memstats_heap_released_bytes 8.183808e+06
+# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+# TYPE go_memstats_heap_sys_bytes gauge
+go_memstats_heap_sys_bytes 1.9857408e+07
+# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE go_memstats_last_gc_time_seconds gauge
+go_memstats_last_gc_time_seconds 1.666193406309744e+09
+# HELP go_memstats_lookups_total Total number of pointer lookups.
+# TYPE go_memstats_lookups_total counter
+go_memstats_lookups_total 0
+# HELP go_memstats_mallocs_total Total number of mallocs.
+# TYPE go_memstats_mallocs_total counter
+go_memstats_mallocs_total 1.36073423e+08
+# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+# TYPE go_memstats_mcache_inuse_bytes gauge
+go_memstats_mcache_inuse_bytes 9600
+# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+# TYPE go_memstats_mcache_sys_bytes gauge
+go_memstats_mcache_sys_bytes 16384
+# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+# TYPE go_memstats_mspan_inuse_bytes gauge
+go_memstats_mspan_inuse_bytes 168232
+# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+# TYPE go_memstats_mspan_sys_bytes gauge
+go_memstats_mspan_sys_bytes 294912
+# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+# TYPE go_memstats_next_gc_bytes gauge
+go_memstats_next_gc_bytes 7.052768e+06
+# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+# TYPE go_memstats_other_sys_bytes gauge
+go_memstats_other_sys_bytes 1.745085e+06
+# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+# TYPE go_memstats_stack_inuse_bytes gauge
+go_memstats_stack_inuse_bytes 1.114112e+06
+# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+# TYPE go_memstats_stack_sys_bytes gauge
+go_memstats_stack_sys_bytes 1.114112e+06
+# HELP go_memstats_sys_bytes Number of bytes obtained from system.
+# TYPE go_memstats_sys_bytes gauge
+go_memstats_sys_bytes 3.0229512e+07
+# HELP go_threads Number of OS threads created.
+# TYPE go_threads gauge
+go_threads 11
+# HELP mongodb_asserts_total serverStatus.asserts.
+# TYPE mongodb_asserts_total untyped
+mongodb_asserts_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1",type="msg"} 0
+mongodb_asserts_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1",type="regular"} 0
+mongodb_asserts_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1",type="rollovers"} 0
+mongodb_asserts_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1",type="user"} 137
+mongodb_asserts_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1",type="warning"} 0
+# HELP mongodb_clusterTime_signature_keyId $clusterTime.signature.
+# TYPE mongodb_clusterTime_signature_keyId untyped
+mongodb_clusterTime_signature_keyId{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 7.156240337835393e+18
+# HELP mongodb_connections serverStatus.connections.
+# TYPE mongodb_connections untyped
+mongodb_connections{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1",state="active"} 0
+mongodb_connections{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1",state="available"} 817
+mongodb_connections{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1",state="current"} 2
+mongodb_connections{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1",state="totalCreated"} 1764
+# HELP mongodb_date date
+# TYPE mongodb_date untyped
+mongodb_date{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.666193406309e+12
+# HELP mongodb_dbstats_avgObjSize dbstats.
+# TYPE mongodb_dbstats_avgObjSize untyped
+mongodb_dbstats_avgObjSize{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="admin",rs_nm="rs0",rs_state="1"} 226.83333333333334
+mongodb_dbstats_avgObjSize{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="config",rs_nm="rs0",rs_state="1"} 131
+mongodb_dbstats_avgObjSize{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="local",rs_nm="rs0",rs_state="1"} 239.8095238095238
+# HELP mongodb_dbstats_clusterTime_signature_keyId dbstats.$clusterTime.signature.
+# TYPE mongodb_dbstats_clusterTime_signature_keyId untyped
+mongodb_dbstats_clusterTime_signature_keyId{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="admin",rs_nm="rs0",rs_state="1"} 7.156240337835393e+18
+mongodb_dbstats_clusterTime_signature_keyId{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="config",rs_nm="rs0",rs_state="1"} 7.156240337835393e+18
+mongodb_dbstats_clusterTime_signature_keyId{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="local",rs_nm="rs0",rs_state="1"} 7.156240337835393e+18
+# HELP mongodb_dbstats_collections dbstats.
+# TYPE mongodb_dbstats_collections untyped
+mongodb_dbstats_collections{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="admin",rs_nm="rs0",rs_state="1"} 3
+mongodb_dbstats_collections{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="config",rs_nm="rs0",rs_state="1"} 2
+mongodb_dbstats_collections{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="local",rs_nm="rs0",rs_state="1"} 7
+# HELP mongodb_dbstats_dataSize dbstats.
+# TYPE mongodb_dbstats_dataSize untyped
+mongodb_dbstats_dataSize{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="admin",rs_nm="rs0",rs_state="1"} 1361
+mongodb_dbstats_dataSize{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="config",rs_nm="rs0",rs_state="1"} 63273
+mongodb_dbstats_dataSize{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="local",rs_nm="rs0",rs_state="1"} 151080
+# HELP mongodb_dbstats_fsTotalSize dbstats.
+# TYPE mongodb_dbstats_fsTotalSize untyped
+mongodb_dbstats_fsTotalSize{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="admin",rs_nm="rs0",rs_state="1"} 1.07362627584e+11
+mongodb_dbstats_fsTotalSize{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="config",rs_nm="rs0",rs_state="1"} 1.07362627584e+11
+mongodb_dbstats_fsTotalSize{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="local",rs_nm="rs0",rs_state="1"} 1.07362627584e+11
+# HELP mongodb_dbstats_fsUsedSize dbstats.
+# TYPE mongodb_dbstats_fsUsedSize untyped
+mongodb_dbstats_fsUsedSize{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="admin",rs_nm="rs0",rs_state="1"} 2.457663488e+10
+mongodb_dbstats_fsUsedSize{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="config",rs_nm="rs0",rs_state="1"} 2.457663488e+10
+mongodb_dbstats_fsUsedSize{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="local",rs_nm="rs0",rs_state="1"} 2.457663488e+10
+# HELP mongodb_dbstats_indexSize dbstats.
+# TYPE mongodb_dbstats_indexSize untyped
+mongodb_dbstats_indexSize{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="admin",rs_nm="rs0",rs_state="1"} 106496
+mongodb_dbstats_indexSize{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="config",rs_nm="rs0",rs_state="1"} 126976
+mongodb_dbstats_indexSize{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="local",rs_nm="rs0",rs_state="1"} 106496
+# HELP mongodb_dbstats_indexes dbstats.
+# TYPE mongodb_dbstats_indexes untyped
+mongodb_dbstats_indexes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="admin",rs_nm="rs0",rs_state="1"} 4
+mongodb_dbstats_indexes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="config",rs_nm="rs0",rs_state="1"} 3
+mongodb_dbstats_indexes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="local",rs_nm="rs0",rs_state="1"} 6
+# HELP mongodb_dbstats_numExtents dbstats.
+# TYPE mongodb_dbstats_numExtents untyped
+mongodb_dbstats_numExtents{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_dbstats_numExtents{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="config",rs_nm="rs0",rs_state="1"} 0
+mongodb_dbstats_numExtents{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="local",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_dbstats_objects dbstats.
+# TYPE mongodb_dbstats_objects untyped
+mongodb_dbstats_objects{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="admin",rs_nm="rs0",rs_state="1"} 6
+mongodb_dbstats_objects{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="config",rs_nm="rs0",rs_state="1"} 483
+mongodb_dbstats_objects{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="local",rs_nm="rs0",rs_state="1"} 630
+# HELP mongodb_dbstats_ok dbstats.
+# TYPE mongodb_dbstats_ok untyped
+mongodb_dbstats_ok{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="admin",rs_nm="rs0",rs_state="1"} 1
+mongodb_dbstats_ok{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="config",rs_nm="rs0",rs_state="1"} 1
+mongodb_dbstats_ok{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="local",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_dbstats_storageSize dbstats.
+# TYPE mongodb_dbstats_storageSize untyped
+mongodb_dbstats_storageSize{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="admin",rs_nm="rs0",rs_state="1"} 69632
+mongodb_dbstats_storageSize{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="config",rs_nm="rs0",rs_state="1"} 61440
+mongodb_dbstats_storageSize{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="local",rs_nm="rs0",rs_state="1"} 200704
+# HELP mongodb_dbstats_views dbstats.
+# TYPE mongodb_dbstats_views untyped
+mongodb_dbstats_views{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_dbstats_views{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="config",rs_nm="rs0",rs_state="1"} 0
+mongodb_dbstats_views{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="local",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_electionCandidateMetrics_electionTerm electionCandidateMetrics.
+# TYPE mongodb_electionCandidateMetrics_electionTerm untyped
+mongodb_electionCandidateMetrics_electionTerm{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 3
+# HELP mongodb_electionCandidateMetrics_electionTimeoutMillis electionCandidateMetrics.
+# TYPE mongodb_electionCandidateMetrics_electionTimeoutMillis untyped
+mongodb_electionCandidateMetrics_electionTimeoutMillis{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 10000
+# HELP mongodb_electionCandidateMetrics_lastCommittedOpTimeAtElection_t electionCandidateMetrics.lastCommittedOpTimeAtElection.
+# TYPE mongodb_electionCandidateMetrics_lastCommittedOpTimeAtElection_t untyped
+mongodb_electionCandidateMetrics_lastCommittedOpTimeAtElection_t{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} -1
+# HELP mongodb_electionCandidateMetrics_lastElectionDate electionCandidateMetrics.
+# TYPE mongodb_electionCandidateMetrics_lastElectionDate untyped
+mongodb_electionCandidateMetrics_lastElectionDate{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.666192064201e+12
+# HELP mongodb_electionCandidateMetrics_lastSeenOpTimeAtElection_t electionCandidateMetrics.lastSeenOpTimeAtElection.
+# TYPE mongodb_electionCandidateMetrics_lastSeenOpTimeAtElection_t untyped
+mongodb_electionCandidateMetrics_lastSeenOpTimeAtElection_t{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 2
+# HELP mongodb_electionCandidateMetrics_newTermStartDate electionCandidateMetrics.
+# TYPE mongodb_electionCandidateMetrics_newTermStartDate untyped
+mongodb_electionCandidateMetrics_newTermStartDate{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.666192066201e+12
+# HELP mongodb_electionCandidateMetrics_numVotesNeeded electionCandidateMetrics.
+# TYPE mongodb_electionCandidateMetrics_numVotesNeeded untyped
+mongodb_electionCandidateMetrics_numVotesNeeded{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_electionCandidateMetrics_priorityAtElection electionCandidateMetrics.
+# TYPE mongodb_electionCandidateMetrics_priorityAtElection untyped
+mongodb_electionCandidateMetrics_priorityAtElection{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 5
+# HELP mongodb_electionCandidateMetrics_wMajorityWriteAvailabilityDate electionCandidateMetrics.
+# TYPE mongodb_electionCandidateMetrics_wMajorityWriteAvailabilityDate untyped
+mongodb_electionCandidateMetrics_wMajorityWriteAvailabilityDate{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.666192066284e+12
+# HELP mongodb_end end
+# TYPE mongodb_end untyped
+mongodb_end{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.666193406002e+12
+# HELP mongodb_extra_info_page_faults_total serverStatus.extra_info.
+# TYPE mongodb_extra_info_page_faults_total untyped
+mongodb_extra_info_page_faults_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_heartbeatIntervalMillis heartbeatIntervalMillis
+# TYPE mongodb_heartbeatIntervalMillis untyped
+mongodb_heartbeatIntervalMillis{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 2000
+# HELP mongodb_instance_local_time start
+# TYPE mongodb_instance_local_time untyped
+mongodb_instance_local_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.666193406e+12
+# HELP mongodb_instance_uptime_seconds serverStatus.
+# TYPE mongodb_instance_uptime_seconds untyped
+mongodb_instance_uptime_seconds{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1342
+# HELP mongodb_members_configVersion members.
+# TYPE mongodb_members_configVersion untyped
+mongodb_members_configVersion{cl_id="6350129adfb0b7e3db4773bb",cl_role="",member_idx="dev-db-mongodb-primary-0.dev-db-mongodb-headless.default.svc.cluster.local:27017",member_state="PRIMARY",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_members_electionDate members.
+# TYPE mongodb_members_electionDate untyped
+mongodb_members_electionDate{cl_id="6350129adfb0b7e3db4773bb",cl_role="",member_idx="dev-db-mongodb-primary-0.dev-db-mongodb-headless.default.svc.cluster.local:27017",member_state="PRIMARY",rs_nm="rs0",rs_state="1"} 1.666192064e+12
+# HELP mongodb_members_health members.
+# TYPE mongodb_members_health untyped
+mongodb_members_health{cl_id="6350129adfb0b7e3db4773bb",cl_role="",member_idx="dev-db-mongodb-primary-0.dev-db-mongodb-headless.default.svc.cluster.local:27017",member_state="PRIMARY",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_members_id members.
+# TYPE mongodb_members_id untyped
+mongodb_members_id{cl_id="6350129adfb0b7e3db4773bb",cl_role="",member_idx="dev-db-mongodb-primary-0.dev-db-mongodb-headless.default.svc.cluster.local:27017",member_state="PRIMARY",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_members_optimeDate members.
+# TYPE mongodb_members_optimeDate untyped
+mongodb_members_optimeDate{cl_id="6350129adfb0b7e3db4773bb",cl_role="",member_idx="dev-db-mongodb-primary-0.dev-db-mongodb-headless.default.svc.cluster.local:27017",member_state="PRIMARY",rs_nm="rs0",rs_state="1"} 1.666193406e+12
+# HELP mongodb_members_optime_t members.optime.
+# TYPE mongodb_members_optime_t untyped
+mongodb_members_optime_t{cl_id="6350129adfb0b7e3db4773bb",cl_role="",member_idx="dev-db-mongodb-primary-0.dev-db-mongodb-headless.default.svc.cluster.local:27017",member_state="PRIMARY",rs_nm="rs0",rs_state="1"} 3
+# HELP mongodb_members_self members.
+# TYPE mongodb_members_self untyped
+mongodb_members_self{cl_id="6350129adfb0b7e3db4773bb",cl_role="",member_idx="dev-db-mongodb-primary-0.dev-db-mongodb-headless.default.svc.cluster.local:27017",member_state="PRIMARY",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_members_state members.
+# TYPE mongodb_members_state untyped
+mongodb_members_state{cl_id="6350129adfb0b7e3db4773bb",cl_role="",member_idx="dev-db-mongodb-primary-0.dev-db-mongodb-headless.default.svc.cluster.local:27017",member_state="PRIMARY",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_members_syncSourceId members.
+# TYPE mongodb_members_syncSourceId untyped
+mongodb_members_syncSourceId{cl_id="6350129adfb0b7e3db4773bb",cl_role="",member_idx="dev-db-mongodb-primary-0.dev-db-mongodb-headless.default.svc.cluster.local:27017",member_state="PRIMARY",rs_nm="rs0",rs_state="1"} -1
+# HELP mongodb_members_uptime members.
+# TYPE mongodb_members_uptime untyped
+mongodb_members_uptime{cl_id="6350129adfb0b7e3db4773bb",cl_role="",member_idx="dev-db-mongodb-primary-0.dev-db-mongodb-headless.default.svc.cluster.local:27017",member_state="PRIMARY",rs_nm="rs0",rs_state="1"} 1343
+# HELP mongodb_memory mongodb_memory
+# TYPE mongodb_memory untyped
+mongodb_memory{type="mapped"} 0
+mongodb_memory{type="mapped_with_journal"} 0
+mongodb_memory{type="resident"} 80
+mongodb_memory{type="virtual"} 1357
+# HELP mongodb_mongod_db_collections_total dbstats.
+# TYPE mongodb_mongod_db_collections_total untyped
+mongodb_mongod_db_collections_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="admin",rs_nm="rs0",rs_state="1"} 3
+mongodb_mongod_db_collections_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="config",rs_nm="rs0",rs_state="1"} 2
+mongodb_mongod_db_collections_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="local",rs_nm="rs0",rs_state="1"} 7
+# HELP mongodb_mongod_db_data_size_bytes dbstats.
+# TYPE mongodb_mongod_db_data_size_bytes untyped
+mongodb_mongod_db_data_size_bytes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="admin",rs_nm="rs0",rs_state="1"} 1361
+mongodb_mongod_db_data_size_bytes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="config",rs_nm="rs0",rs_state="1"} 63273
+mongodb_mongod_db_data_size_bytes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="local",rs_nm="rs0",rs_state="1"} 151080
+# HELP mongodb_mongod_db_index_size_bytes dbstats.
+# TYPE mongodb_mongod_db_index_size_bytes untyped
+mongodb_mongod_db_index_size_bytes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="admin",rs_nm="rs0",rs_state="1"} 106496
+mongodb_mongod_db_index_size_bytes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="config",rs_nm="rs0",rs_state="1"} 126976
+mongodb_mongod_db_index_size_bytes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="local",rs_nm="rs0",rs_state="1"} 106496
+# HELP mongodb_mongod_db_indexes_total dbstats.
+# TYPE mongodb_mongod_db_indexes_total untyped
+mongodb_mongod_db_indexes_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="admin",rs_nm="rs0",rs_state="1"} 4
+mongodb_mongod_db_indexes_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="config",rs_nm="rs0",rs_state="1"} 3
+mongodb_mongod_db_indexes_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="local",rs_nm="rs0",rs_state="1"} 6
+# HELP mongodb_mongod_db_objects_total dbstats.
+# TYPE mongodb_mongod_db_objects_total untyped
+mongodb_mongod_db_objects_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="admin",rs_nm="rs0",rs_state="1"} 6
+mongodb_mongod_db_objects_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="config",rs_nm="rs0",rs_state="1"} 483
+mongodb_mongod_db_objects_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",database="local",rs_nm="rs0",rs_state="1"} 630
+# HELP mongodb_mongod_global_lock_client mongodb_mongod_global_lock_client
+# TYPE mongodb_mongod_global_lock_client untyped
+mongodb_mongod_global_lock_client{type="reader"} 0
+mongodb_mongod_global_lock_client{type="total"} 42
+mongodb_mongod_global_lock_client{type="writer"} 0
+# HELP mongodb_mongod_global_lock_current_queue serverStatus.globalLock.currentQueue.
+# TYPE mongodb_mongod_global_lock_current_queue untyped
+mongodb_mongod_global_lock_current_queue{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1",type="reader"} 0
+mongodb_mongod_global_lock_current_queue{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1",type="total"} 0
+mongodb_mongod_global_lock_current_queue{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1",type="writer"} 0
+# HELP mongodb_mongod_instance_uptime_seconds serverStatus.
+# TYPE mongodb_mongod_instance_uptime_seconds untyped
+mongodb_mongod_instance_uptime_seconds{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1342
+# HELP mongodb_mongod_locks_time_acquiring_global_microseconds_total sum of serverStatus.locks.Global.timeAcquiringMicros.[r|w]
+# TYPE mongodb_mongod_locks_time_acquiring_global_microseconds_total gauge
+mongodb_mongod_locks_time_acquiring_global_microseconds_total 1612
+# HELP mongodb_mongod_metrics_cursor_open serverStatus.metrics.cursor.open.
+# TYPE mongodb_mongod_metrics_cursor_open untyped
+mongodb_mongod_metrics_cursor_open{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1",state="noTimeout"} 0
+mongodb_mongod_metrics_cursor_open{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1",state="pinned"} 0
+mongodb_mongod_metrics_cursor_open{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1",state="total"} 0
+# HELP mongodb_mongod_metrics_cursor_timed_out_total serverStatus.metrics.cursor.
+# TYPE mongodb_mongod_metrics_cursor_timed_out_total untyped
+mongodb_mongod_metrics_cursor_timed_out_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_mongod_metrics_document_total serverStatus.metrics.document.
+# TYPE mongodb_mongod_metrics_document_total untyped
+mongodb_mongod_metrics_document_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1",state="deleted"} 0
+mongodb_mongod_metrics_document_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1",state="inserted"} 0
+mongodb_mongod_metrics_document_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1",state="returned"} 1088
+mongodb_mongod_metrics_document_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1",state="updated"} 0
+# HELP mongodb_mongod_metrics_get_last_error_wtime_num_total serverStatus.metrics.getLastError.wtime.
+# TYPE mongodb_mongod_metrics_get_last_error_wtime_num_total untyped
+mongodb_mongod_metrics_get_last_error_wtime_num_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 5
+# HELP mongodb_mongod_metrics_get_last_error_wtime_total_milliseconds serverStatus.metrics.getLastError.wtime.
+# TYPE mongodb_mongod_metrics_get_last_error_wtime_total_milliseconds untyped
+mongodb_mongod_metrics_get_last_error_wtime_total_milliseconds{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_mongod_metrics_get_last_error_wtimeouts_total serverStatus.metrics.getLastError.
+# TYPE mongodb_mongod_metrics_get_last_error_wtimeouts_total untyped
+mongodb_mongod_metrics_get_last_error_wtimeouts_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_mongod_metrics_operation_total mongodb_mongod_metrics_operation_total
+# TYPE mongodb_mongod_metrics_operation_total untyped
+mongodb_mongod_metrics_operation_total{state="scanAndOrder"} 3
+mongodb_mongod_metrics_operation_total{state="writeConflicts"} 0
+# HELP mongodb_mongod_metrics_query_executor_total mongodb_mongod_metrics_query_executor_total
+# TYPE mongodb_mongod_metrics_query_executor_total untyped
+mongodb_mongod_metrics_query_executor_total{state="scanned"} 0
+mongodb_mongod_metrics_query_executor_total{state="scanned_objects"} 1088
+# HELP mongodb_mongod_metrics_record_moves_total serverStatus.metrics.record.
+# TYPE mongodb_mongod_metrics_record_moves_total untyped
+mongodb_mongod_metrics_record_moves_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_mongod_metrics_repl_apply_batches_num_total serverStatus.metrics.repl.apply.batches.
+# TYPE mongodb_mongod_metrics_repl_apply_batches_num_total untyped
+mongodb_mongod_metrics_repl_apply_batches_num_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_mongod_metrics_repl_apply_batches_total_milliseconds serverStatus.metrics.repl.apply.batches.
+# TYPE mongodb_mongod_metrics_repl_apply_batches_total_milliseconds untyped
+mongodb_mongod_metrics_repl_apply_batches_total_milliseconds{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_mongod_metrics_repl_apply_ops_total serverStatus.metrics.repl.apply.
+# TYPE mongodb_mongod_metrics_repl_apply_ops_total untyped
+mongodb_mongod_metrics_repl_apply_ops_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_mongod_metrics_repl_buffer_count serverStatus.metrics.repl.buffer.
+# TYPE mongodb_mongod_metrics_repl_buffer_count counter
+mongodb_mongod_metrics_repl_buffer_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_mongod_metrics_repl_buffer_max_size_bytes serverStatus.metrics.repl.buffer.
+# TYPE mongodb_mongod_metrics_repl_buffer_max_size_bytes untyped
+mongodb_mongod_metrics_repl_buffer_max_size_bytes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 2.68435456e+08
+# HELP mongodb_mongod_metrics_repl_buffer_size_bytes serverStatus.metrics.repl.buffer.
+# TYPE mongodb_mongod_metrics_repl_buffer_size_bytes untyped
+mongodb_mongod_metrics_repl_buffer_size_bytes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_mongod_metrics_repl_executor_unsignaled_events serverStatus.metrics.repl.executor.
+# TYPE mongodb_mongod_metrics_repl_executor_unsignaled_events untyped
+mongodb_mongod_metrics_repl_executor_unsignaled_events{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_mongod_metrics_repl_network_bytes_total serverStatus.metrics.repl.network.
+# TYPE mongodb_mongod_metrics_repl_network_bytes_total untyped
+mongodb_mongod_metrics_repl_network_bytes_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_mongod_metrics_repl_network_getmores_num_total serverStatus.metrics.repl.network.getmores.
+# TYPE mongodb_mongod_metrics_repl_network_getmores_num_total untyped
+mongodb_mongod_metrics_repl_network_getmores_num_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_mongod_metrics_repl_network_getmores_total_milliseconds serverStatus.metrics.repl.network.getmores.
+# TYPE mongodb_mongod_metrics_repl_network_getmores_total_milliseconds untyped
+mongodb_mongod_metrics_repl_network_getmores_total_milliseconds{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_mongod_metrics_repl_network_ops_total serverStatus.metrics.repl.network.
+# TYPE mongodb_mongod_metrics_repl_network_ops_total untyped
+mongodb_mongod_metrics_repl_network_ops_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_mongod_metrics_repl_network_readers_created_total serverStatus.metrics.repl.network.
+# TYPE mongodb_mongod_metrics_repl_network_readers_created_total untyped
+mongodb_mongod_metrics_repl_network_readers_created_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_mongod_metrics_ttl_deleted_documents_total serverStatus.metrics.ttl.
+# TYPE mongodb_mongod_metrics_ttl_deleted_documents_total untyped
+mongodb_mongod_metrics_ttl_deleted_documents_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_mongod_metrics_ttl_passes_total serverStatus.metrics.ttl.
+# TYPE mongodb_mongod_metrics_ttl_passes_total untyped
+mongodb_mongod_metrics_ttl_passes_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 22
+# HELP mongodb_mongod_op_counters_repl_total serverStatus.opcountersRepl.
+# TYPE mongodb_mongod_op_counters_repl_total untyped
+mongodb_mongod_op_counters_repl_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1",type="command"} 0
+mongodb_mongod_op_counters_repl_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1",type="delete"} 0
+mongodb_mongod_op_counters_repl_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1",type="getmore"} 0
+mongodb_mongod_op_counters_repl_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1",type="insert"} 0
+mongodb_mongod_op_counters_repl_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1",type="query"} 0
+mongodb_mongod_op_counters_repl_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1",type="update"} 0
+# HELP mongodb_mongod_op_latencies_latency_total mongodb_ss_opLatencies_latency
+# TYPE mongodb_mongod_op_latencies_latency_total untyped
+mongodb_mongod_op_latencies_latency_total{type="command"} 2.695412e+06
+mongodb_mongod_op_latencies_latency_total{type="read"} 196719
+mongodb_mongod_op_latencies_latency_total{type="transactions"} 0
+mongodb_mongod_op_latencies_latency_total{type="write"} 0
+# HELP mongodb_mongod_op_latencies_ops_total mongodb_ss_opLatencies_ops
+# TYPE mongodb_mongod_op_latencies_ops_total untyped
+mongodb_mongod_op_latencies_ops_total{type="command"} 14508
+mongodb_mongod_op_latencies_ops_total{type="read"} 2168
+mongodb_mongod_op_latencies_ops_total{type="transactions"} 0
+mongodb_mongod_op_latencies_ops_total{type="write"} 0
+# HELP mongodb_mongod_replset_member_config_version The configVersion value is the replica set configuration version.
+# TYPE mongodb_mongod_replset_member_config_version gauge
+mongodb_mongod_replset_member_config_version{name="dev-db-mongodb-primary-0.dev-db-mongodb-headless.default.svc.cluster.local:27017",set="rs0",state="PRIMARY"} 1
+# HELP mongodb_mongod_replset_member_election_date The timestamp the node was elected as replica leader
+# TYPE mongodb_mongod_replset_member_election_date gauge
+mongodb_mongod_replset_member_election_date{name="dev-db-mongodb-primary-0.dev-db-mongodb-headless.default.svc.cluster.local:27017",set="rs0",state="PRIMARY"} 1.666192064e+09
+# HELP mongodb_mongod_replset_member_last_heartbeat The lastHeartbeat value provides an ISODate formatted date and time of the transmission time of last heartbeat received from this member.
+# TYPE mongodb_mongod_replset_member_last_heartbeat gauge
+mongodb_mongod_replset_member_last_heartbeat{name="dev-db-mongodb-primary-0.dev-db-mongodb-headless.default.svc.cluster.local:27017",set="rs0",state="PRIMARY"} 0
+# HELP mongodb_mongod_replset_member_last_heartbeat_recv The lastHeartbeatRecv value provides an ISODate formatted date and time that the last heartbeat was received from this member.
+# TYPE mongodb_mongod_replset_member_last_heartbeat_recv gauge
+mongodb_mongod_replset_member_last_heartbeat_recv{name="dev-db-mongodb-primary-0.dev-db-mongodb-headless.default.svc.cluster.local:27017",set="rs0",state="PRIMARY"} 0
+# HELP mongodb_mongod_replset_my_name The replica state name of the current member.
+# TYPE mongodb_mongod_replset_my_name gauge
+mongodb_mongod_replset_my_name{name="dev-db-mongodb-primary-0.dev-db-mongodb-headless.default.svc.cluster.local:27017",set="rs0"} 1
+# HELP mongodb_mongod_replset_my_state An integer between 0 and 10 that represents the replica state of the current member
+# TYPE mongodb_mongod_replset_my_state gauge
+mongodb_mongod_replset_my_state{set="rs0"} 1
+# HELP mongodb_mongod_replset_number_of_members The number of replica set members.
+# TYPE mongodb_mongod_replset_number_of_members gauge
+mongodb_mongod_replset_number_of_members{set="rs0"} 1
+# HELP mongodb_mongod_replset_oplog_head_timestamp The timestamp of the newest change in the oplog
+# TYPE mongodb_mongod_replset_oplog_head_timestamp gauge
+mongodb_mongod_replset_oplog_head_timestamp 1.666193396e+09
+# HELP mongodb_mongod_replset_oplog_tail_timestamp The timestamp of the oldest change in the oplog
+# TYPE mongodb_mongod_replset_oplog_tail_timestamp gauge
+mongodb_mongod_replset_oplog_tail_timestamp 1.666192026e+09
+# HELP mongodb_mongod_storage_engine The storage engine used by the MongoDB instance
+# TYPE mongodb_mongod_storage_engine gauge
+mongodb_mongod_storage_engine{engine="wiredTiger"} 1
+# HELP mongodb_mongod_wiredtiger_blockmanager_bytes_total mongodb_mongod_wiredtiger_blockmanager_bytes_total
+# TYPE mongodb_mongod_wiredtiger_blockmanager_bytes_total untyped
+mongodb_mongod_wiredtiger_blockmanager_bytes_total{type="read"} 614400
+mongodb_mongod_wiredtiger_blockmanager_bytes_total{type="read_mapped"} 0
+mongodb_mongod_wiredtiger_blockmanager_bytes_total{type="written"} 2.531328e+06
+# HELP mongodb_mongod_wiredtiger_cache_bytes mongodb_mongod_wiredtiger_cache_bytes
+# TYPE mongodb_mongod_wiredtiger_cache_bytes untyped
+mongodb_mongod_wiredtiger_cache_bytes{type="total"} 534286
+# HELP mongodb_mongod_wiredtiger_cache_bytes_total mongodb_mongod_wiredtiger_cache_bytes_total
+# TYPE mongodb_mongod_wiredtiger_cache_bytes_total untyped
+mongodb_mongod_wiredtiger_cache_bytes_total{type="read"} 58707
+mongodb_mongod_wiredtiger_cache_bytes_total{type="written"} 1.72371e+06
+# HELP mongodb_mongod_wiredtiger_cache_evicted_total wiredtiger cache evicted total
+# TYPE mongodb_mongod_wiredtiger_cache_evicted_total gauge
+mongodb_mongod_wiredtiger_cache_evicted_total 0
+# HELP mongodb_mongod_wiredtiger_cache_max_bytes serverStatus.wiredTiger.cache.
+# TYPE mongodb_mongod_wiredtiger_cache_max_bytes untyped
+mongodb_mongod_wiredtiger_cache_max_bytes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.6245587968e+10
+# HELP mongodb_mongod_wiredtiger_cache_overhead_percent serverStatus.wiredTiger.cache.
+# TYPE mongodb_mongod_wiredtiger_cache_overhead_percent untyped
+mongodb_mongod_wiredtiger_cache_overhead_percent{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 8
+# HELP mongodb_mongod_wiredtiger_cache_pages mongodb_mongod_wiredtiger_cache_pages
+# TYPE mongodb_mongod_wiredtiger_cache_pages untyped
+mongodb_mongod_wiredtiger_cache_pages{type="dirty"} 5
+mongodb_mongod_wiredtiger_cache_pages{type="total"} 44
+# HELP mongodb_mongod_wiredtiger_cache_pages_total mongodb_mongod_wiredtiger_cache_pages_total
+# TYPE mongodb_mongod_wiredtiger_cache_pages_total untyped
+mongodb_mongod_wiredtiger_cache_pages_total{type="read"} 39
+mongodb_mongod_wiredtiger_cache_pages_total{type="written"} 212
+# HELP mongodb_mongod_wiredtiger_concurrent_transactions_available_tickets mongodb_ss_wt_concurrentTransactions_available
+# TYPE mongodb_mongod_wiredtiger_concurrent_transactions_available_tickets untyped
+mongodb_mongod_wiredtiger_concurrent_transactions_available_tickets{txn_rw="read"} 128
+mongodb_mongod_wiredtiger_concurrent_transactions_available_tickets{txn_rw="write"} 128
+# HELP mongodb_mongod_wiredtiger_concurrent_transactions_out_tickets mongodb_ss_wt_concurrentTransactions_out
+# TYPE mongodb_mongod_wiredtiger_concurrent_transactions_out_tickets untyped
+mongodb_mongod_wiredtiger_concurrent_transactions_out_tickets{txn_rw="read"} 0
+mongodb_mongod_wiredtiger_concurrent_transactions_out_tickets{txn_rw="write"} 0
+# HELP mongodb_mongod_wiredtiger_concurrent_transactions_total_tickets mongodb_ss_wt_concurrentTransactions_totalTickets
+# TYPE mongodb_mongod_wiredtiger_concurrent_transactions_total_tickets untyped
+mongodb_mongod_wiredtiger_concurrent_transactions_total_tickets{txn_rw="read"} 128
+mongodb_mongod_wiredtiger_concurrent_transactions_total_tickets{txn_rw="write"} 128
+# HELP mongodb_mongod_wiredtiger_log_bytes_total mongodb_mongod_wiredtiger_log_bytes_total
+# TYPE mongodb_mongod_wiredtiger_log_bytes_total untyped
+mongodb_mongod_wiredtiger_log_bytes_total{type="payload"} 197981
+mongodb_mongod_wiredtiger_log_bytes_total{type="unwritten"} 264960
+# HELP mongodb_mongod_wiredtiger_log_operations_total mongodb_mongod_wiredtiger_log_operations_total
+# TYPE mongodb_mongod_wiredtiger_log_operations_total untyped
+mongodb_mongod_wiredtiger_log_operations_total{type="flush"} 13519
+mongodb_mongod_wiredtiger_log_operations_total{type="scan"} 4
+mongodb_mongod_wiredtiger_log_operations_total{type="scan_double"} 3
+mongodb_mongod_wiredtiger_log_operations_total{type="sync"} 182
+mongodb_mongod_wiredtiger_log_operations_total{type="sync_dir"} 1
+mongodb_mongod_wiredtiger_log_operations_total{type="write"} 707
+# HELP mongodb_mongod_wiredtiger_log_records_scanned_total serverStatus.wiredTiger.log.
+# TYPE mongodb_mongod_wiredtiger_log_records_scanned_total untyped
+mongodb_mongod_wiredtiger_log_records_scanned_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 14
+# HELP mongodb_mongod_wiredtiger_log_records_total mongodb_mongod_wiredtiger_log_records_total
+# TYPE mongodb_mongod_wiredtiger_log_records_total untyped
+mongodb_mongod_wiredtiger_log_records_total{type="compressed"} 25
+mongodb_mongod_wiredtiger_log_records_total{type="uncompressed"} 615
+# HELP mongodb_mongod_wiredtiger_session_open_sessions_total serverStatus.wiredTiger.session.
+# TYPE mongodb_mongod_wiredtiger_session_open_sessions_total counter
+mongodb_mongod_wiredtiger_session_open_sessions_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 20
+# HELP mongodb_mongod_wiredtiger_transactions_checkpoint_milliseconds mongodb_mongod_wiredtiger_transactions_checkpoint_milliseconds
+# TYPE mongodb_mongod_wiredtiger_transactions_checkpoint_milliseconds untyped
+mongodb_mongod_wiredtiger_transactions_checkpoint_milliseconds{type="max"} 18
+mongodb_mongod_wiredtiger_transactions_checkpoint_milliseconds{type="min"} 2
+# HELP mongodb_mongod_wiredtiger_transactions_checkpoint_milliseconds_total serverStatus.wiredTiger.transaction.
+# TYPE mongodb_mongod_wiredtiger_transactions_checkpoint_milliseconds_total untyped
+mongodb_mongod_wiredtiger_transactions_checkpoint_milliseconds_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 127
+# HELP mongodb_mongod_wiredtiger_transactions_running_checkpoints serverStatus.wiredTiger.transaction.
+# TYPE mongodb_mongod_wiredtiger_transactions_running_checkpoints untyped
+mongodb_mongod_wiredtiger_transactions_running_checkpoints{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_mongod_wiredtiger_transactions_total mongodb_mongod_wiredtiger_transactions_total
+# TYPE mongodb_mongod_wiredtiger_transactions_total untyped
+mongodb_mongod_wiredtiger_transactions_total{type="committed"} 637
+mongodb_mongod_wiredtiger_transactions_total{type="rolled_back"} 7913
+# HELP mongodb_myState myState
+# TYPE mongodb_myState untyped
+mongodb_myState{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_network_metrics_num_requests_total serverStatus.network.
+# TYPE mongodb_network_metrics_num_requests_total untyped
+mongodb_network_metrics_num_requests_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 16676
+# HELP mongodb_ok ok
+# TYPE mongodb_ok untyped
+mongodb_ok{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_op_counters_total serverStatus.opcounters.
+# TYPE mongodb_op_counters_total untyped
+mongodb_op_counters_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1",type="command"} 14384
+mongodb_op_counters_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1",type="delete"} 1
+mongodb_op_counters_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1",type="getmore"} 0
+mongodb_op_counters_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1",type="insert"} 0
+mongodb_op_counters_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1",type="query"} 2176
+mongodb_op_counters_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1",type="update"} 481
+# HELP mongodb_oplog_stats_avgObjSize local.oplog.rs.stats.
+# TYPE mongodb_oplog_stats_avgObjSize untyped
+mongodb_oplog_stats_avgObjSize{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 228
+# HELP mongodb_oplog_stats_capped local.oplog.rs.stats.
+# TYPE mongodb_oplog_stats_capped untyped
+mongodb_oplog_stats_capped{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_oplog_stats_count local.oplog.rs.stats.
+# TYPE mongodb_oplog_stats_count counter
+mongodb_oplog_stats_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 621
+# HELP mongodb_oplog_stats_end local.oplog.rs.stats.
+# TYPE mongodb_oplog_stats_end untyped
+mongodb_oplog_stats_end{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.666193406001e+12
+# HELP mongodb_oplog_stats_max local.oplog.rs.stats.
+# TYPE mongodb_oplog_stats_max untyped
+mongodb_oplog_stats_max{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} -1
+# HELP mongodb_oplog_stats_maxSize local.oplog.rs.stats.
+# TYPE mongodb_oplog_stats_maxSize untyped
+mongodb_oplog_stats_maxSize{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 4.70112256e+09
+# HELP mongodb_oplog_stats_nindexes local.oplog.rs.stats.
+# TYPE mongodb_oplog_stats_nindexes untyped
+mongodb_oplog_stats_nindexes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_ok local.oplog.rs.stats.
+# TYPE mongodb_oplog_stats_ok untyped
+mongodb_oplog_stats_ok{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_oplog_stats_size local.oplog.rs.stats.
+# TYPE mongodb_oplog_stats_size untyped
+mongodb_oplog_stats_size{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 141760
+# HELP mongodb_oplog_stats_sleepCount local.oplog.rs.stats.
+# TYPE mongodb_oplog_stats_sleepCount counter
+mongodb_oplog_stats_sleepCount{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_sleepMS local.oplog.rs.stats.
+# TYPE mongodb_oplog_stats_sleepMS untyped
+mongodb_oplog_stats_sleepMS{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_start local.oplog.rs.stats.
+# TYPE mongodb_oplog_stats_start untyped
+mongodb_oplog_stats_start{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.666193406001e+12
+# HELP mongodb_oplog_stats_storageSize local.oplog.rs.stats.
+# TYPE mongodb_oplog_stats_storageSize untyped
+mongodb_oplog_stats_storageSize{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 73728
+# HELP mongodb_oplog_stats_totalIndexSize local.oplog.rs.stats.
+# TYPE mongodb_oplog_stats_totalIndexSize untyped
+mongodb_oplog_stats_totalIndexSize{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_LSM_bloom_filter_false_positives local.oplog.rs.stats.wiredTiger.LSM.
+# TYPE mongodb_oplog_stats_wt_LSM_bloom_filter_false_positives untyped
+mongodb_oplog_stats_wt_LSM_bloom_filter_false_positives{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_LSM_bloom_filter_hits local.oplog.rs.stats.wiredTiger.LSM.
+# TYPE mongodb_oplog_stats_wt_LSM_bloom_filter_hits untyped
+mongodb_oplog_stats_wt_LSM_bloom_filter_hits{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_LSM_bloom_filter_misses local.oplog.rs.stats.wiredTiger.LSM.
+# TYPE mongodb_oplog_stats_wt_LSM_bloom_filter_misses untyped
+mongodb_oplog_stats_wt_LSM_bloom_filter_misses{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_LSM_bloom_filter_pages_evicted_from_cache local.oplog.rs.stats.wiredTiger.LSM.
+# TYPE mongodb_oplog_stats_wt_LSM_bloom_filter_pages_evicted_from_cache untyped
+mongodb_oplog_stats_wt_LSM_bloom_filter_pages_evicted_from_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_LSM_bloom_filter_pages_read_into_cache local.oplog.rs.stats.wiredTiger.LSM.
+# TYPE mongodb_oplog_stats_wt_LSM_bloom_filter_pages_read_into_cache untyped
+mongodb_oplog_stats_wt_LSM_bloom_filter_pages_read_into_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_LSM_bloom_filters_in_the_LSM_tree local.oplog.rs.stats.wiredTiger.LSM.
+# TYPE mongodb_oplog_stats_wt_LSM_bloom_filters_in_the_LSM_tree untyped
+mongodb_oplog_stats_wt_LSM_bloom_filters_in_the_LSM_tree{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_LSM_chunks_in_the_LSM_tree local.oplog.rs.stats.wiredTiger.LSM.
+# TYPE mongodb_oplog_stats_wt_LSM_chunks_in_the_LSM_tree untyped
+mongodb_oplog_stats_wt_LSM_chunks_in_the_LSM_tree{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_LSM_highest_merge_generation_in_the_LSM_tree local.oplog.rs.stats.wiredTiger.LSM.
+# TYPE mongodb_oplog_stats_wt_LSM_highest_merge_generation_in_the_LSM_tree untyped
+mongodb_oplog_stats_wt_LSM_highest_merge_generation_in_the_LSM_tree{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_LSM_queries_that_could_have_benefited_from_a_Bloom_filter_that_did_not_exist local.oplog.rs.stats.wiredTiger.LSM.
+# TYPE mongodb_oplog_stats_wt_LSM_queries_that_could_have_benefited_from_a_Bloom_filter_that_did_not_exist untyped
+mongodb_oplog_stats_wt_LSM_queries_that_could_have_benefited_from_a_Bloom_filter_that_did_not_exist{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_LSM_sleep_for_LSM_checkpoint_throttle local.oplog.rs.stats.wiredTiger.LSM.
+# TYPE mongodb_oplog_stats_wt_LSM_sleep_for_LSM_checkpoint_throttle untyped
+mongodb_oplog_stats_wt_LSM_sleep_for_LSM_checkpoint_throttle{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_LSM_sleep_for_LSM_merge_throttle local.oplog.rs.stats.wiredTiger.LSM.
+# TYPE mongodb_oplog_stats_wt_LSM_sleep_for_LSM_merge_throttle untyped
+mongodb_oplog_stats_wt_LSM_sleep_for_LSM_merge_throttle{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_LSM_total_size_of_bloom_filters local.oplog.rs.stats.wiredTiger.LSM.
+# TYPE mongodb_oplog_stats_wt_LSM_total_size_of_bloom_filters untyped
+mongodb_oplog_stats_wt_LSM_total_size_of_bloom_filters{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_block_manager_allocations_requiring_file_extension local.oplog.rs.stats.wiredTiger.block-manager.
+# TYPE mongodb_oplog_stats_wt_block_manager_allocations_requiring_file_extension untyped
+mongodb_oplog_stats_wt_block_manager_allocations_requiring_file_extension{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 12
+# HELP mongodb_oplog_stats_wt_block_manager_blocks_allocated local.oplog.rs.stats.wiredTiger.block-manager.
+# TYPE mongodb_oplog_stats_wt_block_manager_blocks_allocated untyped
+mongodb_oplog_stats_wt_block_manager_blocks_allocated{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 94
+# HELP mongodb_oplog_stats_wt_block_manager_blocks_freed local.oplog.rs.stats.wiredTiger.block-manager.
+# TYPE mongodb_oplog_stats_wt_block_manager_blocks_freed untyped
+mongodb_oplog_stats_wt_block_manager_blocks_freed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 23
+# HELP mongodb_oplog_stats_wt_block_manager_checkpoint_size local.oplog.rs.stats.wiredTiger.block-manager.
+# TYPE mongodb_oplog_stats_wt_block_manager_checkpoint_size untyped
+mongodb_oplog_stats_wt_block_manager_checkpoint_size{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 40960
+# HELP mongodb_oplog_stats_wt_block_manager_file_allocation_unit_size local.oplog.rs.stats.wiredTiger.block-manager.
+# TYPE mongodb_oplog_stats_wt_block_manager_file_allocation_unit_size untyped
+mongodb_oplog_stats_wt_block_manager_file_allocation_unit_size{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 4096
+# HELP mongodb_oplog_stats_wt_block_manager_file_bytes_available_for_reuse local.oplog.rs.stats.wiredTiger.block-manager.
+# TYPE mongodb_oplog_stats_wt_block_manager_file_bytes_available_for_reuse untyped
+mongodb_oplog_stats_wt_block_manager_file_bytes_available_for_reuse{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 16384
+# HELP mongodb_oplog_stats_wt_block_manager_file_magic_number local.oplog.rs.stats.wiredTiger.block-manager.
+# TYPE mongodb_oplog_stats_wt_block_manager_file_magic_number untyped
+mongodb_oplog_stats_wt_block_manager_file_magic_number{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 120897
+# HELP mongodb_oplog_stats_wt_block_manager_file_major_version_number local.oplog.rs.stats.wiredTiger.block-manager.
+# TYPE mongodb_oplog_stats_wt_block_manager_file_major_version_number untyped
+mongodb_oplog_stats_wt_block_manager_file_major_version_number{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_oplog_stats_wt_block_manager_file_size_in_bytes local.oplog.rs.stats.wiredTiger.block-manager.
+# TYPE mongodb_oplog_stats_wt_block_manager_file_size_in_bytes untyped
+mongodb_oplog_stats_wt_block_manager_file_size_in_bytes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 73728
+# HELP mongodb_oplog_stats_wt_block_manager_minor_version_number local.oplog.rs.stats.wiredTiger.block-manager.
+# TYPE mongodb_oplog_stats_wt_block_manager_minor_version_number untyped
+mongodb_oplog_stats_wt_block_manager_minor_version_number{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_btree_btree_checkpoint_generation local.oplog.rs.stats.wiredTiger.btree.
+# TYPE mongodb_oplog_stats_wt_btree_btree_checkpoint_generation untyped
+mongodb_oplog_stats_wt_btree_btree_checkpoint_generation{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 24
+# HELP mongodb_oplog_stats_wt_btree_column_store_fixed_size_leaf_pages local.oplog.rs.stats.wiredTiger.btree.
+# TYPE mongodb_oplog_stats_wt_btree_column_store_fixed_size_leaf_pages untyped
+mongodb_oplog_stats_wt_btree_column_store_fixed_size_leaf_pages{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_btree_column_store_internal_pages local.oplog.rs.stats.wiredTiger.btree.
+# TYPE mongodb_oplog_stats_wt_btree_column_store_internal_pages untyped
+mongodb_oplog_stats_wt_btree_column_store_internal_pages{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_btree_column_store_variable_size_RLE_encoded_values local.oplog.rs.stats.wiredTiger.btree.
+# TYPE mongodb_oplog_stats_wt_btree_column_store_variable_size_RLE_encoded_values untyped
+mongodb_oplog_stats_wt_btree_column_store_variable_size_RLE_encoded_values{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_btree_column_store_variable_size_deleted_values local.oplog.rs.stats.wiredTiger.btree.
+# TYPE mongodb_oplog_stats_wt_btree_column_store_variable_size_deleted_values untyped
+mongodb_oplog_stats_wt_btree_column_store_variable_size_deleted_values{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_btree_column_store_variable_size_leaf_pages local.oplog.rs.stats.wiredTiger.btree.
+# TYPE mongodb_oplog_stats_wt_btree_column_store_variable_size_leaf_pages untyped
+mongodb_oplog_stats_wt_btree_column_store_variable_size_leaf_pages{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_btree_fixed_record_size local.oplog.rs.stats.wiredTiger.btree.
+# TYPE mongodb_oplog_stats_wt_btree_fixed_record_size untyped
+mongodb_oplog_stats_wt_btree_fixed_record_size{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_btree_maximum_internal_page_key_size local.oplog.rs.stats.wiredTiger.btree.
+# TYPE mongodb_oplog_stats_wt_btree_maximum_internal_page_key_size untyped
+mongodb_oplog_stats_wt_btree_maximum_internal_page_key_size{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 368
+# HELP mongodb_oplog_stats_wt_btree_maximum_internal_page_size local.oplog.rs.stats.wiredTiger.btree.
+# TYPE mongodb_oplog_stats_wt_btree_maximum_internal_page_size untyped
+mongodb_oplog_stats_wt_btree_maximum_internal_page_size{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 4096
+# HELP mongodb_oplog_stats_wt_btree_maximum_leaf_page_key_size local.oplog.rs.stats.wiredTiger.btree.
+# TYPE mongodb_oplog_stats_wt_btree_maximum_leaf_page_key_size untyped
+mongodb_oplog_stats_wt_btree_maximum_leaf_page_key_size{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 2867
+# HELP mongodb_oplog_stats_wt_btree_maximum_leaf_page_size local.oplog.rs.stats.wiredTiger.btree.
+# TYPE mongodb_oplog_stats_wt_btree_maximum_leaf_page_size untyped
+mongodb_oplog_stats_wt_btree_maximum_leaf_page_size{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 32768
+# HELP mongodb_oplog_stats_wt_btree_maximum_leaf_page_value_size local.oplog.rs.stats.wiredTiger.btree.
+# TYPE mongodb_oplog_stats_wt_btree_maximum_leaf_page_value_size untyped
+mongodb_oplog_stats_wt_btree_maximum_leaf_page_value_size{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 6.7108864e+07
+# HELP mongodb_oplog_stats_wt_btree_maximum_tree_depth local.oplog.rs.stats.wiredTiger.btree.
+# TYPE mongodb_oplog_stats_wt_btree_maximum_tree_depth untyped
+mongodb_oplog_stats_wt_btree_maximum_tree_depth{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 3
+# HELP mongodb_oplog_stats_wt_btree_number_of_key_value_pairs local.oplog.rs.stats.wiredTiger.btree.
+# TYPE mongodb_oplog_stats_wt_btree_number_of_key_value_pairs untyped
+mongodb_oplog_stats_wt_btree_number_of_key_value_pairs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_btree_overflow_pages local.oplog.rs.stats.wiredTiger.btree.
+# TYPE mongodb_oplog_stats_wt_btree_overflow_pages untyped
+mongodb_oplog_stats_wt_btree_overflow_pages{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_btree_pages_rewritten_by_compaction local.oplog.rs.stats.wiredTiger.btree.
+# TYPE mongodb_oplog_stats_wt_btree_pages_rewritten_by_compaction untyped
+mongodb_oplog_stats_wt_btree_pages_rewritten_by_compaction{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_btree_row_store_internal_pages local.oplog.rs.stats.wiredTiger.btree.
+# TYPE mongodb_oplog_stats_wt_btree_row_store_internal_pages untyped
+mongodb_oplog_stats_wt_btree_row_store_internal_pages{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_btree_row_store_leaf_pages local.oplog.rs.stats.wiredTiger.btree.
+# TYPE mongodb_oplog_stats_wt_btree_row_store_leaf_pages untyped
+mongodb_oplog_stats_wt_btree_row_store_leaf_pages{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_bytes_currently_in_the_cache local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_bytes_currently_in_the_cache untyped
+mongodb_oplog_stats_wt_cache_bytes_currently_in_the_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 216318
+# HELP mongodb_oplog_stats_wt_cache_bytes_dirty_in_the_cache_cumulative local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_bytes_dirty_in_the_cache_cumulative untyped
+mongodb_oplog_stats_wt_cache_bytes_dirty_in_the_cache_cumulative{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 14804
+# HELP mongodb_oplog_stats_wt_cache_bytes_read_into_cache local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_bytes_read_into_cache untyped
+mongodb_oplog_stats_wt_cache_bytes_read_into_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 2620
+# HELP mongodb_oplog_stats_wt_cache_bytes_written_from_cache local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_bytes_written_from_cache untyped
+mongodb_oplog_stats_wt_cache_bytes_written_from_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 583281
+# HELP mongodb_oplog_stats_wt_cache_checkpoint_blocked_page_eviction local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_checkpoint_blocked_page_eviction untyped
+mongodb_oplog_stats_wt_cache_checkpoint_blocked_page_eviction{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_data_source_pages_selected_for_eviction_unable_to_be_evicted local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_data_source_pages_selected_for_eviction_unable_to_be_evicted untyped
+mongodb_oplog_stats_wt_cache_data_source_pages_selected_for_eviction_unable_to_be_evicted{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_eviction_walk_passes_of_a_file local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_eviction_walk_passes_of_a_file untyped
+mongodb_oplog_stats_wt_cache_eviction_walk_passes_of_a_file{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_eviction_walk_target_pages_histogram_0_9 local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_eviction_walk_target_pages_histogram_0_9 untyped
+mongodb_oplog_stats_wt_cache_eviction_walk_target_pages_histogram_0_9{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_eviction_walk_target_pages_histogram_10_31 local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_eviction_walk_target_pages_histogram_10_31 untyped
+mongodb_oplog_stats_wt_cache_eviction_walk_target_pages_histogram_10_31{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_eviction_walk_target_pages_histogram_128_and_higher local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_eviction_walk_target_pages_histogram_128_and_higher untyped
+mongodb_oplog_stats_wt_cache_eviction_walk_target_pages_histogram_128_and_higher{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_eviction_walk_target_pages_histogram_32_63 local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_eviction_walk_target_pages_histogram_32_63 untyped
+mongodb_oplog_stats_wt_cache_eviction_walk_target_pages_histogram_32_63{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_eviction_walk_target_pages_histogram_64_128 local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_eviction_walk_target_pages_histogram_64_128 untyped
+mongodb_oplog_stats_wt_cache_eviction_walk_target_pages_histogram_64_128{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_eviction_walks_abandoned local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_eviction_walks_abandoned untyped
+mongodb_oplog_stats_wt_cache_eviction_walks_abandoned{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_eviction_walks_gave_up_because_they_restarted_their_walk_twice local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_eviction_walks_gave_up_because_they_restarted_their_walk_twice untyped
+mongodb_oplog_stats_wt_cache_eviction_walks_gave_up_because_they_restarted_their_walk_twice{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_eviction_walks_gave_up_because_they_saw_too_many_pages_and_found_no_candidates local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_eviction_walks_gave_up_because_they_saw_too_many_pages_and_found_no_candidates untyped
+mongodb_oplog_stats_wt_cache_eviction_walks_gave_up_because_they_saw_too_many_pages_and_found_no_candidates{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_eviction_walks_gave_up_because_they_saw_too_many_pages_and_found_too_few_candidates local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_eviction_walks_gave_up_because_they_saw_too_many_pages_and_found_too_few_candidates untyped
+mongodb_oplog_stats_wt_cache_eviction_walks_gave_up_because_they_saw_too_many_pages_and_found_too_few_candidates{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_eviction_walks_reached_end_of_tree local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_eviction_walks_reached_end_of_tree untyped
+mongodb_oplog_stats_wt_cache_eviction_walks_reached_end_of_tree{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_eviction_walks_started_from_root_of_tree local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_eviction_walks_started_from_root_of_tree untyped
+mongodb_oplog_stats_wt_cache_eviction_walks_started_from_root_of_tree{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_eviction_walks_started_from_saved_location_in_tree local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_eviction_walks_started_from_saved_location_in_tree untyped
+mongodb_oplog_stats_wt_cache_eviction_walks_started_from_saved_location_in_tree{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_hazard_pointer_blocked_page_eviction local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_hazard_pointer_blocked_page_eviction untyped
+mongodb_oplog_stats_wt_cache_hazard_pointer_blocked_page_eviction{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_in_memory_page_passed_criteria_to_be_split local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_in_memory_page_passed_criteria_to_be_split untyped
+mongodb_oplog_stats_wt_cache_in_memory_page_passed_criteria_to_be_split{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_in_memory_page_splits local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_in_memory_page_splits untyped
+mongodb_oplog_stats_wt_cache_in_memory_page_splits{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_internal_pages_evicted local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_internal_pages_evicted untyped
+mongodb_oplog_stats_wt_cache_internal_pages_evicted{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_internal_pages_split_during_eviction local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_internal_pages_split_during_eviction untyped
+mongodb_oplog_stats_wt_cache_internal_pages_split_during_eviction{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_leaf_pages_split_during_eviction local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_leaf_pages_split_during_eviction untyped
+mongodb_oplog_stats_wt_cache_leaf_pages_split_during_eviction{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_modified_pages_evicted local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_modified_pages_evicted untyped
+mongodb_oplog_stats_wt_cache_modified_pages_evicted{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_overflow_pages_read_into_cache local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_overflow_pages_read_into_cache untyped
+mongodb_oplog_stats_wt_cache_overflow_pages_read_into_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_page_split_during_eviction_deepened_the_tree local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_page_split_during_eviction_deepened_the_tree untyped
+mongodb_oplog_stats_wt_cache_page_split_during_eviction_deepened_the_tree{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_page_written_requiring_cache_overflow_records local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_page_written_requiring_cache_overflow_records untyped
+mongodb_oplog_stats_wt_cache_page_written_requiring_cache_overflow_records{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_pages_read_into_cache local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_pages_read_into_cache untyped
+mongodb_oplog_stats_wt_cache_pages_read_into_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 2
+# HELP mongodb_oplog_stats_wt_cache_pages_read_into_cache_after_truncate local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_pages_read_into_cache_after_truncate untyped
+mongodb_oplog_stats_wt_cache_pages_read_into_cache_after_truncate{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_pages_read_into_cache_after_truncate_in_prepare_state local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_pages_read_into_cache_after_truncate_in_prepare_state untyped
+mongodb_oplog_stats_wt_cache_pages_read_into_cache_after_truncate_in_prepare_state{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_pages_read_into_cache_requiring_cache_overflow_entries local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_pages_read_into_cache_requiring_cache_overflow_entries untyped
+mongodb_oplog_stats_wt_cache_pages_read_into_cache_requiring_cache_overflow_entries{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_pages_requested_from_the_cache local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_pages_requested_from_the_cache untyped
+mongodb_oplog_stats_wt_cache_pages_requested_from_the_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 2240
+# HELP mongodb_oplog_stats_wt_cache_pages_seen_by_eviction_walk local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_pages_seen_by_eviction_walk untyped
+mongodb_oplog_stats_wt_cache_pages_seen_by_eviction_walk{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_pages_written_from_cache local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_pages_written_from_cache untyped
+mongodb_oplog_stats_wt_cache_pages_written_from_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 50
+# HELP mongodb_oplog_stats_wt_cache_pages_written_requiring_in_memory_restoration local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_pages_written_requiring_in_memory_restoration untyped
+mongodb_oplog_stats_wt_cache_pages_written_requiring_in_memory_restoration{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_tracked_dirty_bytes_in_the_cache local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_tracked_dirty_bytes_in_the_cache untyped
+mongodb_oplog_stats_wt_cache_tracked_dirty_bytes_in_the_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 215814
+# HELP mongodb_oplog_stats_wt_cache_unmodified_pages_evicted local.oplog.rs.stats.wiredTiger.cache.
+# TYPE mongodb_oplog_stats_wt_cache_unmodified_pages_evicted untyped
+mongodb_oplog_stats_wt_cache_unmodified_pages_evicted{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_walk_Average_difference_between_current_eviction_generation_when_the_page_was_last_considered local.oplog.rs.stats.wiredTiger.cache_walk.
+# TYPE mongodb_oplog_stats_wt_cache_walk_Average_difference_between_current_eviction_generation_when_the_page_was_last_considered untyped
+mongodb_oplog_stats_wt_cache_walk_Average_difference_between_current_eviction_generation_when_the_page_was_last_considered{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_walk_Average_on_disk_page_image_size_seen local.oplog.rs.stats.wiredTiger.cache_walk.
+# TYPE mongodb_oplog_stats_wt_cache_walk_Average_on_disk_page_image_size_seen untyped
+mongodb_oplog_stats_wt_cache_walk_Average_on_disk_page_image_size_seen{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_walk_Average_time_in_cache_for_pages_that_have_been_visited_by_the_eviction_server local.oplog.rs.stats.wiredTiger.cache_walk.
+# TYPE mongodb_oplog_stats_wt_cache_walk_Average_time_in_cache_for_pages_that_have_been_visited_by_the_eviction_server untyped
+mongodb_oplog_stats_wt_cache_walk_Average_time_in_cache_for_pages_that_have_been_visited_by_the_eviction_server{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_walk_Average_time_in_cache_for_pages_that_have_not_been_visited_by_the_eviction_server local.oplog.rs.stats.wiredTiger.cache_walk.
+# TYPE mongodb_oplog_stats_wt_cache_walk_Average_time_in_cache_for_pages_that_have_not_been_visited_by_the_eviction_server untyped
+mongodb_oplog_stats_wt_cache_walk_Average_time_in_cache_for_pages_that_have_not_been_visited_by_the_eviction_server{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_walk_Clean_pages_currently_in_cache local.oplog.rs.stats.wiredTiger.cache_walk.
+# TYPE mongodb_oplog_stats_wt_cache_walk_Clean_pages_currently_in_cache untyped
+mongodb_oplog_stats_wt_cache_walk_Clean_pages_currently_in_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_walk_Current_eviction_generation local.oplog.rs.stats.wiredTiger.cache_walk.
+# TYPE mongodb_oplog_stats_wt_cache_walk_Current_eviction_generation untyped
+mongodb_oplog_stats_wt_cache_walk_Current_eviction_generation{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_walk_Dirty_pages_currently_in_cache local.oplog.rs.stats.wiredTiger.cache_walk.
+# TYPE mongodb_oplog_stats_wt_cache_walk_Dirty_pages_currently_in_cache untyped
+mongodb_oplog_stats_wt_cache_walk_Dirty_pages_currently_in_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_walk_Entries_in_the_root_page local.oplog.rs.stats.wiredTiger.cache_walk.
+# TYPE mongodb_oplog_stats_wt_cache_walk_Entries_in_the_root_page untyped
+mongodb_oplog_stats_wt_cache_walk_Entries_in_the_root_page{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_walk_Internal_pages_currently_in_cache local.oplog.rs.stats.wiredTiger.cache_walk.
+# TYPE mongodb_oplog_stats_wt_cache_walk_Internal_pages_currently_in_cache untyped
+mongodb_oplog_stats_wt_cache_walk_Internal_pages_currently_in_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_walk_Leaf_pages_currently_in_cache local.oplog.rs.stats.wiredTiger.cache_walk.
+# TYPE mongodb_oplog_stats_wt_cache_walk_Leaf_pages_currently_in_cache untyped
+mongodb_oplog_stats_wt_cache_walk_Leaf_pages_currently_in_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_walk_Maximum_difference_between_current_eviction_generation_when_the_page_was_last_considered local.oplog.rs.stats.wiredTiger.cache_walk.
+# TYPE mongodb_oplog_stats_wt_cache_walk_Maximum_difference_between_current_eviction_generation_when_the_page_was_last_considered untyped
+mongodb_oplog_stats_wt_cache_walk_Maximum_difference_between_current_eviction_generation_when_the_page_was_last_considered{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_walk_Maximum_page_size_seen local.oplog.rs.stats.wiredTiger.cache_walk.
+# TYPE mongodb_oplog_stats_wt_cache_walk_Maximum_page_size_seen untyped
+mongodb_oplog_stats_wt_cache_walk_Maximum_page_size_seen{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_walk_Minimum_on_disk_page_image_size_seen local.oplog.rs.stats.wiredTiger.cache_walk.
+# TYPE mongodb_oplog_stats_wt_cache_walk_Minimum_on_disk_page_image_size_seen untyped
+mongodb_oplog_stats_wt_cache_walk_Minimum_on_disk_page_image_size_seen{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_walk_Number_of_pages_never_visited_by_eviction_server local.oplog.rs.stats.wiredTiger.cache_walk.
+# TYPE mongodb_oplog_stats_wt_cache_walk_Number_of_pages_never_visited_by_eviction_server untyped
+mongodb_oplog_stats_wt_cache_walk_Number_of_pages_never_visited_by_eviction_server{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_walk_On_disk_page_image_sizes_smaller_than_a_single_allocation_unit local.oplog.rs.stats.wiredTiger.cache_walk.
+# TYPE mongodb_oplog_stats_wt_cache_walk_On_disk_page_image_sizes_smaller_than_a_single_allocation_unit untyped
+mongodb_oplog_stats_wt_cache_walk_On_disk_page_image_sizes_smaller_than_a_single_allocation_unit{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_walk_Pages_created_in_memory_and_never_written local.oplog.rs.stats.wiredTiger.cache_walk.
+# TYPE mongodb_oplog_stats_wt_cache_walk_Pages_created_in_memory_and_never_written untyped
+mongodb_oplog_stats_wt_cache_walk_Pages_created_in_memory_and_never_written{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_walk_Pages_currently_queued_for_eviction local.oplog.rs.stats.wiredTiger.cache_walk.
+# TYPE mongodb_oplog_stats_wt_cache_walk_Pages_currently_queued_for_eviction untyped
+mongodb_oplog_stats_wt_cache_walk_Pages_currently_queued_for_eviction{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_walk_Pages_that_could_not_be_queued_for_eviction local.oplog.rs.stats.wiredTiger.cache_walk.
+# TYPE mongodb_oplog_stats_wt_cache_walk_Pages_that_could_not_be_queued_for_eviction untyped
+mongodb_oplog_stats_wt_cache_walk_Pages_that_could_not_be_queued_for_eviction{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_walk_Refs_skipped_during_cache_traversal local.oplog.rs.stats.wiredTiger.cache_walk.
+# TYPE mongodb_oplog_stats_wt_cache_walk_Refs_skipped_during_cache_traversal untyped
+mongodb_oplog_stats_wt_cache_walk_Refs_skipped_during_cache_traversal{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_walk_Size_of_the_root_page local.oplog.rs.stats.wiredTiger.cache_walk.
+# TYPE mongodb_oplog_stats_wt_cache_walk_Size_of_the_root_page untyped
+mongodb_oplog_stats_wt_cache_walk_Size_of_the_root_page{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cache_walk_Total_number_of_pages_currently_in_cache local.oplog.rs.stats.wiredTiger.cache_walk.
+# TYPE mongodb_oplog_stats_wt_cache_walk_Total_number_of_pages_currently_in_cache untyped
+mongodb_oplog_stats_wt_cache_walk_Total_number_of_pages_currently_in_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_compression_compressed_pages_read local.oplog.rs.stats.wiredTiger.compression.
+# TYPE mongodb_oplog_stats_wt_compression_compressed_pages_read untyped
+mongodb_oplog_stats_wt_compression_compressed_pages_read{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_compression_compressed_pages_written local.oplog.rs.stats.wiredTiger.compression.
+# TYPE mongodb_oplog_stats_wt_compression_compressed_pages_written untyped
+mongodb_oplog_stats_wt_compression_compressed_pages_written{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 26
+# HELP mongodb_oplog_stats_wt_compression_page_written_failed_to_compress local.oplog.rs.stats.wiredTiger.compression.
+# TYPE mongodb_oplog_stats_wt_compression_page_written_failed_to_compress untyped
+mongodb_oplog_stats_wt_compression_page_written_failed_to_compress{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_compression_page_written_was_too_small_to_compress local.oplog.rs.stats.wiredTiger.compression.
+# TYPE mongodb_oplog_stats_wt_compression_page_written_was_too_small_to_compress untyped
+mongodb_oplog_stats_wt_compression_page_written_was_too_small_to_compress{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 24
+# HELP mongodb_oplog_stats_wt_cursor_bulk_loaded_cursor_insert_calls local.oplog.rs.stats.wiredTiger.cursor.
+# TYPE mongodb_oplog_stats_wt_cursor_bulk_loaded_cursor_insert_calls untyped
+mongodb_oplog_stats_wt_cursor_bulk_loaded_cursor_insert_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cursor_close_calls_that_result_in_cache local.oplog.rs.stats.wiredTiger.cursor.
+# TYPE mongodb_oplog_stats_wt_cursor_close_calls_that_result_in_cache untyped
+mongodb_oplog_stats_wt_cursor_close_calls_that_result_in_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cursor_create_calls local.oplog.rs.stats.wiredTiger.cursor.
+# TYPE mongodb_oplog_stats_wt_cursor_create_calls untyped
+mongodb_oplog_stats_wt_cursor_create_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 3
+# HELP mongodb_oplog_stats_wt_cursor_cursor_insert_key_and_value_bytes_inserted local.oplog.rs.stats.wiredTiger.cursor.
+# TYPE mongodb_oplog_stats_wt_cursor_cursor_insert_key_and_value_bytes_inserted untyped
+mongodb_oplog_stats_wt_cursor_cursor_insert_key_and_value_bytes_inserted{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 144857
+# HELP mongodb_oplog_stats_wt_cursor_cursor_operation_restarted local.oplog.rs.stats.wiredTiger.cursor.
+# TYPE mongodb_oplog_stats_wt_cursor_cursor_operation_restarted untyped
+mongodb_oplog_stats_wt_cursor_cursor_operation_restarted{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cursor_cursor_remove_key_bytes_removed local.oplog.rs.stats.wiredTiger.cursor.
+# TYPE mongodb_oplog_stats_wt_cursor_cursor_remove_key_bytes_removed untyped
+mongodb_oplog_stats_wt_cursor_cursor_remove_key_bytes_removed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cursor_cursor_update_value_bytes_updated local.oplog.rs.stats.wiredTiger.cursor.
+# TYPE mongodb_oplog_stats_wt_cursor_cursor_update_value_bytes_updated untyped
+mongodb_oplog_stats_wt_cursor_cursor_update_value_bytes_updated{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cursor_cursors_reused_from_cache local.oplog.rs.stats.wiredTiger.cursor.
+# TYPE mongodb_oplog_stats_wt_cursor_cursors_reused_from_cache untyped
+mongodb_oplog_stats_wt_cursor_cursors_reused_from_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1215
+# HELP mongodb_oplog_stats_wt_cursor_insert_calls local.oplog.rs.stats.wiredTiger.cursor.
+# TYPE mongodb_oplog_stats_wt_cursor_insert_calls untyped
+mongodb_oplog_stats_wt_cursor_insert_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 611
+# HELP mongodb_oplog_stats_wt_cursor_modify_calls local.oplog.rs.stats.wiredTiger.cursor.
+# TYPE mongodb_oplog_stats_wt_cursor_modify_calls untyped
+mongodb_oplog_stats_wt_cursor_modify_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cursor_next_calls local.oplog.rs.stats.wiredTiger.cursor.
+# TYPE mongodb_oplog_stats_wt_cursor_next_calls untyped
+mongodb_oplog_stats_wt_cursor_next_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 552
+# HELP mongodb_oplog_stats_wt_cursor_open_cursor_count local.oplog.rs.stats.wiredTiger.cursor.
+# TYPE mongodb_oplog_stats_wt_cursor_open_cursor_count counter
+mongodb_oplog_stats_wt_cursor_open_cursor_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cursor_prev_calls local.oplog.rs.stats.wiredTiger.cursor.
+# TYPE mongodb_oplog_stats_wt_cursor_prev_calls untyped
+mongodb_oplog_stats_wt_cursor_prev_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1087
+# HELP mongodb_oplog_stats_wt_cursor_remove_calls local.oplog.rs.stats.wiredTiger.cursor.
+# TYPE mongodb_oplog_stats_wt_cursor_remove_calls untyped
+mongodb_oplog_stats_wt_cursor_remove_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cursor_reserve_calls local.oplog.rs.stats.wiredTiger.cursor.
+# TYPE mongodb_oplog_stats_wt_cursor_reserve_calls untyped
+mongodb_oplog_stats_wt_cursor_reserve_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cursor_reset_calls local.oplog.rs.stats.wiredTiger.cursor.
+# TYPE mongodb_oplog_stats_wt_cursor_reset_calls untyped
+mongodb_oplog_stats_wt_cursor_reset_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 3999
+# HELP mongodb_oplog_stats_wt_cursor_search_calls local.oplog.rs.stats.wiredTiger.cursor.
+# TYPE mongodb_oplog_stats_wt_cursor_search_calls untyped
+mongodb_oplog_stats_wt_cursor_search_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cursor_search_near_calls local.oplog.rs.stats.wiredTiger.cursor.
+# TYPE mongodb_oplog_stats_wt_cursor_search_near_calls untyped
+mongodb_oplog_stats_wt_cursor_search_near_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cursor_truncate_calls local.oplog.rs.stats.wiredTiger.cursor.
+# TYPE mongodb_oplog_stats_wt_cursor_truncate_calls untyped
+mongodb_oplog_stats_wt_cursor_truncate_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_cursor_update_calls local.oplog.rs.stats.wiredTiger.cursor.
+# TYPE mongodb_oplog_stats_wt_cursor_update_calls untyped
+mongodb_oplog_stats_wt_cursor_update_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_metadata_formatVersion local.oplog.rs.stats.wiredTiger.metadata.
+# TYPE mongodb_oplog_stats_wt_metadata_formatVersion untyped
+mongodb_oplog_stats_wt_metadata_formatVersion{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_oplog_stats_wt_metadata_oplogKeyExtractionVersion local.oplog.rs.stats.wiredTiger.metadata.
+# TYPE mongodb_oplog_stats_wt_metadata_oplogKeyExtractionVersion untyped
+mongodb_oplog_stats_wt_metadata_oplogKeyExtractionVersion{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_oplog_stats_wt_reconciliation_dictionary_matches local.oplog.rs.stats.wiredTiger.reconciliation.
+# TYPE mongodb_oplog_stats_wt_reconciliation_dictionary_matches untyped
+mongodb_oplog_stats_wt_reconciliation_dictionary_matches{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_reconciliation_fast_path_pages_deleted local.oplog.rs.stats.wiredTiger.reconciliation.
+# TYPE mongodb_oplog_stats_wt_reconciliation_fast_path_pages_deleted untyped
+mongodb_oplog_stats_wt_reconciliation_fast_path_pages_deleted{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_reconciliation_internal_page_key_bytes_discarded_using_suffix_compression local.oplog.rs.stats.wiredTiger.reconciliation.
+# TYPE mongodb_oplog_stats_wt_reconciliation_internal_page_key_bytes_discarded_using_suffix_compression untyped
+mongodb_oplog_stats_wt_reconciliation_internal_page_key_bytes_discarded_using_suffix_compression{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 117
+# HELP mongodb_oplog_stats_wt_reconciliation_internal_page_multi_block_writes local.oplog.rs.stats.wiredTiger.reconciliation.
+# TYPE mongodb_oplog_stats_wt_reconciliation_internal_page_multi_block_writes untyped
+mongodb_oplog_stats_wt_reconciliation_internal_page_multi_block_writes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_reconciliation_internal_page_overflow_keys local.oplog.rs.stats.wiredTiger.reconciliation.
+# TYPE mongodb_oplog_stats_wt_reconciliation_internal_page_overflow_keys untyped
+mongodb_oplog_stats_wt_reconciliation_internal_page_overflow_keys{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_reconciliation_leaf_page_key_bytes_discarded_using_prefix_compression local.oplog.rs.stats.wiredTiger.reconciliation.
+# TYPE mongodb_oplog_stats_wt_reconciliation_leaf_page_key_bytes_discarded_using_prefix_compression untyped
+mongodb_oplog_stats_wt_reconciliation_leaf_page_key_bytes_discarded_using_prefix_compression{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_reconciliation_leaf_page_multi_block_writes local.oplog.rs.stats.wiredTiger.reconciliation.
+# TYPE mongodb_oplog_stats_wt_reconciliation_leaf_page_multi_block_writes untyped
+mongodb_oplog_stats_wt_reconciliation_leaf_page_multi_block_writes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 18
+# HELP mongodb_oplog_stats_wt_reconciliation_leaf_page_overflow_keys local.oplog.rs.stats.wiredTiger.reconciliation.
+# TYPE mongodb_oplog_stats_wt_reconciliation_leaf_page_overflow_keys untyped
+mongodb_oplog_stats_wt_reconciliation_leaf_page_overflow_keys{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_reconciliation_maximum_blocks_required_for_a_page local.oplog.rs.stats.wiredTiger.reconciliation.
+# TYPE mongodb_oplog_stats_wt_reconciliation_maximum_blocks_required_for_a_page untyped
+mongodb_oplog_stats_wt_reconciliation_maximum_blocks_required_for_a_page{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_oplog_stats_wt_reconciliation_overflow_values_written local.oplog.rs.stats.wiredTiger.reconciliation.
+# TYPE mongodb_oplog_stats_wt_reconciliation_overflow_values_written untyped
+mongodb_oplog_stats_wt_reconciliation_overflow_values_written{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_reconciliation_page_checksum_matches local.oplog.rs.stats.wiredTiger.reconciliation.
+# TYPE mongodb_oplog_stats_wt_reconciliation_page_checksum_matches untyped
+mongodb_oplog_stats_wt_reconciliation_page_checksum_matches{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 39
+# HELP mongodb_oplog_stats_wt_reconciliation_page_reconciliation_calls local.oplog.rs.stats.wiredTiger.reconciliation.
+# TYPE mongodb_oplog_stats_wt_reconciliation_page_reconciliation_calls untyped
+mongodb_oplog_stats_wt_reconciliation_page_reconciliation_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 44
+# HELP mongodb_oplog_stats_wt_reconciliation_page_reconciliation_calls_for_eviction local.oplog.rs.stats.wiredTiger.reconciliation.
+# TYPE mongodb_oplog_stats_wt_reconciliation_page_reconciliation_calls_for_eviction untyped
+mongodb_oplog_stats_wt_reconciliation_page_reconciliation_calls_for_eviction{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_reconciliation_pages_deleted local.oplog.rs.stats.wiredTiger.reconciliation.
+# TYPE mongodb_oplog_stats_wt_reconciliation_pages_deleted untyped
+mongodb_oplog_stats_wt_reconciliation_pages_deleted{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_session_object_compaction local.oplog.rs.stats.wiredTiger.session.
+# TYPE mongodb_oplog_stats_wt_session_object_compaction untyped
+mongodb_oplog_stats_wt_session_object_compaction{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_oplog_stats_wt_transaction_update_conflicts local.oplog.rs.stats.wiredTiger.transaction.
+# TYPE mongodb_oplog_stats_wt_transaction_update_conflicts untyped
+mongodb_oplog_stats_wt_transaction_update_conflicts{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_optimes_appliedOpTime_t optimes.appliedOpTime.
+# TYPE mongodb_optimes_appliedOpTime_t untyped
+mongodb_optimes_appliedOpTime_t{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 3
+# HELP mongodb_optimes_durableOpTime_t optimes.durableOpTime.
+# TYPE mongodb_optimes_durableOpTime_t untyped
+mongodb_optimes_durableOpTime_t{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 3
+# HELP mongodb_optimes_lastCommittedOpTime_t optimes.lastCommittedOpTime.
+# TYPE mongodb_optimes_lastCommittedOpTime_t untyped
+mongodb_optimes_lastCommittedOpTime_t{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 3
+# HELP mongodb_optimes_readConcernMajorityOpTime_t optimes.readConcernMajorityOpTime.
+# TYPE mongodb_optimes_readConcernMajorityOpTime_t untyped
+mongodb_optimes_readConcernMajorityOpTime_t{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 3
+# HELP mongodb_rs_date replSetGetStatus.
+# TYPE mongodb_rs_date untyped
+mongodb_rs_date{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.666193406001e+12
+# HELP mongodb_rs_electionCandidateMetrics_electionTerm replSetGetStatus.electionCandidateMetrics.
+# TYPE mongodb_rs_electionCandidateMetrics_electionTerm untyped
+mongodb_rs_electionCandidateMetrics_electionTerm{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 3
+# HELP mongodb_rs_electionCandidateMetrics_electionTimeoutMillis replSetGetStatus.electionCandidateMetrics.
+# TYPE mongodb_rs_electionCandidateMetrics_electionTimeoutMillis untyped
+mongodb_rs_electionCandidateMetrics_electionTimeoutMillis{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 10000
+# HELP mongodb_rs_electionCandidateMetrics_lastCommittedOpTimeAtElection_t replSetGetStatus.electionCandidateMetrics.lastCommittedOpTimeAtElection.
+# TYPE mongodb_rs_electionCandidateMetrics_lastCommittedOpTimeAtElection_t untyped
+mongodb_rs_electionCandidateMetrics_lastCommittedOpTimeAtElection_t{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} -1
+# HELP mongodb_rs_electionCandidateMetrics_lastElectionDate replSetGetStatus.electionCandidateMetrics.
+# TYPE mongodb_rs_electionCandidateMetrics_lastElectionDate untyped
+mongodb_rs_electionCandidateMetrics_lastElectionDate{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.666192064201e+12
+# HELP mongodb_rs_electionCandidateMetrics_lastSeenOpTimeAtElection_t replSetGetStatus.electionCandidateMetrics.lastSeenOpTimeAtElection.
+# TYPE mongodb_rs_electionCandidateMetrics_lastSeenOpTimeAtElection_t untyped
+mongodb_rs_electionCandidateMetrics_lastSeenOpTimeAtElection_t{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 2
+# HELP mongodb_rs_electionCandidateMetrics_newTermStartDate replSetGetStatus.electionCandidateMetrics.
+# TYPE mongodb_rs_electionCandidateMetrics_newTermStartDate untyped
+mongodb_rs_electionCandidateMetrics_newTermStartDate{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.666192066201e+12
+# HELP mongodb_rs_electionCandidateMetrics_numVotesNeeded replSetGetStatus.electionCandidateMetrics.
+# TYPE mongodb_rs_electionCandidateMetrics_numVotesNeeded untyped
+mongodb_rs_electionCandidateMetrics_numVotesNeeded{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_rs_electionCandidateMetrics_priorityAtElection replSetGetStatus.electionCandidateMetrics.
+# TYPE mongodb_rs_electionCandidateMetrics_priorityAtElection untyped
+mongodb_rs_electionCandidateMetrics_priorityAtElection{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 5
+# HELP mongodb_rs_electionCandidateMetrics_wMajorityWriteAvailabilityDate replSetGetStatus.electionCandidateMetrics.
+# TYPE mongodb_rs_electionCandidateMetrics_wMajorityWriteAvailabilityDate untyped
+mongodb_rs_electionCandidateMetrics_wMajorityWriteAvailabilityDate{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.666192066284e+12
+# HELP mongodb_rs_end replSetGetStatus.
+# TYPE mongodb_rs_end untyped
+mongodb_rs_end{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.666193406001e+12
+# HELP mongodb_rs_heartbeatIntervalMillis replSetGetStatus.
+# TYPE mongodb_rs_heartbeatIntervalMillis untyped
+mongodb_rs_heartbeatIntervalMillis{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 2000
+# HELP mongodb_rs_members_configVersion replSetGetStatus.members.
+# TYPE mongodb_rs_members_configVersion untyped
+mongodb_rs_members_configVersion{cl_id="6350129adfb0b7e3db4773bb",cl_role="",member_idx="dev-db-mongodb-primary-0.dev-db-mongodb-headless.default.svc.cluster.local:27017",member_state="PRIMARY",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_rs_members_electionDate replSetGetStatus.members.
+# TYPE mongodb_rs_members_electionDate untyped
+mongodb_rs_members_electionDate{cl_id="6350129adfb0b7e3db4773bb",cl_role="",member_idx="dev-db-mongodb-primary-0.dev-db-mongodb-headless.default.svc.cluster.local:27017",member_state="PRIMARY",rs_nm="rs0",rs_state="1"} 1.666192064e+12
+# HELP mongodb_rs_members_health replSetGetStatus.members.
+# TYPE mongodb_rs_members_health untyped
+mongodb_rs_members_health{cl_id="6350129adfb0b7e3db4773bb",cl_role="",member_idx="dev-db-mongodb-primary-0.dev-db-mongodb-headless.default.svc.cluster.local:27017",member_state="PRIMARY",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_rs_members_id replSetGetStatus.members.
+# TYPE mongodb_rs_members_id untyped
+mongodb_rs_members_id{cl_id="6350129adfb0b7e3db4773bb",cl_role="",member_idx="dev-db-mongodb-primary-0.dev-db-mongodb-headless.default.svc.cluster.local:27017",member_state="PRIMARY",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_rs_members_optimeDate replSetGetStatus.members.
+# TYPE mongodb_rs_members_optimeDate untyped
+mongodb_rs_members_optimeDate{cl_id="6350129adfb0b7e3db4773bb",cl_role="",member_idx="dev-db-mongodb-primary-0.dev-db-mongodb-headless.default.svc.cluster.local:27017",member_state="PRIMARY",rs_nm="rs0",rs_state="1"} 1.666193396e+12
+# HELP mongodb_rs_members_optime_t replSetGetStatus.members.optime.
+# TYPE mongodb_rs_members_optime_t untyped
+mongodb_rs_members_optime_t{cl_id="6350129adfb0b7e3db4773bb",cl_role="",member_idx="dev-db-mongodb-primary-0.dev-db-mongodb-headless.default.svc.cluster.local:27017",member_state="PRIMARY",rs_nm="rs0",rs_state="1"} 3
+# HELP mongodb_rs_members_self replSetGetStatus.members.
+# TYPE mongodb_rs_members_self untyped
+mongodb_rs_members_self{cl_id="6350129adfb0b7e3db4773bb",cl_role="",member_idx="dev-db-mongodb-primary-0.dev-db-mongodb-headless.default.svc.cluster.local:27017",member_state="PRIMARY",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_rs_members_state replSetGetStatus.members.
+# TYPE mongodb_rs_members_state untyped
+mongodb_rs_members_state{cl_id="6350129adfb0b7e3db4773bb",cl_role="",member_idx="dev-db-mongodb-primary-0.dev-db-mongodb-headless.default.svc.cluster.local:27017",member_state="PRIMARY",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_rs_members_syncSourceId replSetGetStatus.members.
+# TYPE mongodb_rs_members_syncSourceId untyped
+mongodb_rs_members_syncSourceId{cl_id="6350129adfb0b7e3db4773bb",cl_role="",member_idx="dev-db-mongodb-primary-0.dev-db-mongodb-headless.default.svc.cluster.local:27017",member_state="PRIMARY",rs_nm="rs0",rs_state="1"} -1
+# HELP mongodb_rs_members_uptime replSetGetStatus.members.
+# TYPE mongodb_rs_members_uptime untyped
+mongodb_rs_members_uptime{cl_id="6350129adfb0b7e3db4773bb",cl_role="",member_idx="dev-db-mongodb-primary-0.dev-db-mongodb-headless.default.svc.cluster.local:27017",member_state="PRIMARY",rs_nm="rs0",rs_state="1"} 1342
+# HELP mongodb_rs_myState replSetGetStatus.
+# TYPE mongodb_rs_myState untyped
+mongodb_rs_myState{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_rs_ok replSetGetStatus.
+# TYPE mongodb_rs_ok untyped
+mongodb_rs_ok{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_rs_optimes_appliedOpTime_t replSetGetStatus.optimes.appliedOpTime.
+# TYPE mongodb_rs_optimes_appliedOpTime_t untyped
+mongodb_rs_optimes_appliedOpTime_t{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 3
+# HELP mongodb_rs_optimes_durableOpTime_t replSetGetStatus.optimes.durableOpTime.
+# TYPE mongodb_rs_optimes_durableOpTime_t untyped
+mongodb_rs_optimes_durableOpTime_t{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 3
+# HELP mongodb_rs_optimes_lastCommittedOpTime_t replSetGetStatus.optimes.lastCommittedOpTime.
+# TYPE mongodb_rs_optimes_lastCommittedOpTime_t untyped
+mongodb_rs_optimes_lastCommittedOpTime_t{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 3
+# HELP mongodb_rs_optimes_readConcernMajorityOpTime_t replSetGetStatus.optimes.readConcernMajorityOpTime.
+# TYPE mongodb_rs_optimes_readConcernMajorityOpTime_t untyped
+mongodb_rs_optimes_readConcernMajorityOpTime_t{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 3
+# HELP mongodb_rs_start replSetGetStatus.
+# TYPE mongodb_rs_start untyped
+mongodb_rs_start{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.666193406001e+12
+# HELP mongodb_rs_syncSourceId replSetGetStatus.
+# TYPE mongodb_rs_syncSourceId untyped
+mongodb_rs_syncSourceId{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} -1
+# HELP mongodb_rs_term replSetGetStatus.
+# TYPE mongodb_rs_term untyped
+mongodb_rs_term{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 3
+# HELP mongodb_ss_asserts serverStatus.asserts.
+# TYPE mongodb_ss_asserts untyped
+mongodb_ss_asserts{assert_type="msg",cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_asserts{assert_type="regular",cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_asserts{assert_type="rollovers",cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_asserts{assert_type="user",cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 137
+mongodb_ss_asserts{assert_type="warning",cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_connections serverStatus.connections.
+# TYPE mongodb_ss_connections untyped
+mongodb_ss_connections{cl_id="6350129adfb0b7e3db4773bb",cl_role="",conn_type="active",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_connections{cl_id="6350129adfb0b7e3db4773bb",cl_role="",conn_type="available",rs_nm="rs0",rs_state="1"} 817
+mongodb_ss_connections{cl_id="6350129adfb0b7e3db4773bb",cl_role="",conn_type="current",rs_nm="rs0",rs_state="1"} 2
+mongodb_ss_connections{cl_id="6350129adfb0b7e3db4773bb",cl_role="",conn_type="totalCreated",rs_nm="rs0",rs_state="1"} 1764
+# HELP mongodb_ss_electionMetrics_averageCatchUpOps serverStatus.electionMetrics.
+# TYPE mongodb_ss_electionMetrics_averageCatchUpOps untyped
+mongodb_ss_electionMetrics_averageCatchUpOps{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_electionMetrics_catchUpTakeover_called serverStatus.electionMetrics.catchUpTakeover.
+# TYPE mongodb_ss_electionMetrics_catchUpTakeover_called untyped
+mongodb_ss_electionMetrics_catchUpTakeover_called{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_electionMetrics_catchUpTakeover_successful serverStatus.electionMetrics.catchUpTakeover.
+# TYPE mongodb_ss_electionMetrics_catchUpTakeover_successful untyped
+mongodb_ss_electionMetrics_catchUpTakeover_successful{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_electionMetrics_electionTimeout_called serverStatus.electionMetrics.electionTimeout.
+# TYPE mongodb_ss_electionMetrics_electionTimeout_called untyped
+mongodb_ss_electionMetrics_electionTimeout_called{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_ss_electionMetrics_electionTimeout_successful serverStatus.electionMetrics.electionTimeout.
+# TYPE mongodb_ss_electionMetrics_electionTimeout_successful untyped
+mongodb_ss_electionMetrics_electionTimeout_successful{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_ss_electionMetrics_freezeTimeout_called serverStatus.electionMetrics.freezeTimeout.
+# TYPE mongodb_ss_electionMetrics_freezeTimeout_called untyped
+mongodb_ss_electionMetrics_freezeTimeout_called{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_electionMetrics_freezeTimeout_successful serverStatus.electionMetrics.freezeTimeout.
+# TYPE mongodb_ss_electionMetrics_freezeTimeout_successful untyped
+mongodb_ss_electionMetrics_freezeTimeout_successful{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_electionMetrics_numCatchUps serverStatus.electionMetrics.
+# TYPE mongodb_ss_electionMetrics_numCatchUps untyped
+mongodb_ss_electionMetrics_numCatchUps{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_electionMetrics_numCatchUpsAlreadyCaughtUp serverStatus.electionMetrics.
+# TYPE mongodb_ss_electionMetrics_numCatchUpsAlreadyCaughtUp untyped
+mongodb_ss_electionMetrics_numCatchUpsAlreadyCaughtUp{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_electionMetrics_numCatchUpsFailedWithError serverStatus.electionMetrics.
+# TYPE mongodb_ss_electionMetrics_numCatchUpsFailedWithError untyped
+mongodb_ss_electionMetrics_numCatchUpsFailedWithError{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_electionMetrics_numCatchUpsFailedWithNewTerm serverStatus.electionMetrics.
+# TYPE mongodb_ss_electionMetrics_numCatchUpsFailedWithNewTerm untyped
+mongodb_ss_electionMetrics_numCatchUpsFailedWithNewTerm{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_electionMetrics_numCatchUpsFailedWithReplSetAbortPrimaryCatchUpCmd serverStatus.electionMetrics.
+# TYPE mongodb_ss_electionMetrics_numCatchUpsFailedWithReplSetAbortPrimaryCatchUpCmd untyped
+mongodb_ss_electionMetrics_numCatchUpsFailedWithReplSetAbortPrimaryCatchUpCmd{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_electionMetrics_numCatchUpsSkipped serverStatus.electionMetrics.
+# TYPE mongodb_ss_electionMetrics_numCatchUpsSkipped untyped
+mongodb_ss_electionMetrics_numCatchUpsSkipped{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_ss_electionMetrics_numCatchUpsSucceeded serverStatus.electionMetrics.
+# TYPE mongodb_ss_electionMetrics_numCatchUpsSucceeded untyped
+mongodb_ss_electionMetrics_numCatchUpsSucceeded{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_electionMetrics_numCatchUpsTimedOut serverStatus.electionMetrics.
+# TYPE mongodb_ss_electionMetrics_numCatchUpsTimedOut untyped
+mongodb_ss_electionMetrics_numCatchUpsTimedOut{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_electionMetrics_numStepDownsCausedByHigherTerm serverStatus.electionMetrics.
+# TYPE mongodb_ss_electionMetrics_numStepDownsCausedByHigherTerm untyped
+mongodb_ss_electionMetrics_numStepDownsCausedByHigherTerm{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_electionMetrics_priorityTakeover_called serverStatus.electionMetrics.priorityTakeover.
+# TYPE mongodb_ss_electionMetrics_priorityTakeover_called untyped
+mongodb_ss_electionMetrics_priorityTakeover_called{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_electionMetrics_priorityTakeover_successful serverStatus.electionMetrics.priorityTakeover.
+# TYPE mongodb_ss_electionMetrics_priorityTakeover_successful untyped
+mongodb_ss_electionMetrics_priorityTakeover_successful{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_electionMetrics_stepUpCmd_called serverStatus.electionMetrics.stepUpCmd.
+# TYPE mongodb_ss_electionMetrics_stepUpCmd_called untyped
+mongodb_ss_electionMetrics_stepUpCmd_called{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_electionMetrics_stepUpCmd_successful serverStatus.electionMetrics.stepUpCmd.
+# TYPE mongodb_ss_electionMetrics_stepUpCmd_successful untyped
+mongodb_ss_electionMetrics_stepUpCmd_successful{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_end serverStatus.
+# TYPE mongodb_ss_end untyped
+mongodb_ss_end{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.666193406001e+12
+# HELP mongodb_ss_extra_info_page_faults serverStatus.extra_info.
+# TYPE mongodb_ss_extra_info_page_faults untyped
+mongodb_ss_extra_info_page_faults{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_globalLock_activeClients_readers serverStatus.globalLock.activeClients.
+# TYPE mongodb_ss_globalLock_activeClients_readers untyped
+mongodb_ss_globalLock_activeClients_readers{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_globalLock_activeClients_total serverStatus.globalLock.activeClients.
+# TYPE mongodb_ss_globalLock_activeClients_total untyped
+mongodb_ss_globalLock_activeClients_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 42
+# HELP mongodb_ss_globalLock_activeClients_writers serverStatus.globalLock.activeClients.
+# TYPE mongodb_ss_globalLock_activeClients_writers untyped
+mongodb_ss_globalLock_activeClients_writers{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_globalLock_currentQueue serverStatus.globalLock.currentQueue.
+# TYPE mongodb_ss_globalLock_currentQueue untyped
+mongodb_ss_globalLock_currentQueue{cl_id="6350129adfb0b7e3db4773bb",cl_role="",count_type="readers",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_globalLock_currentQueue{cl_id="6350129adfb0b7e3db4773bb",cl_role="",count_type="total",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_globalLock_currentQueue{cl_id="6350129adfb0b7e3db4773bb",cl_role="",count_type="writers",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_globalLock_totalTime serverStatus.globalLock.
+# TYPE mongodb_ss_globalLock_totalTime untyped
+mongodb_ss_globalLock_totalTime{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.342715e+09
+# HELP mongodb_ss_localTime serverStatus.
+# TYPE mongodb_ss_localTime untyped
+mongodb_ss_localTime{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.666193406e+12
+# HELP mongodb_ss_locks_Collection_acquireCount_W serverStatus.locks.Collection.acquireCount.
+# TYPE mongodb_ss_locks_Collection_acquireCount_W untyped
+mongodb_ss_locks_Collection_acquireCount_W{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_ss_locks_Collection_acquireCount_r serverStatus.locks.Collection.acquireCount.
+# TYPE mongodb_ss_locks_Collection_acquireCount_r untyped
+mongodb_ss_locks_Collection_acquireCount_r{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 13606
+# HELP mongodb_ss_locks_Collection_acquireCount_w serverStatus.locks.Collection.acquireCount.
+# TYPE mongodb_ss_locks_Collection_acquireCount_w untyped
+mongodb_ss_locks_Collection_acquireCount_w{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 507
+# HELP mongodb_ss_locks_Database_acquireCount_R serverStatus.locks.Database.acquireCount.
+# TYPE mongodb_ss_locks_Database_acquireCount_R untyped
+mongodb_ss_locks_Database_acquireCount_R{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 3
+# HELP mongodb_ss_locks_Database_acquireCount_W serverStatus.locks.Database.acquireCount.
+# TYPE mongodb_ss_locks_Database_acquireCount_W untyped
+mongodb_ss_locks_Database_acquireCount_W{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 22
+# HELP mongodb_ss_locks_Database_acquireCount_r serverStatus.locks.Database.acquireCount.
+# TYPE mongodb_ss_locks_Database_acquireCount_r untyped
+mongodb_ss_locks_Database_acquireCount_r{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 14756
+# HELP mongodb_ss_locks_Database_acquireCount_w serverStatus.locks.Database.acquireCount.
+# TYPE mongodb_ss_locks_Database_acquireCount_w untyped
+mongodb_ss_locks_Database_acquireCount_w{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 509
+# HELP mongodb_ss_locks_Database_acquireWaitCount_r serverStatus.locks.Database.acquireWaitCount.
+# TYPE mongodb_ss_locks_Database_acquireWaitCount_r untyped
+mongodb_ss_locks_Database_acquireWaitCount_r{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_ss_locks_Database_timeAcquiringMicros_r serverStatus.locks.Database.timeAcquiringMicros.
+# TYPE mongodb_ss_locks_Database_timeAcquiringMicros_r untyped
+mongodb_ss_locks_Database_timeAcquiringMicros_r{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 96
+# HELP mongodb_ss_locks_Global_acquireCount_W serverStatus.locks.Global.acquireCount.
+# TYPE mongodb_ss_locks_Global_acquireCount_W untyped
+mongodb_ss_locks_Global_acquireCount_W{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 7
+# HELP mongodb_ss_locks_Global_acquireCount_r serverStatus.locks.Global.acquireCount.
+# TYPE mongodb_ss_locks_Global_acquireCount_r untyped
+mongodb_ss_locks_Global_acquireCount_r{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 26093
+# HELP mongodb_ss_locks_Global_acquireCount_w serverStatus.locks.Global.acquireCount.
+# TYPE mongodb_ss_locks_Global_acquireCount_w untyped
+mongodb_ss_locks_Global_acquireCount_w{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 665
+# HELP mongodb_ss_locks_Global_acquireWaitCount_W serverStatus.locks.Global.acquireWaitCount.
+# TYPE mongodb_ss_locks_Global_acquireWaitCount_W untyped
+mongodb_ss_locks_Global_acquireWaitCount_W{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_ss_locks_Global_acquireWaitCount_r serverStatus.locks.Global.acquireWaitCount.
+# TYPE mongodb_ss_locks_Global_acquireWaitCount_r untyped
+mongodb_ss_locks_Global_acquireWaitCount_r{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 3
+# HELP mongodb_ss_locks_Global_timeAcquiringMicros_W serverStatus.locks.Global.timeAcquiringMicros.
+# TYPE mongodb_ss_locks_Global_timeAcquiringMicros_W untyped
+mongodb_ss_locks_Global_timeAcquiringMicros_W{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 88
+# HELP mongodb_ss_locks_Global_timeAcquiringMicros_r serverStatus.locks.Global.timeAcquiringMicros.
+# TYPE mongodb_ss_locks_Global_timeAcquiringMicros_r untyped
+mongodb_ss_locks_Global_timeAcquiringMicros_r{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1612
+# HELP mongodb_ss_locks_acquireCount mongodb_ss_locks_acquireCount
+# TYPE mongodb_ss_locks_acquireCount untyped
+mongodb_ss_locks_acquireCount{lock_mode="W",resource="Global"} 7
+mongodb_ss_locks_acquireCount{lock_mode="r",resource="Global"} 26093
+mongodb_ss_locks_acquireCount{lock_mode="w",resource="Global"} 665
+# HELP mongodb_ss_locks_oplog_acquireCount_r serverStatus.locks.oplog.acquireCount.
+# TYPE mongodb_ss_locks_oplog_acquireCount_r untyped
+mongodb_ss_locks_oplog_acquireCount_r{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 6019
+# HELP mongodb_ss_locks_oplog_acquireCount_w serverStatus.locks.oplog.acquireCount.
+# TYPE mongodb_ss_locks_oplog_acquireCount_w untyped
+mongodb_ss_locks_oplog_acquireCount_w{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_ss_logicalSessionRecordCache_activeSessionsCount serverStatus.logicalSessionRecordCache.
+# TYPE mongodb_ss_logicalSessionRecordCache_activeSessionsCount counter
+mongodb_ss_logicalSessionRecordCache_activeSessionsCount{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 61
+# HELP mongodb_ss_logicalSessionRecordCache_lastSessionsCollectionJobCursorsClosed serverStatus.logicalSessionRecordCache.
+# TYPE mongodb_ss_logicalSessionRecordCache_lastSessionsCollectionJobCursorsClosed untyped
+mongodb_ss_logicalSessionRecordCache_lastSessionsCollectionJobCursorsClosed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_logicalSessionRecordCache_lastSessionsCollectionJobDurationMillis serverStatus.logicalSessionRecordCache.
+# TYPE mongodb_ss_logicalSessionRecordCache_lastSessionsCollectionJobDurationMillis untyped
+mongodb_ss_logicalSessionRecordCache_lastSessionsCollectionJobDurationMillis{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 6
+# HELP mongodb_ss_logicalSessionRecordCache_lastSessionsCollectionJobEntriesEnded serverStatus.logicalSessionRecordCache.
+# TYPE mongodb_ss_logicalSessionRecordCache_lastSessionsCollectionJobEntriesEnded untyped
+mongodb_ss_logicalSessionRecordCache_lastSessionsCollectionJobEntriesEnded{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_ss_logicalSessionRecordCache_lastSessionsCollectionJobEntriesRefreshed serverStatus.logicalSessionRecordCache.
+# TYPE mongodb_ss_logicalSessionRecordCache_lastSessionsCollectionJobEntriesRefreshed untyped
+mongodb_ss_logicalSessionRecordCache_lastSessionsCollectionJobEntriesRefreshed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 120
+# HELP mongodb_ss_logicalSessionRecordCache_lastSessionsCollectionJobTimestamp serverStatus.logicalSessionRecordCache.
+# TYPE mongodb_ss_logicalSessionRecordCache_lastSessionsCollectionJobTimestamp untyped
+mongodb_ss_logicalSessionRecordCache_lastSessionsCollectionJobTimestamp{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.666193264199e+12
+# HELP mongodb_ss_logicalSessionRecordCache_lastTransactionReaperJobDurationMillis serverStatus.logicalSessionRecordCache.
+# TYPE mongodb_ss_logicalSessionRecordCache_lastTransactionReaperJobDurationMillis untyped
+mongodb_ss_logicalSessionRecordCache_lastTransactionReaperJobDurationMillis{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_logicalSessionRecordCache_lastTransactionReaperJobEntriesCleanedUp serverStatus.logicalSessionRecordCache.
+# TYPE mongodb_ss_logicalSessionRecordCache_lastTransactionReaperJobEntriesCleanedUp untyped
+mongodb_ss_logicalSessionRecordCache_lastTransactionReaperJobEntriesCleanedUp{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_logicalSessionRecordCache_lastTransactionReaperJobTimestamp serverStatus.logicalSessionRecordCache.
+# TYPE mongodb_ss_logicalSessionRecordCache_lastTransactionReaperJobTimestamp untyped
+mongodb_ss_logicalSessionRecordCache_lastTransactionReaperJobTimestamp{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.666193264199e+12
+# HELP mongodb_ss_logicalSessionRecordCache_sessionsCollectionJobCount serverStatus.logicalSessionRecordCache.
+# TYPE mongodb_ss_logicalSessionRecordCache_sessionsCollectionJobCount counter
+mongodb_ss_logicalSessionRecordCache_sessionsCollectionJobCount{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 5
+# HELP mongodb_ss_logicalSessionRecordCache_transactionReaperJobCount serverStatus.logicalSessionRecordCache.
+# TYPE mongodb_ss_logicalSessionRecordCache_transactionReaperJobCount counter
+mongodb_ss_logicalSessionRecordCache_transactionReaperJobCount{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 5
+# HELP mongodb_ss_mem_bits serverStatus.mem.
+# TYPE mongodb_ss_mem_bits untyped
+mongodb_ss_mem_bits{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 64
+# HELP mongodb_ss_mem_mapped serverStatus.mem.
+# TYPE mongodb_ss_mem_mapped untyped
+mongodb_ss_mem_mapped{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_mem_mappedWithJournal serverStatus.mem.
+# TYPE mongodb_ss_mem_mappedWithJournal untyped
+mongodb_ss_mem_mappedWithJournal{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_mem_resident serverStatus.mem.
+# TYPE mongodb_ss_mem_resident untyped
+mongodb_ss_mem_resident{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 80
+# HELP mongodb_ss_mem_supported serverStatus.mem.
+# TYPE mongodb_ss_mem_supported untyped
+mongodb_ss_mem_supported{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_ss_mem_virtual serverStatus.mem.
+# TYPE mongodb_ss_mem_virtual untyped
+mongodb_ss_mem_virtual{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1357
+# HELP mongodb_ss_metrics_commands serverStatus.metrics.commands.
+# TYPE mongodb_ss_metrics_commands untyped
+mongodb_ss_metrics_commands{cl_id="6350129adfb0b7e3db4773bb",cl_role="",cmd_name="<UNKNOWN>",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_abortTransaction_failed serverStatus.metrics.commands.abortTransaction.
+# TYPE mongodb_ss_metrics_commands_abortTransaction_failed untyped
+mongodb_ss_metrics_commands_abortTransaction_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_abortTransaction_total serverStatus.metrics.commands.abortTransaction.
+# TYPE mongodb_ss_metrics_commands_abortTransaction_total untyped
+mongodb_ss_metrics_commands_abortTransaction_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_aggregate_failed serverStatus.metrics.commands.aggregate.
+# TYPE mongodb_ss_metrics_commands_aggregate_failed untyped
+mongodb_ss_metrics_commands_aggregate_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_aggregate_total serverStatus.metrics.commands.aggregate.
+# TYPE mongodb_ss_metrics_commands_aggregate_total untyped
+mongodb_ss_metrics_commands_aggregate_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_appendOplogNote_failed serverStatus.metrics.commands.appendOplogNote.
+# TYPE mongodb_ss_metrics_commands_appendOplogNote_failed untyped
+mongodb_ss_metrics_commands_appendOplogNote_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_appendOplogNote_total serverStatus.metrics.commands.appendOplogNote.
+# TYPE mongodb_ss_metrics_commands_appendOplogNote_total untyped
+mongodb_ss_metrics_commands_appendOplogNote_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_applyOps_failed serverStatus.metrics.commands.applyOps.
+# TYPE mongodb_ss_metrics_commands_applyOps_failed untyped
+mongodb_ss_metrics_commands_applyOps_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_applyOps_total serverStatus.metrics.commands.applyOps.
+# TYPE mongodb_ss_metrics_commands_applyOps_total untyped
+mongodb_ss_metrics_commands_applyOps_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_authenticate_failed serverStatus.metrics.commands.authenticate.
+# TYPE mongodb_ss_metrics_commands_authenticate_failed untyped
+mongodb_ss_metrics_commands_authenticate_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_authenticate_total serverStatus.metrics.commands.authenticate.
+# TYPE mongodb_ss_metrics_commands_authenticate_total untyped
+mongodb_ss_metrics_commands_authenticate_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_availableQueryOptions_failed serverStatus.metrics.commands.availableQueryOptions.
+# TYPE mongodb_ss_metrics_commands_availableQueryOptions_failed untyped
+mongodb_ss_metrics_commands_availableQueryOptions_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_availableQueryOptions_total serverStatus.metrics.commands.availableQueryOptions.
+# TYPE mongodb_ss_metrics_commands_availableQueryOptions_total untyped
+mongodb_ss_metrics_commands_availableQueryOptions_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_buildInfo_failed serverStatus.metrics.commands.buildInfo.
+# TYPE mongodb_ss_metrics_commands_buildInfo_failed untyped
+mongodb_ss_metrics_commands_buildInfo_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_buildInfo_total serverStatus.metrics.commands.buildInfo.
+# TYPE mongodb_ss_metrics_commands_buildInfo_total untyped
+mongodb_ss_metrics_commands_buildInfo_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 134
+# HELP mongodb_ss_metrics_commands_checkShardingIndex_failed serverStatus.metrics.commands.checkShardingIndex.
+# TYPE mongodb_ss_metrics_commands_checkShardingIndex_failed untyped
+mongodb_ss_metrics_commands_checkShardingIndex_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_checkShardingIndex_total serverStatus.metrics.commands.checkShardingIndex.
+# TYPE mongodb_ss_metrics_commands_checkShardingIndex_total untyped
+mongodb_ss_metrics_commands_checkShardingIndex_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_cleanupOrphaned_failed serverStatus.metrics.commands.cleanupOrphaned.
+# TYPE mongodb_ss_metrics_commands_cleanupOrphaned_failed untyped
+mongodb_ss_metrics_commands_cleanupOrphaned_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_cleanupOrphaned_total serverStatus.metrics.commands.cleanupOrphaned.
+# TYPE mongodb_ss_metrics_commands_cleanupOrphaned_total untyped
+mongodb_ss_metrics_commands_cleanupOrphaned_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_cloneCatalogData_failed serverStatus.metrics.commands._cloneCatalogData.
+# TYPE mongodb_ss_metrics_commands_cloneCatalogData_failed untyped
+mongodb_ss_metrics_commands_cloneCatalogData_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_cloneCatalogData_total serverStatus.metrics.commands._cloneCatalogData.
+# TYPE mongodb_ss_metrics_commands_cloneCatalogData_total untyped
+mongodb_ss_metrics_commands_cloneCatalogData_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_cloneCollectionAsCapped_failed serverStatus.metrics.commands.cloneCollectionAsCapped.
+# TYPE mongodb_ss_metrics_commands_cloneCollectionAsCapped_failed untyped
+mongodb_ss_metrics_commands_cloneCollectionAsCapped_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_cloneCollectionAsCapped_total serverStatus.metrics.commands.cloneCollectionAsCapped.
+# TYPE mongodb_ss_metrics_commands_cloneCollectionAsCapped_total untyped
+mongodb_ss_metrics_commands_cloneCollectionAsCapped_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_cloneCollectionOptionsFromPrimaryShard_failed serverStatus.metrics.commands._cloneCollectionOptionsFromPrimaryShard.
+# TYPE mongodb_ss_metrics_commands_cloneCollectionOptionsFromPrimaryShard_failed untyped
+mongodb_ss_metrics_commands_cloneCollectionOptionsFromPrimaryShard_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_cloneCollectionOptionsFromPrimaryShard_total serverStatus.metrics.commands._cloneCollectionOptionsFromPrimaryShard.
+# TYPE mongodb_ss_metrics_commands_cloneCollectionOptionsFromPrimaryShard_total untyped
+mongodb_ss_metrics_commands_cloneCollectionOptionsFromPrimaryShard_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_cloneCollection_failed serverStatus.metrics.commands.cloneCollection.
+# TYPE mongodb_ss_metrics_commands_cloneCollection_failed untyped
+mongodb_ss_metrics_commands_cloneCollection_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_cloneCollection_total serverStatus.metrics.commands.cloneCollection.
+# TYPE mongodb_ss_metrics_commands_cloneCollection_total untyped
+mongodb_ss_metrics_commands_cloneCollection_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_clone_failed serverStatus.metrics.commands.clone.
+# TYPE mongodb_ss_metrics_commands_clone_failed untyped
+mongodb_ss_metrics_commands_clone_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_clone_total serverStatus.metrics.commands.clone.
+# TYPE mongodb_ss_metrics_commands_clone_total untyped
+mongodb_ss_metrics_commands_clone_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_collMod_failed serverStatus.metrics.commands.collMod.
+# TYPE mongodb_ss_metrics_commands_collMod_failed untyped
+mongodb_ss_metrics_commands_collMod_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_collMod_total serverStatus.metrics.commands.collMod.
+# TYPE mongodb_ss_metrics_commands_collMod_total untyped
+mongodb_ss_metrics_commands_collMod_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_collStats_failed serverStatus.metrics.commands.collStats.
+# TYPE mongodb_ss_metrics_commands_collStats_failed untyped
+mongodb_ss_metrics_commands_collStats_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_collStats_total serverStatus.metrics.commands.collStats.
+# TYPE mongodb_ss_metrics_commands_collStats_total untyped
+mongodb_ss_metrics_commands_collStats_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_commitTransaction_failed serverStatus.metrics.commands.commitTransaction.
+# TYPE mongodb_ss_metrics_commands_commitTransaction_failed untyped
+mongodb_ss_metrics_commands_commitTransaction_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_commitTransaction_total serverStatus.metrics.commands.commitTransaction.
+# TYPE mongodb_ss_metrics_commands_commitTransaction_total untyped
+mongodb_ss_metrics_commands_commitTransaction_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_compact_failed serverStatus.metrics.commands.compact.
+# TYPE mongodb_ss_metrics_commands_compact_failed untyped
+mongodb_ss_metrics_commands_compact_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_compact_total serverStatus.metrics.commands.compact.
+# TYPE mongodb_ss_metrics_commands_compact_total untyped
+mongodb_ss_metrics_commands_compact_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrAddShardToZone_failed serverStatus.metrics.commands._configsvrAddShardToZone.
+# TYPE mongodb_ss_metrics_commands_configsvrAddShardToZone_failed untyped
+mongodb_ss_metrics_commands_configsvrAddShardToZone_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrAddShardToZone_total serverStatus.metrics.commands._configsvrAddShardToZone.
+# TYPE mongodb_ss_metrics_commands_configsvrAddShardToZone_total untyped
+mongodb_ss_metrics_commands_configsvrAddShardToZone_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrAddShard_failed serverStatus.metrics.commands._configsvrAddShard.
+# TYPE mongodb_ss_metrics_commands_configsvrAddShard_failed untyped
+mongodb_ss_metrics_commands_configsvrAddShard_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrAddShard_total serverStatus.metrics.commands._configsvrAddShard.
+# TYPE mongodb_ss_metrics_commands_configsvrAddShard_total untyped
+mongodb_ss_metrics_commands_configsvrAddShard_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrBalancerStart_failed serverStatus.metrics.commands._configsvrBalancerStart.
+# TYPE mongodb_ss_metrics_commands_configsvrBalancerStart_failed untyped
+mongodb_ss_metrics_commands_configsvrBalancerStart_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrBalancerStart_total serverStatus.metrics.commands._configsvrBalancerStart.
+# TYPE mongodb_ss_metrics_commands_configsvrBalancerStart_total untyped
+mongodb_ss_metrics_commands_configsvrBalancerStart_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrBalancerStatus_failed serverStatus.metrics.commands._configsvrBalancerStatus.
+# TYPE mongodb_ss_metrics_commands_configsvrBalancerStatus_failed untyped
+mongodb_ss_metrics_commands_configsvrBalancerStatus_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrBalancerStatus_total serverStatus.metrics.commands._configsvrBalancerStatus.
+# TYPE mongodb_ss_metrics_commands_configsvrBalancerStatus_total untyped
+mongodb_ss_metrics_commands_configsvrBalancerStatus_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrBalancerStop_failed serverStatus.metrics.commands._configsvrBalancerStop.
+# TYPE mongodb_ss_metrics_commands_configsvrBalancerStop_failed untyped
+mongodb_ss_metrics_commands_configsvrBalancerStop_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrBalancerStop_total serverStatus.metrics.commands._configsvrBalancerStop.
+# TYPE mongodb_ss_metrics_commands_configsvrBalancerStop_total untyped
+mongodb_ss_metrics_commands_configsvrBalancerStop_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrCommitChunkMerge_failed serverStatus.metrics.commands._configsvrCommitChunkMerge.
+# TYPE mongodb_ss_metrics_commands_configsvrCommitChunkMerge_failed untyped
+mongodb_ss_metrics_commands_configsvrCommitChunkMerge_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrCommitChunkMerge_total serverStatus.metrics.commands._configsvrCommitChunkMerge.
+# TYPE mongodb_ss_metrics_commands_configsvrCommitChunkMerge_total untyped
+mongodb_ss_metrics_commands_configsvrCommitChunkMerge_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrCommitChunkMigration_failed serverStatus.metrics.commands._configsvrCommitChunkMigration.
+# TYPE mongodb_ss_metrics_commands_configsvrCommitChunkMigration_failed untyped
+mongodb_ss_metrics_commands_configsvrCommitChunkMigration_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrCommitChunkMigration_total serverStatus.metrics.commands._configsvrCommitChunkMigration.
+# TYPE mongodb_ss_metrics_commands_configsvrCommitChunkMigration_total untyped
+mongodb_ss_metrics_commands_configsvrCommitChunkMigration_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrCommitChunkSplit_failed serverStatus.metrics.commands._configsvrCommitChunkSplit.
+# TYPE mongodb_ss_metrics_commands_configsvrCommitChunkSplit_failed untyped
+mongodb_ss_metrics_commands_configsvrCommitChunkSplit_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrCommitChunkSplit_total serverStatus.metrics.commands._configsvrCommitChunkSplit.
+# TYPE mongodb_ss_metrics_commands_configsvrCommitChunkSplit_total untyped
+mongodb_ss_metrics_commands_configsvrCommitChunkSplit_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrCommitMovePrimary_failed serverStatus.metrics.commands._configsvrCommitMovePrimary.
+# TYPE mongodb_ss_metrics_commands_configsvrCommitMovePrimary_failed untyped
+mongodb_ss_metrics_commands_configsvrCommitMovePrimary_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrCommitMovePrimary_total serverStatus.metrics.commands._configsvrCommitMovePrimary.
+# TYPE mongodb_ss_metrics_commands_configsvrCommitMovePrimary_total untyped
+mongodb_ss_metrics_commands_configsvrCommitMovePrimary_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrCreateCollection_failed serverStatus.metrics.commands._configsvrCreateCollection.
+# TYPE mongodb_ss_metrics_commands_configsvrCreateCollection_failed untyped
+mongodb_ss_metrics_commands_configsvrCreateCollection_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrCreateCollection_total serverStatus.metrics.commands._configsvrCreateCollection.
+# TYPE mongodb_ss_metrics_commands_configsvrCreateCollection_total untyped
+mongodb_ss_metrics_commands_configsvrCreateCollection_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrCreateDatabase_failed serverStatus.metrics.commands._configsvrCreateDatabase.
+# TYPE mongodb_ss_metrics_commands_configsvrCreateDatabase_failed untyped
+mongodb_ss_metrics_commands_configsvrCreateDatabase_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrCreateDatabase_total serverStatus.metrics.commands._configsvrCreateDatabase.
+# TYPE mongodb_ss_metrics_commands_configsvrCreateDatabase_total untyped
+mongodb_ss_metrics_commands_configsvrCreateDatabase_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrDropCollection_failed serverStatus.metrics.commands._configsvrDropCollection.
+# TYPE mongodb_ss_metrics_commands_configsvrDropCollection_failed untyped
+mongodb_ss_metrics_commands_configsvrDropCollection_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrDropCollection_total serverStatus.metrics.commands._configsvrDropCollection.
+# TYPE mongodb_ss_metrics_commands_configsvrDropCollection_total untyped
+mongodb_ss_metrics_commands_configsvrDropCollection_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrDropDatabase_failed serverStatus.metrics.commands._configsvrDropDatabase.
+# TYPE mongodb_ss_metrics_commands_configsvrDropDatabase_failed untyped
+mongodb_ss_metrics_commands_configsvrDropDatabase_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrDropDatabase_total serverStatus.metrics.commands._configsvrDropDatabase.
+# TYPE mongodb_ss_metrics_commands_configsvrDropDatabase_total untyped
+mongodb_ss_metrics_commands_configsvrDropDatabase_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrEnableSharding_failed serverStatus.metrics.commands._configsvrEnableSharding.
+# TYPE mongodb_ss_metrics_commands_configsvrEnableSharding_failed untyped
+mongodb_ss_metrics_commands_configsvrEnableSharding_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrEnableSharding_total serverStatus.metrics.commands._configsvrEnableSharding.
+# TYPE mongodb_ss_metrics_commands_configsvrEnableSharding_total untyped
+mongodb_ss_metrics_commands_configsvrEnableSharding_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrMoveChunk_failed serverStatus.metrics.commands._configsvrMoveChunk.
+# TYPE mongodb_ss_metrics_commands_configsvrMoveChunk_failed untyped
+mongodb_ss_metrics_commands_configsvrMoveChunk_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrMoveChunk_total serverStatus.metrics.commands._configsvrMoveChunk.
+# TYPE mongodb_ss_metrics_commands_configsvrMoveChunk_total untyped
+mongodb_ss_metrics_commands_configsvrMoveChunk_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrMovePrimary_failed serverStatus.metrics.commands._configsvrMovePrimary.
+# TYPE mongodb_ss_metrics_commands_configsvrMovePrimary_failed untyped
+mongodb_ss_metrics_commands_configsvrMovePrimary_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrMovePrimary_total serverStatus.metrics.commands._configsvrMovePrimary.
+# TYPE mongodb_ss_metrics_commands_configsvrMovePrimary_total untyped
+mongodb_ss_metrics_commands_configsvrMovePrimary_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrRemoveShardFromZone_failed serverStatus.metrics.commands._configsvrRemoveShardFromZone.
+# TYPE mongodb_ss_metrics_commands_configsvrRemoveShardFromZone_failed untyped
+mongodb_ss_metrics_commands_configsvrRemoveShardFromZone_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrRemoveShardFromZone_total serverStatus.metrics.commands._configsvrRemoveShardFromZone.
+# TYPE mongodb_ss_metrics_commands_configsvrRemoveShardFromZone_total untyped
+mongodb_ss_metrics_commands_configsvrRemoveShardFromZone_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrRemoveShard_failed serverStatus.metrics.commands._configsvrRemoveShard.
+# TYPE mongodb_ss_metrics_commands_configsvrRemoveShard_failed untyped
+mongodb_ss_metrics_commands_configsvrRemoveShard_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrRemoveShard_total serverStatus.metrics.commands._configsvrRemoveShard.
+# TYPE mongodb_ss_metrics_commands_configsvrRemoveShard_total untyped
+mongodb_ss_metrics_commands_configsvrRemoveShard_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrShardCollection_failed serverStatus.metrics.commands._configsvrShardCollection.
+# TYPE mongodb_ss_metrics_commands_configsvrShardCollection_failed untyped
+mongodb_ss_metrics_commands_configsvrShardCollection_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrShardCollection_total serverStatus.metrics.commands._configsvrShardCollection.
+# TYPE mongodb_ss_metrics_commands_configsvrShardCollection_total untyped
+mongodb_ss_metrics_commands_configsvrShardCollection_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrUpdateZoneKeyRange_failed serverStatus.metrics.commands._configsvrUpdateZoneKeyRange.
+# TYPE mongodb_ss_metrics_commands_configsvrUpdateZoneKeyRange_failed untyped
+mongodb_ss_metrics_commands_configsvrUpdateZoneKeyRange_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_configsvrUpdateZoneKeyRange_total serverStatus.metrics.commands._configsvrUpdateZoneKeyRange.
+# TYPE mongodb_ss_metrics_commands_configsvrUpdateZoneKeyRange_total untyped
+mongodb_ss_metrics_commands_configsvrUpdateZoneKeyRange_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_connPoolStats_failed serverStatus.metrics.commands.connPoolStats.
+# TYPE mongodb_ss_metrics_commands_connPoolStats_failed untyped
+mongodb_ss_metrics_commands_connPoolStats_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_connPoolStats_total serverStatus.metrics.commands.connPoolStats.
+# TYPE mongodb_ss_metrics_commands_connPoolStats_total untyped
+mongodb_ss_metrics_commands_connPoolStats_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_connPoolSync_failed serverStatus.metrics.commands.connPoolSync.
+# TYPE mongodb_ss_metrics_commands_connPoolSync_failed untyped
+mongodb_ss_metrics_commands_connPoolSync_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_connPoolSync_total serverStatus.metrics.commands.connPoolSync.
+# TYPE mongodb_ss_metrics_commands_connPoolSync_total untyped
+mongodb_ss_metrics_commands_connPoolSync_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_connectionStatus_failed serverStatus.metrics.commands.connectionStatus.
+# TYPE mongodb_ss_metrics_commands_connectionStatus_failed untyped
+mongodb_ss_metrics_commands_connectionStatus_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_connectionStatus_total serverStatus.metrics.commands.connectionStatus.
+# TYPE mongodb_ss_metrics_commands_connectionStatus_total untyped
+mongodb_ss_metrics_commands_connectionStatus_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_convertToCapped_failed serverStatus.metrics.commands.convertToCapped.
+# TYPE mongodb_ss_metrics_commands_convertToCapped_failed untyped
+mongodb_ss_metrics_commands_convertToCapped_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_convertToCapped_total serverStatus.metrics.commands.convertToCapped.
+# TYPE mongodb_ss_metrics_commands_convertToCapped_total untyped
+mongodb_ss_metrics_commands_convertToCapped_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_copydb_failed serverStatus.metrics.commands.copydb.
+# TYPE mongodb_ss_metrics_commands_copydb_failed untyped
+mongodb_ss_metrics_commands_copydb_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_copydb_total serverStatus.metrics.commands.copydb.
+# TYPE mongodb_ss_metrics_commands_copydb_total untyped
+mongodb_ss_metrics_commands_copydb_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_copydbsaslstart_failed serverStatus.metrics.commands.copydbsaslstart.
+# TYPE mongodb_ss_metrics_commands_copydbsaslstart_failed untyped
+mongodb_ss_metrics_commands_copydbsaslstart_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_copydbsaslstart_total serverStatus.metrics.commands.copydbsaslstart.
+# TYPE mongodb_ss_metrics_commands_copydbsaslstart_total untyped
+mongodb_ss_metrics_commands_copydbsaslstart_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_count_failed serverStatus.metrics.commands.count.
+# TYPE mongodb_ss_metrics_commands_count_failed untyped
+mongodb_ss_metrics_commands_count_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_count_total serverStatus.metrics.commands.count.
+# TYPE mongodb_ss_metrics_commands_count_total untyped
+mongodb_ss_metrics_commands_count_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_createIndexes_failed serverStatus.metrics.commands.createIndexes.
+# TYPE mongodb_ss_metrics_commands_createIndexes_failed untyped
+mongodb_ss_metrics_commands_createIndexes_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_createIndexes_total serverStatus.metrics.commands.createIndexes.
+# TYPE mongodb_ss_metrics_commands_createIndexes_total untyped
+mongodb_ss_metrics_commands_createIndexes_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_createRole_failed serverStatus.metrics.commands.createRole.
+# TYPE mongodb_ss_metrics_commands_createRole_failed untyped
+mongodb_ss_metrics_commands_createRole_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_createRole_total serverStatus.metrics.commands.createRole.
+# TYPE mongodb_ss_metrics_commands_createRole_total untyped
+mongodb_ss_metrics_commands_createRole_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_createUser_failed serverStatus.metrics.commands.createUser.
+# TYPE mongodb_ss_metrics_commands_createUser_failed untyped
+mongodb_ss_metrics_commands_createUser_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_createUser_total serverStatus.metrics.commands.createUser.
+# TYPE mongodb_ss_metrics_commands_createUser_total untyped
+mongodb_ss_metrics_commands_createUser_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_create_failed serverStatus.metrics.commands.create.
+# TYPE mongodb_ss_metrics_commands_create_failed untyped
+mongodb_ss_metrics_commands_create_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_ss_metrics_commands_create_total serverStatus.metrics.commands.create.
+# TYPE mongodb_ss_metrics_commands_create_total untyped
+mongodb_ss_metrics_commands_create_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_ss_metrics_commands_currentOp_failed serverStatus.metrics.commands.currentOp.
+# TYPE mongodb_ss_metrics_commands_currentOp_failed untyped
+mongodb_ss_metrics_commands_currentOp_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_currentOp_total serverStatus.metrics.commands.currentOp.
+# TYPE mongodb_ss_metrics_commands_currentOp_total untyped
+mongodb_ss_metrics_commands_currentOp_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_dataSize_failed serverStatus.metrics.commands.dataSize.
+# TYPE mongodb_ss_metrics_commands_dataSize_failed untyped
+mongodb_ss_metrics_commands_dataSize_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_dataSize_total serverStatus.metrics.commands.dataSize.
+# TYPE mongodb_ss_metrics_commands_dataSize_total untyped
+mongodb_ss_metrics_commands_dataSize_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_dbHash_failed serverStatus.metrics.commands.dbHash.
+# TYPE mongodb_ss_metrics_commands_dbHash_failed untyped
+mongodb_ss_metrics_commands_dbHash_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_dbHash_total serverStatus.metrics.commands.dbHash.
+# TYPE mongodb_ss_metrics_commands_dbHash_total untyped
+mongodb_ss_metrics_commands_dbHash_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_dbStats_failed serverStatus.metrics.commands.dbStats.
+# TYPE mongodb_ss_metrics_commands_dbStats_failed untyped
+mongodb_ss_metrics_commands_dbStats_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_dbStats_total serverStatus.metrics.commands.dbStats.
+# TYPE mongodb_ss_metrics_commands_dbStats_total untyped
+mongodb_ss_metrics_commands_dbStats_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1623
+# HELP mongodb_ss_metrics_commands_delete_failed serverStatus.metrics.commands.delete.
+# TYPE mongodb_ss_metrics_commands_delete_failed untyped
+mongodb_ss_metrics_commands_delete_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_delete_total serverStatus.metrics.commands.delete.
+# TYPE mongodb_ss_metrics_commands_delete_total untyped
+mongodb_ss_metrics_commands_delete_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_ss_metrics_commands_distinct_failed serverStatus.metrics.commands.distinct.
+# TYPE mongodb_ss_metrics_commands_distinct_failed untyped
+mongodb_ss_metrics_commands_distinct_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_distinct_total serverStatus.metrics.commands.distinct.
+# TYPE mongodb_ss_metrics_commands_distinct_total untyped
+mongodb_ss_metrics_commands_distinct_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_driverOIDTest_failed serverStatus.metrics.commands.driverOIDTest.
+# TYPE mongodb_ss_metrics_commands_driverOIDTest_failed untyped
+mongodb_ss_metrics_commands_driverOIDTest_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_driverOIDTest_total serverStatus.metrics.commands.driverOIDTest.
+# TYPE mongodb_ss_metrics_commands_driverOIDTest_total untyped
+mongodb_ss_metrics_commands_driverOIDTest_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_dropAllRolesFromDatabase_failed serverStatus.metrics.commands.dropAllRolesFromDatabase.
+# TYPE mongodb_ss_metrics_commands_dropAllRolesFromDatabase_failed untyped
+mongodb_ss_metrics_commands_dropAllRolesFromDatabase_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_dropAllRolesFromDatabase_total serverStatus.metrics.commands.dropAllRolesFromDatabase.
+# TYPE mongodb_ss_metrics_commands_dropAllRolesFromDatabase_total untyped
+mongodb_ss_metrics_commands_dropAllRolesFromDatabase_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_dropAllUsersFromDatabase_failed serverStatus.metrics.commands.dropAllUsersFromDatabase.
+# TYPE mongodb_ss_metrics_commands_dropAllUsersFromDatabase_failed untyped
+mongodb_ss_metrics_commands_dropAllUsersFromDatabase_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_dropAllUsersFromDatabase_total serverStatus.metrics.commands.dropAllUsersFromDatabase.
+# TYPE mongodb_ss_metrics_commands_dropAllUsersFromDatabase_total untyped
+mongodb_ss_metrics_commands_dropAllUsersFromDatabase_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_dropDatabase_failed serverStatus.metrics.commands.dropDatabase.
+# TYPE mongodb_ss_metrics_commands_dropDatabase_failed untyped
+mongodb_ss_metrics_commands_dropDatabase_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_dropDatabase_total serverStatus.metrics.commands.dropDatabase.
+# TYPE mongodb_ss_metrics_commands_dropDatabase_total untyped
+mongodb_ss_metrics_commands_dropDatabase_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_dropIndexes_failed serverStatus.metrics.commands.dropIndexes.
+# TYPE mongodb_ss_metrics_commands_dropIndexes_failed untyped
+mongodb_ss_metrics_commands_dropIndexes_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_dropIndexes_total serverStatus.metrics.commands.dropIndexes.
+# TYPE mongodb_ss_metrics_commands_dropIndexes_total untyped
+mongodb_ss_metrics_commands_dropIndexes_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_dropRole_failed serverStatus.metrics.commands.dropRole.
+# TYPE mongodb_ss_metrics_commands_dropRole_failed untyped
+mongodb_ss_metrics_commands_dropRole_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_dropRole_total serverStatus.metrics.commands.dropRole.
+# TYPE mongodb_ss_metrics_commands_dropRole_total untyped
+mongodb_ss_metrics_commands_dropRole_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_dropUser_failed serverStatus.metrics.commands.dropUser.
+# TYPE mongodb_ss_metrics_commands_dropUser_failed untyped
+mongodb_ss_metrics_commands_dropUser_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_dropUser_total serverStatus.metrics.commands.dropUser.
+# TYPE mongodb_ss_metrics_commands_dropUser_total untyped
+mongodb_ss_metrics_commands_dropUser_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_drop_failed serverStatus.metrics.commands.drop.
+# TYPE mongodb_ss_metrics_commands_drop_failed untyped
+mongodb_ss_metrics_commands_drop_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_drop_total serverStatus.metrics.commands.drop.
+# TYPE mongodb_ss_metrics_commands_drop_total untyped
+mongodb_ss_metrics_commands_drop_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_endSessions_failed serverStatus.metrics.commands.endSessions.
+# TYPE mongodb_ss_metrics_commands_endSessions_failed untyped
+mongodb_ss_metrics_commands_endSessions_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_endSessions_total serverStatus.metrics.commands.endSessions.
+# TYPE mongodb_ss_metrics_commands_endSessions_total untyped
+mongodb_ss_metrics_commands_endSessions_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 6
+# HELP mongodb_ss_metrics_commands_eval_failed serverStatus.metrics.commands.eval.
+# TYPE mongodb_ss_metrics_commands_eval_failed untyped
+mongodb_ss_metrics_commands_eval_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_eval_total serverStatus.metrics.commands.eval.
+# TYPE mongodb_ss_metrics_commands_eval_total untyped
+mongodb_ss_metrics_commands_eval_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_explain_failed serverStatus.metrics.commands.explain.
+# TYPE mongodb_ss_metrics_commands_explain_failed untyped
+mongodb_ss_metrics_commands_explain_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_explain_total serverStatus.metrics.commands.explain.
+# TYPE mongodb_ss_metrics_commands_explain_total untyped
+mongodb_ss_metrics_commands_explain_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_features_failed serverStatus.metrics.commands.features.
+# TYPE mongodb_ss_metrics_commands_features_failed untyped
+mongodb_ss_metrics_commands_features_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_features_total serverStatus.metrics.commands.features.
+# TYPE mongodb_ss_metrics_commands_features_total untyped
+mongodb_ss_metrics_commands_features_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_filemd5_failed serverStatus.metrics.commands.filemd5.
+# TYPE mongodb_ss_metrics_commands_filemd5_failed untyped
+mongodb_ss_metrics_commands_filemd5_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_filemd5_total serverStatus.metrics.commands.filemd5.
+# TYPE mongodb_ss_metrics_commands_filemd5_total untyped
+mongodb_ss_metrics_commands_filemd5_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_findAndModify_failed serverStatus.metrics.commands.findAndModify.
+# TYPE mongodb_ss_metrics_commands_findAndModify_failed untyped
+mongodb_ss_metrics_commands_findAndModify_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_findAndModify_total serverStatus.metrics.commands.findAndModify.
+# TYPE mongodb_ss_metrics_commands_findAndModify_total untyped
+mongodb_ss_metrics_commands_findAndModify_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_find_failed serverStatus.metrics.commands.find.
+# TYPE mongodb_ss_metrics_commands_find_failed untyped
+mongodb_ss_metrics_commands_find_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_find_total serverStatus.metrics.commands.find.
+# TYPE mongodb_ss_metrics_commands_find_total untyped
+mongodb_ss_metrics_commands_find_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 2176
+# HELP mongodb_ss_metrics_commands_flushDatabaseCacheUpdates_failed serverStatus.metrics.commands._flushDatabaseCacheUpdates.
+# TYPE mongodb_ss_metrics_commands_flushDatabaseCacheUpdates_failed untyped
+mongodb_ss_metrics_commands_flushDatabaseCacheUpdates_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_flushDatabaseCacheUpdates_total serverStatus.metrics.commands._flushDatabaseCacheUpdates.
+# TYPE mongodb_ss_metrics_commands_flushDatabaseCacheUpdates_total untyped
+mongodb_ss_metrics_commands_flushDatabaseCacheUpdates_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_flushRouterConfig_failed serverStatus.metrics.commands.flushRouterConfig.
+# TYPE mongodb_ss_metrics_commands_flushRouterConfig_failed untyped
+mongodb_ss_metrics_commands_flushRouterConfig_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_flushRouterConfig_total serverStatus.metrics.commands.flushRouterConfig.
+# TYPE mongodb_ss_metrics_commands_flushRouterConfig_total untyped
+mongodb_ss_metrics_commands_flushRouterConfig_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_flushRoutingTableCacheUpdates_failed serverStatus.metrics.commands._flushRoutingTableCacheUpdates.
+# TYPE mongodb_ss_metrics_commands_flushRoutingTableCacheUpdates_failed untyped
+mongodb_ss_metrics_commands_flushRoutingTableCacheUpdates_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_flushRoutingTableCacheUpdates_total serverStatus.metrics.commands._flushRoutingTableCacheUpdates.
+# TYPE mongodb_ss_metrics_commands_flushRoutingTableCacheUpdates_total untyped
+mongodb_ss_metrics_commands_flushRoutingTableCacheUpdates_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_fsyncUnlock_failed serverStatus.metrics.commands.fsyncUnlock.
+# TYPE mongodb_ss_metrics_commands_fsyncUnlock_failed untyped
+mongodb_ss_metrics_commands_fsyncUnlock_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_fsyncUnlock_total serverStatus.metrics.commands.fsyncUnlock.
+# TYPE mongodb_ss_metrics_commands_fsyncUnlock_total untyped
+mongodb_ss_metrics_commands_fsyncUnlock_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_fsync_failed serverStatus.metrics.commands.fsync.
+# TYPE mongodb_ss_metrics_commands_fsync_failed untyped
+mongodb_ss_metrics_commands_fsync_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_fsync_total serverStatus.metrics.commands.fsync.
+# TYPE mongodb_ss_metrics_commands_fsync_total untyped
+mongodb_ss_metrics_commands_fsync_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_geoNear_failed serverStatus.metrics.commands.geoNear.
+# TYPE mongodb_ss_metrics_commands_geoNear_failed untyped
+mongodb_ss_metrics_commands_geoNear_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_geoNear_total serverStatus.metrics.commands.geoNear.
+# TYPE mongodb_ss_metrics_commands_geoNear_total untyped
+mongodb_ss_metrics_commands_geoNear_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_geoSearch_failed serverStatus.metrics.commands.geoSearch.
+# TYPE mongodb_ss_metrics_commands_geoSearch_failed untyped
+mongodb_ss_metrics_commands_geoSearch_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_geoSearch_total serverStatus.metrics.commands.geoSearch.
+# TYPE mongodb_ss_metrics_commands_geoSearch_total untyped
+mongodb_ss_metrics_commands_geoSearch_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_getCmdLineOpts_failed serverStatus.metrics.commands.getCmdLineOpts.
+# TYPE mongodb_ss_metrics_commands_getCmdLineOpts_failed untyped
+mongodb_ss_metrics_commands_getCmdLineOpts_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_getCmdLineOpts_total serverStatus.metrics.commands.getCmdLineOpts.
+# TYPE mongodb_ss_metrics_commands_getCmdLineOpts_total untyped
+mongodb_ss_metrics_commands_getCmdLineOpts_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 543
+# HELP mongodb_ss_metrics_commands_getDatabaseVersion_failed serverStatus.metrics.commands.getDatabaseVersion.
+# TYPE mongodb_ss_metrics_commands_getDatabaseVersion_failed untyped
+mongodb_ss_metrics_commands_getDatabaseVersion_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_getDatabaseVersion_total serverStatus.metrics.commands.getDatabaseVersion.
+# TYPE mongodb_ss_metrics_commands_getDatabaseVersion_total untyped
+mongodb_ss_metrics_commands_getDatabaseVersion_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_getDiagnosticData_failed serverStatus.metrics.commands.getDiagnosticData.
+# TYPE mongodb_ss_metrics_commands_getDiagnosticData_failed untyped
+mongodb_ss_metrics_commands_getDiagnosticData_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_getDiagnosticData_total serverStatus.metrics.commands.getDiagnosticData.
+# TYPE mongodb_ss_metrics_commands_getDiagnosticData_total untyped
+mongodb_ss_metrics_commands_getDiagnosticData_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1628
+# HELP mongodb_ss_metrics_commands_getFreeMonitoringStatus_failed serverStatus.metrics.commands.getFreeMonitoringStatus.
+# TYPE mongodb_ss_metrics_commands_getFreeMonitoringStatus_failed untyped
+mongodb_ss_metrics_commands_getFreeMonitoringStatus_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_getFreeMonitoringStatus_total serverStatus.metrics.commands.getFreeMonitoringStatus.
+# TYPE mongodb_ss_metrics_commands_getFreeMonitoringStatus_total untyped
+mongodb_ss_metrics_commands_getFreeMonitoringStatus_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_getLastError_failed serverStatus.metrics.commands.getLastError.
+# TYPE mongodb_ss_metrics_commands_getLastError_failed untyped
+mongodb_ss_metrics_commands_getLastError_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_getLastError_total serverStatus.metrics.commands.getLastError.
+# TYPE mongodb_ss_metrics_commands_getLastError_total untyped
+mongodb_ss_metrics_commands_getLastError_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_getLog_failed serverStatus.metrics.commands.getLog.
+# TYPE mongodb_ss_metrics_commands_getLog_failed untyped
+mongodb_ss_metrics_commands_getLog_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_getLog_total serverStatus.metrics.commands.getLog.
+# TYPE mongodb_ss_metrics_commands_getLog_total untyped
+mongodb_ss_metrics_commands_getLog_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_getMore_failed serverStatus.metrics.commands.getMore.
+# TYPE mongodb_ss_metrics_commands_getMore_failed untyped
+mongodb_ss_metrics_commands_getMore_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_getMore_total serverStatus.metrics.commands.getMore.
+# TYPE mongodb_ss_metrics_commands_getMore_total untyped
+mongodb_ss_metrics_commands_getMore_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_getNextSessionMods_failed serverStatus.metrics.commands._getNextSessionMods.
+# TYPE mongodb_ss_metrics_commands_getNextSessionMods_failed untyped
+mongodb_ss_metrics_commands_getNextSessionMods_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_getNextSessionMods_total serverStatus.metrics.commands._getNextSessionMods.
+# TYPE mongodb_ss_metrics_commands_getNextSessionMods_total untyped
+mongodb_ss_metrics_commands_getNextSessionMods_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_getParameter_failed serverStatus.metrics.commands.getParameter.
+# TYPE mongodb_ss_metrics_commands_getParameter_failed untyped
+mongodb_ss_metrics_commands_getParameter_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_getParameter_total serverStatus.metrics.commands.getParameter.
+# TYPE mongodb_ss_metrics_commands_getParameter_total untyped
+mongodb_ss_metrics_commands_getParameter_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_getPrevError_failed serverStatus.metrics.commands.getPrevError.
+# TYPE mongodb_ss_metrics_commands_getPrevError_failed untyped
+mongodb_ss_metrics_commands_getPrevError_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_getPrevError_total serverStatus.metrics.commands.getPrevError.
+# TYPE mongodb_ss_metrics_commands_getPrevError_total untyped
+mongodb_ss_metrics_commands_getPrevError_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_getShardMap_failed serverStatus.metrics.commands.getShardMap.
+# TYPE mongodb_ss_metrics_commands_getShardMap_failed untyped
+mongodb_ss_metrics_commands_getShardMap_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_getShardMap_total serverStatus.metrics.commands.getShardMap.
+# TYPE mongodb_ss_metrics_commands_getShardMap_total untyped
+mongodb_ss_metrics_commands_getShardMap_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_getShardVersion_failed serverStatus.metrics.commands.getShardVersion.
+# TYPE mongodb_ss_metrics_commands_getShardVersion_failed untyped
+mongodb_ss_metrics_commands_getShardVersion_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_getShardVersion_total serverStatus.metrics.commands.getShardVersion.
+# TYPE mongodb_ss_metrics_commands_getShardVersion_total untyped
+mongodb_ss_metrics_commands_getShardVersion_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_getUserCacheGeneration_failed serverStatus.metrics.commands._getUserCacheGeneration.
+# TYPE mongodb_ss_metrics_commands_getUserCacheGeneration_failed untyped
+mongodb_ss_metrics_commands_getUserCacheGeneration_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_getUserCacheGeneration_total serverStatus.metrics.commands._getUserCacheGeneration.
+# TYPE mongodb_ss_metrics_commands_getUserCacheGeneration_total untyped
+mongodb_ss_metrics_commands_getUserCacheGeneration_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_getnonce_failed serverStatus.metrics.commands.getnonce.
+# TYPE mongodb_ss_metrics_commands_getnonce_failed untyped
+mongodb_ss_metrics_commands_getnonce_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_getnonce_total serverStatus.metrics.commands.getnonce.
+# TYPE mongodb_ss_metrics_commands_getnonce_total untyped
+mongodb_ss_metrics_commands_getnonce_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_grantPrivilegesToRole_failed serverStatus.metrics.commands.grantPrivilegesToRole.
+# TYPE mongodb_ss_metrics_commands_grantPrivilegesToRole_failed untyped
+mongodb_ss_metrics_commands_grantPrivilegesToRole_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_grantPrivilegesToRole_total serverStatus.metrics.commands.grantPrivilegesToRole.
+# TYPE mongodb_ss_metrics_commands_grantPrivilegesToRole_total untyped
+mongodb_ss_metrics_commands_grantPrivilegesToRole_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_grantRolesToRole_failed serverStatus.metrics.commands.grantRolesToRole.
+# TYPE mongodb_ss_metrics_commands_grantRolesToRole_failed untyped
+mongodb_ss_metrics_commands_grantRolesToRole_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_grantRolesToRole_total serverStatus.metrics.commands.grantRolesToRole.
+# TYPE mongodb_ss_metrics_commands_grantRolesToRole_total untyped
+mongodb_ss_metrics_commands_grantRolesToRole_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_grantRolesToUser_failed serverStatus.metrics.commands.grantRolesToUser.
+# TYPE mongodb_ss_metrics_commands_grantRolesToUser_failed untyped
+mongodb_ss_metrics_commands_grantRolesToUser_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_grantRolesToUser_total serverStatus.metrics.commands.grantRolesToUser.
+# TYPE mongodb_ss_metrics_commands_grantRolesToUser_total untyped
+mongodb_ss_metrics_commands_grantRolesToUser_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_group_failed serverStatus.metrics.commands.group.
+# TYPE mongodb_ss_metrics_commands_group_failed untyped
+mongodb_ss_metrics_commands_group_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_group_total serverStatus.metrics.commands.group.
+# TYPE mongodb_ss_metrics_commands_group_total untyped
+mongodb_ss_metrics_commands_group_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_hostInfo_failed serverStatus.metrics.commands.hostInfo.
+# TYPE mongodb_ss_metrics_commands_hostInfo_failed untyped
+mongodb_ss_metrics_commands_hostInfo_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_hostInfo_total serverStatus.metrics.commands.hostInfo.
+# TYPE mongodb_ss_metrics_commands_hostInfo_total untyped
+mongodb_ss_metrics_commands_hostInfo_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_insert_failed serverStatus.metrics.commands.insert.
+# TYPE mongodb_ss_metrics_commands_insert_failed untyped
+mongodb_ss_metrics_commands_insert_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_insert_total serverStatus.metrics.commands.insert.
+# TYPE mongodb_ss_metrics_commands_insert_total untyped
+mongodb_ss_metrics_commands_insert_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_invalidateUserCache_failed serverStatus.metrics.commands.invalidateUserCache.
+# TYPE mongodb_ss_metrics_commands_invalidateUserCache_failed untyped
+mongodb_ss_metrics_commands_invalidateUserCache_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_invalidateUserCache_total serverStatus.metrics.commands.invalidateUserCache.
+# TYPE mongodb_ss_metrics_commands_invalidateUserCache_total untyped
+mongodb_ss_metrics_commands_invalidateUserCache_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_isMaster_failed serverStatus.metrics.commands.isMaster.
+# TYPE mongodb_ss_metrics_commands_isMaster_failed untyped
+mongodb_ss_metrics_commands_isMaster_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_isMaster_total serverStatus.metrics.commands.isMaster.
+# TYPE mongodb_ss_metrics_commands_isMaster_total untyped
+mongodb_ss_metrics_commands_isMaster_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 3665
+# HELP mongodb_ss_metrics_commands_isSelf_failed serverStatus.metrics.commands._isSelf.
+# TYPE mongodb_ss_metrics_commands_isSelf_failed untyped
+mongodb_ss_metrics_commands_isSelf_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_isSelf_total serverStatus.metrics.commands._isSelf.
+# TYPE mongodb_ss_metrics_commands_isSelf_total untyped
+mongodb_ss_metrics_commands_isSelf_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_killAllSessionsByPattern_failed serverStatus.metrics.commands.killAllSessionsByPattern.
+# TYPE mongodb_ss_metrics_commands_killAllSessionsByPattern_failed untyped
+mongodb_ss_metrics_commands_killAllSessionsByPattern_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_killAllSessionsByPattern_total serverStatus.metrics.commands.killAllSessionsByPattern.
+# TYPE mongodb_ss_metrics_commands_killAllSessionsByPattern_total untyped
+mongodb_ss_metrics_commands_killAllSessionsByPattern_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_killAllSessions_failed serverStatus.metrics.commands.killAllSessions.
+# TYPE mongodb_ss_metrics_commands_killAllSessions_failed untyped
+mongodb_ss_metrics_commands_killAllSessions_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_killAllSessions_total serverStatus.metrics.commands.killAllSessions.
+# TYPE mongodb_ss_metrics_commands_killAllSessions_total untyped
+mongodb_ss_metrics_commands_killAllSessions_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_killCursors_failed serverStatus.metrics.commands.killCursors.
+# TYPE mongodb_ss_metrics_commands_killCursors_failed untyped
+mongodb_ss_metrics_commands_killCursors_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_killCursors_total serverStatus.metrics.commands.killCursors.
+# TYPE mongodb_ss_metrics_commands_killCursors_total untyped
+mongodb_ss_metrics_commands_killCursors_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_killOp_failed serverStatus.metrics.commands.killOp.
+# TYPE mongodb_ss_metrics_commands_killOp_failed untyped
+mongodb_ss_metrics_commands_killOp_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_killOp_total serverStatus.metrics.commands.killOp.
+# TYPE mongodb_ss_metrics_commands_killOp_total untyped
+mongodb_ss_metrics_commands_killOp_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_killSessions_failed serverStatus.metrics.commands.killSessions.
+# TYPE mongodb_ss_metrics_commands_killSessions_failed untyped
+mongodb_ss_metrics_commands_killSessions_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_killSessions_total serverStatus.metrics.commands.killSessions.
+# TYPE mongodb_ss_metrics_commands_killSessions_total untyped
+mongodb_ss_metrics_commands_killSessions_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_listCollections_failed serverStatus.metrics.commands.listCollections.
+# TYPE mongodb_ss_metrics_commands_listCollections_failed untyped
+mongodb_ss_metrics_commands_listCollections_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_listCollections_total serverStatus.metrics.commands.listCollections.
+# TYPE mongodb_ss_metrics_commands_listCollections_total untyped
+mongodb_ss_metrics_commands_listCollections_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_listCommands_failed serverStatus.metrics.commands.listCommands.
+# TYPE mongodb_ss_metrics_commands_listCommands_failed untyped
+mongodb_ss_metrics_commands_listCommands_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_listCommands_total serverStatus.metrics.commands.listCommands.
+# TYPE mongodb_ss_metrics_commands_listCommands_total untyped
+mongodb_ss_metrics_commands_listCommands_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_listDatabases_failed serverStatus.metrics.commands.listDatabases.
+# TYPE mongodb_ss_metrics_commands_listDatabases_failed untyped
+mongodb_ss_metrics_commands_listDatabases_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_listDatabases_total serverStatus.metrics.commands.listDatabases.
+# TYPE mongodb_ss_metrics_commands_listDatabases_total untyped
+mongodb_ss_metrics_commands_listDatabases_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1084
+# HELP mongodb_ss_metrics_commands_listIndexes_failed serverStatus.metrics.commands.listIndexes.
+# TYPE mongodb_ss_metrics_commands_listIndexes_failed untyped
+mongodb_ss_metrics_commands_listIndexes_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_listIndexes_total serverStatus.metrics.commands.listIndexes.
+# TYPE mongodb_ss_metrics_commands_listIndexes_total untyped
+mongodb_ss_metrics_commands_listIndexes_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 9
+# HELP mongodb_ss_metrics_commands_lockInfo_failed serverStatus.metrics.commands.lockInfo.
+# TYPE mongodb_ss_metrics_commands_lockInfo_failed untyped
+mongodb_ss_metrics_commands_lockInfo_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_lockInfo_total serverStatus.metrics.commands.lockInfo.
+# TYPE mongodb_ss_metrics_commands_lockInfo_total untyped
+mongodb_ss_metrics_commands_lockInfo_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_logRotate_failed serverStatus.metrics.commands.logRotate.
+# TYPE mongodb_ss_metrics_commands_logRotate_failed untyped
+mongodb_ss_metrics_commands_logRotate_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_logRotate_total serverStatus.metrics.commands.logRotate.
+# TYPE mongodb_ss_metrics_commands_logRotate_total untyped
+mongodb_ss_metrics_commands_logRotate_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_logout_failed serverStatus.metrics.commands.logout.
+# TYPE mongodb_ss_metrics_commands_logout_failed untyped
+mongodb_ss_metrics_commands_logout_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_logout_total serverStatus.metrics.commands.logout.
+# TYPE mongodb_ss_metrics_commands_logout_total untyped
+mongodb_ss_metrics_commands_logout_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_mapReduce_failed serverStatus.metrics.commands.mapReduce.
+# TYPE mongodb_ss_metrics_commands_mapReduce_failed untyped
+mongodb_ss_metrics_commands_mapReduce_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_mapReduce_total serverStatus.metrics.commands.mapReduce.
+# TYPE mongodb_ss_metrics_commands_mapReduce_total untyped
+mongodb_ss_metrics_commands_mapReduce_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_mapreduce_shardedfinish_failed serverStatus.metrics.commands.mapreduce.shardedfinish.
+# TYPE mongodb_ss_metrics_commands_mapreduce_shardedfinish_failed untyped
+mongodb_ss_metrics_commands_mapreduce_shardedfinish_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_mapreduce_shardedfinish_total serverStatus.metrics.commands.mapreduce.shardedfinish.
+# TYPE mongodb_ss_metrics_commands_mapreduce_shardedfinish_total untyped
+mongodb_ss_metrics_commands_mapreduce_shardedfinish_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_mergeAuthzCollections_failed serverStatus.metrics.commands._mergeAuthzCollections.
+# TYPE mongodb_ss_metrics_commands_mergeAuthzCollections_failed untyped
+mongodb_ss_metrics_commands_mergeAuthzCollections_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_mergeAuthzCollections_total serverStatus.metrics.commands._mergeAuthzCollections.
+# TYPE mongodb_ss_metrics_commands_mergeAuthzCollections_total untyped
+mongodb_ss_metrics_commands_mergeAuthzCollections_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_mergeChunks_failed serverStatus.metrics.commands.mergeChunks.
+# TYPE mongodb_ss_metrics_commands_mergeChunks_failed untyped
+mongodb_ss_metrics_commands_mergeChunks_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_mergeChunks_total serverStatus.metrics.commands.mergeChunks.
+# TYPE mongodb_ss_metrics_commands_mergeChunks_total untyped
+mongodb_ss_metrics_commands_mergeChunks_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_migrateClone_failed serverStatus.metrics.commands._migrateClone.
+# TYPE mongodb_ss_metrics_commands_migrateClone_failed untyped
+mongodb_ss_metrics_commands_migrateClone_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_migrateClone_total serverStatus.metrics.commands._migrateClone.
+# TYPE mongodb_ss_metrics_commands_migrateClone_total untyped
+mongodb_ss_metrics_commands_migrateClone_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_moveChunk_failed serverStatus.metrics.commands.moveChunk.
+# TYPE mongodb_ss_metrics_commands_moveChunk_failed untyped
+mongodb_ss_metrics_commands_moveChunk_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_moveChunk_total serverStatus.metrics.commands.moveChunk.
+# TYPE mongodb_ss_metrics_commands_moveChunk_total untyped
+mongodb_ss_metrics_commands_moveChunk_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_movePrimary_failed serverStatus.metrics.commands._movePrimary.
+# TYPE mongodb_ss_metrics_commands_movePrimary_failed untyped
+mongodb_ss_metrics_commands_movePrimary_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_movePrimary_total serverStatus.metrics.commands._movePrimary.
+# TYPE mongodb_ss_metrics_commands_movePrimary_total untyped
+mongodb_ss_metrics_commands_movePrimary_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_parallelCollectionScan_failed serverStatus.metrics.commands.parallelCollectionScan.
+# TYPE mongodb_ss_metrics_commands_parallelCollectionScan_failed untyped
+mongodb_ss_metrics_commands_parallelCollectionScan_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_parallelCollectionScan_total serverStatus.metrics.commands.parallelCollectionScan.
+# TYPE mongodb_ss_metrics_commands_parallelCollectionScan_total untyped
+mongodb_ss_metrics_commands_parallelCollectionScan_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_ping_failed serverStatus.metrics.commands.ping.
+# TYPE mongodb_ss_metrics_commands_ping_failed untyped
+mongodb_ss_metrics_commands_ping_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_ping_total serverStatus.metrics.commands.ping.
+# TYPE mongodb_ss_metrics_commands_ping_total untyped
+mongodb_ss_metrics_commands_ping_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1220
+# HELP mongodb_ss_metrics_commands_planCacheClearFilters_failed serverStatus.metrics.commands.planCacheClearFilters.
+# TYPE mongodb_ss_metrics_commands_planCacheClearFilters_failed untyped
+mongodb_ss_metrics_commands_planCacheClearFilters_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_planCacheClearFilters_total serverStatus.metrics.commands.planCacheClearFilters.
+# TYPE mongodb_ss_metrics_commands_planCacheClearFilters_total untyped
+mongodb_ss_metrics_commands_planCacheClearFilters_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_planCacheClear_failed serverStatus.metrics.commands.planCacheClear.
+# TYPE mongodb_ss_metrics_commands_planCacheClear_failed untyped
+mongodb_ss_metrics_commands_planCacheClear_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_planCacheClear_total serverStatus.metrics.commands.planCacheClear.
+# TYPE mongodb_ss_metrics_commands_planCacheClear_total untyped
+mongodb_ss_metrics_commands_planCacheClear_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_planCacheListFilters_failed serverStatus.metrics.commands.planCacheListFilters.
+# TYPE mongodb_ss_metrics_commands_planCacheListFilters_failed untyped
+mongodb_ss_metrics_commands_planCacheListFilters_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_planCacheListFilters_total serverStatus.metrics.commands.planCacheListFilters.
+# TYPE mongodb_ss_metrics_commands_planCacheListFilters_total untyped
+mongodb_ss_metrics_commands_planCacheListFilters_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_planCacheListPlans_failed serverStatus.metrics.commands.planCacheListPlans.
+# TYPE mongodb_ss_metrics_commands_planCacheListPlans_failed untyped
+mongodb_ss_metrics_commands_planCacheListPlans_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_planCacheListPlans_total serverStatus.metrics.commands.planCacheListPlans.
+# TYPE mongodb_ss_metrics_commands_planCacheListPlans_total untyped
+mongodb_ss_metrics_commands_planCacheListPlans_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_planCacheListQueryShapes_failed serverStatus.metrics.commands.planCacheListQueryShapes.
+# TYPE mongodb_ss_metrics_commands_planCacheListQueryShapes_failed untyped
+mongodb_ss_metrics_commands_planCacheListQueryShapes_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_planCacheListQueryShapes_total serverStatus.metrics.commands.planCacheListQueryShapes.
+# TYPE mongodb_ss_metrics_commands_planCacheListQueryShapes_total untyped
+mongodb_ss_metrics_commands_planCacheListQueryShapes_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_planCacheSetFilter_failed serverStatus.metrics.commands.planCacheSetFilter.
+# TYPE mongodb_ss_metrics_commands_planCacheSetFilter_failed untyped
+mongodb_ss_metrics_commands_planCacheSetFilter_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_planCacheSetFilter_total serverStatus.metrics.commands.planCacheSetFilter.
+# TYPE mongodb_ss_metrics_commands_planCacheSetFilter_total untyped
+mongodb_ss_metrics_commands_planCacheSetFilter_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_profile_failed serverStatus.metrics.commands.profile.
+# TYPE mongodb_ss_metrics_commands_profile_failed untyped
+mongodb_ss_metrics_commands_profile_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_profile_total serverStatus.metrics.commands.profile.
+# TYPE mongodb_ss_metrics_commands_profile_total untyped
+mongodb_ss_metrics_commands_profile_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_reIndex_failed serverStatus.metrics.commands.reIndex.
+# TYPE mongodb_ss_metrics_commands_reIndex_failed untyped
+mongodb_ss_metrics_commands_reIndex_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_reIndex_total serverStatus.metrics.commands.reIndex.
+# TYPE mongodb_ss_metrics_commands_reIndex_total untyped
+mongodb_ss_metrics_commands_reIndex_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_recvChunkAbort_failed serverStatus.metrics.commands._recvChunkAbort.
+# TYPE mongodb_ss_metrics_commands_recvChunkAbort_failed untyped
+mongodb_ss_metrics_commands_recvChunkAbort_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_recvChunkAbort_total serverStatus.metrics.commands._recvChunkAbort.
+# TYPE mongodb_ss_metrics_commands_recvChunkAbort_total untyped
+mongodb_ss_metrics_commands_recvChunkAbort_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_recvChunkCommit_failed serverStatus.metrics.commands._recvChunkCommit.
+# TYPE mongodb_ss_metrics_commands_recvChunkCommit_failed untyped
+mongodb_ss_metrics_commands_recvChunkCommit_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_recvChunkCommit_total serverStatus.metrics.commands._recvChunkCommit.
+# TYPE mongodb_ss_metrics_commands_recvChunkCommit_total untyped
+mongodb_ss_metrics_commands_recvChunkCommit_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_recvChunkStart_failed serverStatus.metrics.commands._recvChunkStart.
+# TYPE mongodb_ss_metrics_commands_recvChunkStart_failed untyped
+mongodb_ss_metrics_commands_recvChunkStart_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_recvChunkStart_total serverStatus.metrics.commands._recvChunkStart.
+# TYPE mongodb_ss_metrics_commands_recvChunkStart_total untyped
+mongodb_ss_metrics_commands_recvChunkStart_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_recvChunkStatus_failed serverStatus.metrics.commands._recvChunkStatus.
+# TYPE mongodb_ss_metrics_commands_recvChunkStatus_failed untyped
+mongodb_ss_metrics_commands_recvChunkStatus_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_recvChunkStatus_total serverStatus.metrics.commands._recvChunkStatus.
+# TYPE mongodb_ss_metrics_commands_recvChunkStatus_total untyped
+mongodb_ss_metrics_commands_recvChunkStatus_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_refreshSessionsInternal_failed serverStatus.metrics.commands.refreshSessionsInternal.
+# TYPE mongodb_ss_metrics_commands_refreshSessionsInternal_failed untyped
+mongodb_ss_metrics_commands_refreshSessionsInternal_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_refreshSessionsInternal_total serverStatus.metrics.commands.refreshSessionsInternal.
+# TYPE mongodb_ss_metrics_commands_refreshSessionsInternal_total untyped
+mongodb_ss_metrics_commands_refreshSessionsInternal_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_refreshSessions_failed serverStatus.metrics.commands.refreshSessions.
+# TYPE mongodb_ss_metrics_commands_refreshSessions_failed untyped
+mongodb_ss_metrics_commands_refreshSessions_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_refreshSessions_total serverStatus.metrics.commands.refreshSessions.
+# TYPE mongodb_ss_metrics_commands_refreshSessions_total untyped
+mongodb_ss_metrics_commands_refreshSessions_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_renameCollection_failed serverStatus.metrics.commands.renameCollection.
+# TYPE mongodb_ss_metrics_commands_renameCollection_failed untyped
+mongodb_ss_metrics_commands_renameCollection_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_renameCollection_total serverStatus.metrics.commands.renameCollection.
+# TYPE mongodb_ss_metrics_commands_renameCollection_total untyped
+mongodb_ss_metrics_commands_renameCollection_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_repairCursor_failed serverStatus.metrics.commands.repairCursor.
+# TYPE mongodb_ss_metrics_commands_repairCursor_failed untyped
+mongodb_ss_metrics_commands_repairCursor_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_repairCursor_total serverStatus.metrics.commands.repairCursor.
+# TYPE mongodb_ss_metrics_commands_repairCursor_total untyped
+mongodb_ss_metrics_commands_repairCursor_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_repairDatabase_failed serverStatus.metrics.commands.repairDatabase.
+# TYPE mongodb_ss_metrics_commands_repairDatabase_failed untyped
+mongodb_ss_metrics_commands_repairDatabase_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_repairDatabase_total serverStatus.metrics.commands.repairDatabase.
+# TYPE mongodb_ss_metrics_commands_repairDatabase_total untyped
+mongodb_ss_metrics_commands_repairDatabase_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_replSetAbortPrimaryCatchUp_failed serverStatus.metrics.commands.replSetAbortPrimaryCatchUp.
+# TYPE mongodb_ss_metrics_commands_replSetAbortPrimaryCatchUp_failed untyped
+mongodb_ss_metrics_commands_replSetAbortPrimaryCatchUp_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_replSetAbortPrimaryCatchUp_total serverStatus.metrics.commands.replSetAbortPrimaryCatchUp.
+# TYPE mongodb_ss_metrics_commands_replSetAbortPrimaryCatchUp_total untyped
+mongodb_ss_metrics_commands_replSetAbortPrimaryCatchUp_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_replSetElect_failed serverStatus.metrics.commands.replSetElect.
+# TYPE mongodb_ss_metrics_commands_replSetElect_failed untyped
+mongodb_ss_metrics_commands_replSetElect_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_replSetElect_total serverStatus.metrics.commands.replSetElect.
+# TYPE mongodb_ss_metrics_commands_replSetElect_total untyped
+mongodb_ss_metrics_commands_replSetElect_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_replSetFreeze_failed serverStatus.metrics.commands.replSetFreeze.
+# TYPE mongodb_ss_metrics_commands_replSetFreeze_failed untyped
+mongodb_ss_metrics_commands_replSetFreeze_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_replSetFreeze_total serverStatus.metrics.commands.replSetFreeze.
+# TYPE mongodb_ss_metrics_commands_replSetFreeze_total untyped
+mongodb_ss_metrics_commands_replSetFreeze_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_replSetFresh_failed serverStatus.metrics.commands.replSetFresh.
+# TYPE mongodb_ss_metrics_commands_replSetFresh_failed untyped
+mongodb_ss_metrics_commands_replSetFresh_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_replSetFresh_total serverStatus.metrics.commands.replSetFresh.
+# TYPE mongodb_ss_metrics_commands_replSetFresh_total untyped
+mongodb_ss_metrics_commands_replSetFresh_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_replSetGetConfig_failed serverStatus.metrics.commands.replSetGetConfig.
+# TYPE mongodb_ss_metrics_commands_replSetGetConfig_failed untyped
+mongodb_ss_metrics_commands_replSetGetConfig_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_replSetGetConfig_total serverStatus.metrics.commands.replSetGetConfig.
+# TYPE mongodb_ss_metrics_commands_replSetGetConfig_total untyped
+mongodb_ss_metrics_commands_replSetGetConfig_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1627
+# HELP mongodb_ss_metrics_commands_replSetGetRBID_failed serverStatus.metrics.commands.replSetGetRBID.
+# TYPE mongodb_ss_metrics_commands_replSetGetRBID_failed untyped
+mongodb_ss_metrics_commands_replSetGetRBID_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_replSetGetRBID_total serverStatus.metrics.commands.replSetGetRBID.
+# TYPE mongodb_ss_metrics_commands_replSetGetRBID_total untyped
+mongodb_ss_metrics_commands_replSetGetRBID_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_replSetGetStatus_failed serverStatus.metrics.commands.replSetGetStatus.
+# TYPE mongodb_ss_metrics_commands_replSetGetStatus_failed untyped
+mongodb_ss_metrics_commands_replSetGetStatus_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_replSetGetStatus_total serverStatus.metrics.commands.replSetGetStatus.
+# TYPE mongodb_ss_metrics_commands_replSetGetStatus_total untyped
+mongodb_ss_metrics_commands_replSetGetStatus_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 540
+# HELP mongodb_ss_metrics_commands_replSetHeartbeat_failed serverStatus.metrics.commands.replSetHeartbeat.
+# TYPE mongodb_ss_metrics_commands_replSetHeartbeat_failed untyped
+mongodb_ss_metrics_commands_replSetHeartbeat_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_replSetHeartbeat_total serverStatus.metrics.commands.replSetHeartbeat.
+# TYPE mongodb_ss_metrics_commands_replSetHeartbeat_total untyped
+mongodb_ss_metrics_commands_replSetHeartbeat_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_replSetInitiate_failed serverStatus.metrics.commands.replSetInitiate.
+# TYPE mongodb_ss_metrics_commands_replSetInitiate_failed untyped
+mongodb_ss_metrics_commands_replSetInitiate_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_replSetInitiate_total serverStatus.metrics.commands.replSetInitiate.
+# TYPE mongodb_ss_metrics_commands_replSetInitiate_total untyped
+mongodb_ss_metrics_commands_replSetInitiate_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_replSetMaintenance_failed serverStatus.metrics.commands.replSetMaintenance.
+# TYPE mongodb_ss_metrics_commands_replSetMaintenance_failed untyped
+mongodb_ss_metrics_commands_replSetMaintenance_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_replSetMaintenance_total serverStatus.metrics.commands.replSetMaintenance.
+# TYPE mongodb_ss_metrics_commands_replSetMaintenance_total untyped
+mongodb_ss_metrics_commands_replSetMaintenance_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_replSetReconfig_failed serverStatus.metrics.commands.replSetReconfig.
+# TYPE mongodb_ss_metrics_commands_replSetReconfig_failed untyped
+mongodb_ss_metrics_commands_replSetReconfig_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_replSetReconfig_total serverStatus.metrics.commands.replSetReconfig.
+# TYPE mongodb_ss_metrics_commands_replSetReconfig_total untyped
+mongodb_ss_metrics_commands_replSetReconfig_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_replSetRequestVotes_failed serverStatus.metrics.commands.replSetRequestVotes.
+# TYPE mongodb_ss_metrics_commands_replSetRequestVotes_failed untyped
+mongodb_ss_metrics_commands_replSetRequestVotes_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_replSetRequestVotes_total serverStatus.metrics.commands.replSetRequestVotes.
+# TYPE mongodb_ss_metrics_commands_replSetRequestVotes_total untyped
+mongodb_ss_metrics_commands_replSetRequestVotes_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_replSetResizeOplog_failed serverStatus.metrics.commands.replSetResizeOplog.
+# TYPE mongodb_ss_metrics_commands_replSetResizeOplog_failed untyped
+mongodb_ss_metrics_commands_replSetResizeOplog_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_replSetResizeOplog_total serverStatus.metrics.commands.replSetResizeOplog.
+# TYPE mongodb_ss_metrics_commands_replSetResizeOplog_total untyped
+mongodb_ss_metrics_commands_replSetResizeOplog_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_replSetStepDownWithForce_failed serverStatus.metrics.commands.replSetStepDownWithForce.
+# TYPE mongodb_ss_metrics_commands_replSetStepDownWithForce_failed untyped
+mongodb_ss_metrics_commands_replSetStepDownWithForce_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_replSetStepDownWithForce_total serverStatus.metrics.commands.replSetStepDownWithForce.
+# TYPE mongodb_ss_metrics_commands_replSetStepDownWithForce_total untyped
+mongodb_ss_metrics_commands_replSetStepDownWithForce_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_replSetStepDown_failed serverStatus.metrics.commands.replSetStepDown.
+# TYPE mongodb_ss_metrics_commands_replSetStepDown_failed untyped
+mongodb_ss_metrics_commands_replSetStepDown_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_replSetStepDown_total serverStatus.metrics.commands.replSetStepDown.
+# TYPE mongodb_ss_metrics_commands_replSetStepDown_total untyped
+mongodb_ss_metrics_commands_replSetStepDown_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_replSetStepUp_failed serverStatus.metrics.commands.replSetStepUp.
+# TYPE mongodb_ss_metrics_commands_replSetStepUp_failed untyped
+mongodb_ss_metrics_commands_replSetStepUp_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_replSetStepUp_total serverStatus.metrics.commands.replSetStepUp.
+# TYPE mongodb_ss_metrics_commands_replSetStepUp_total untyped
+mongodb_ss_metrics_commands_replSetStepUp_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_replSetSyncFrom_failed serverStatus.metrics.commands.replSetSyncFrom.
+# TYPE mongodb_ss_metrics_commands_replSetSyncFrom_failed untyped
+mongodb_ss_metrics_commands_replSetSyncFrom_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_replSetSyncFrom_total serverStatus.metrics.commands.replSetSyncFrom.
+# TYPE mongodb_ss_metrics_commands_replSetSyncFrom_total untyped
+mongodb_ss_metrics_commands_replSetSyncFrom_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_replSetUpdatePosition_failed serverStatus.metrics.commands.replSetUpdatePosition.
+# TYPE mongodb_ss_metrics_commands_replSetUpdatePosition_failed untyped
+mongodb_ss_metrics_commands_replSetUpdatePosition_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_replSetUpdatePosition_total serverStatus.metrics.commands.replSetUpdatePosition.
+# TYPE mongodb_ss_metrics_commands_replSetUpdatePosition_total untyped
+mongodb_ss_metrics_commands_replSetUpdatePosition_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_resetError_failed serverStatus.metrics.commands.resetError.
+# TYPE mongodb_ss_metrics_commands_resetError_failed untyped
+mongodb_ss_metrics_commands_resetError_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_resetError_total serverStatus.metrics.commands.resetError.
+# TYPE mongodb_ss_metrics_commands_resetError_total untyped
+mongodb_ss_metrics_commands_resetError_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_revokePrivilegesFromRole_failed serverStatus.metrics.commands.revokePrivilegesFromRole.
+# TYPE mongodb_ss_metrics_commands_revokePrivilegesFromRole_failed untyped
+mongodb_ss_metrics_commands_revokePrivilegesFromRole_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_revokePrivilegesFromRole_total serverStatus.metrics.commands.revokePrivilegesFromRole.
+# TYPE mongodb_ss_metrics_commands_revokePrivilegesFromRole_total untyped
+mongodb_ss_metrics_commands_revokePrivilegesFromRole_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_revokeRolesFromRole_failed serverStatus.metrics.commands.revokeRolesFromRole.
+# TYPE mongodb_ss_metrics_commands_revokeRolesFromRole_failed untyped
+mongodb_ss_metrics_commands_revokeRolesFromRole_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_revokeRolesFromRole_total serverStatus.metrics.commands.revokeRolesFromRole.
+# TYPE mongodb_ss_metrics_commands_revokeRolesFromRole_total untyped
+mongodb_ss_metrics_commands_revokeRolesFromRole_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_revokeRolesFromUser_failed serverStatus.metrics.commands.revokeRolesFromUser.
+# TYPE mongodb_ss_metrics_commands_revokeRolesFromUser_failed untyped
+mongodb_ss_metrics_commands_revokeRolesFromUser_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_revokeRolesFromUser_total serverStatus.metrics.commands.revokeRolesFromUser.
+# TYPE mongodb_ss_metrics_commands_revokeRolesFromUser_total untyped
+mongodb_ss_metrics_commands_revokeRolesFromUser_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_rolesInfo_failed serverStatus.metrics.commands.rolesInfo.
+# TYPE mongodb_ss_metrics_commands_rolesInfo_failed untyped
+mongodb_ss_metrics_commands_rolesInfo_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_rolesInfo_total serverStatus.metrics.commands.rolesInfo.
+# TYPE mongodb_ss_metrics_commands_rolesInfo_total untyped
+mongodb_ss_metrics_commands_rolesInfo_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_saslContinue_failed serverStatus.metrics.commands.saslContinue.
+# TYPE mongodb_ss_metrics_commands_saslContinue_failed untyped
+mongodb_ss_metrics_commands_saslContinue_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_saslContinue_total serverStatus.metrics.commands.saslContinue.
+# TYPE mongodb_ss_metrics_commands_saslContinue_total untyped
+mongodb_ss_metrics_commands_saslContinue_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1086
+# HELP mongodb_ss_metrics_commands_saslStart_failed serverStatus.metrics.commands.saslStart.
+# TYPE mongodb_ss_metrics_commands_saslStart_failed untyped
+mongodb_ss_metrics_commands_saslStart_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_saslStart_total serverStatus.metrics.commands.saslStart.
+# TYPE mongodb_ss_metrics_commands_saslStart_total untyped
+mongodb_ss_metrics_commands_saslStart_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 543
+# HELP mongodb_ss_metrics_commands_serverStatus_failed serverStatus.metrics.commands.serverStatus.
+# TYPE mongodb_ss_metrics_commands_serverStatus_failed untyped
+mongodb_ss_metrics_commands_serverStatus_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_serverStatus_total serverStatus.metrics.commands.serverStatus.
+# TYPE mongodb_ss_metrics_commands_serverStatus_total untyped
+mongodb_ss_metrics_commands_serverStatus_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_setFeatureCompatibilityVersion_failed serverStatus.metrics.commands.setFeatureCompatibilityVersion.
+# TYPE mongodb_ss_metrics_commands_setFeatureCompatibilityVersion_failed untyped
+mongodb_ss_metrics_commands_setFeatureCompatibilityVersion_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_setFeatureCompatibilityVersion_total serverStatus.metrics.commands.setFeatureCompatibilityVersion.
+# TYPE mongodb_ss_metrics_commands_setFeatureCompatibilityVersion_total untyped
+mongodb_ss_metrics_commands_setFeatureCompatibilityVersion_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_setFreeMonitoring_failed serverStatus.metrics.commands.setFreeMonitoring.
+# TYPE mongodb_ss_metrics_commands_setFreeMonitoring_failed untyped
+mongodb_ss_metrics_commands_setFreeMonitoring_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_setFreeMonitoring_total serverStatus.metrics.commands.setFreeMonitoring.
+# TYPE mongodb_ss_metrics_commands_setFreeMonitoring_total untyped
+mongodb_ss_metrics_commands_setFreeMonitoring_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_setParameter_failed serverStatus.metrics.commands.setParameter.
+# TYPE mongodb_ss_metrics_commands_setParameter_failed untyped
+mongodb_ss_metrics_commands_setParameter_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_setParameter_total serverStatus.metrics.commands.setParameter.
+# TYPE mongodb_ss_metrics_commands_setParameter_total untyped
+mongodb_ss_metrics_commands_setParameter_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_setShardVersion_failed serverStatus.metrics.commands.setShardVersion.
+# TYPE mongodb_ss_metrics_commands_setShardVersion_failed untyped
+mongodb_ss_metrics_commands_setShardVersion_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_setShardVersion_total serverStatus.metrics.commands.setShardVersion.
+# TYPE mongodb_ss_metrics_commands_setShardVersion_total untyped
+mongodb_ss_metrics_commands_setShardVersion_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_shardConnPoolStats_failed serverStatus.metrics.commands.shardConnPoolStats.
+# TYPE mongodb_ss_metrics_commands_shardConnPoolStats_failed untyped
+mongodb_ss_metrics_commands_shardConnPoolStats_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_shardConnPoolStats_total serverStatus.metrics.commands.shardConnPoolStats.
+# TYPE mongodb_ss_metrics_commands_shardConnPoolStats_total untyped
+mongodb_ss_metrics_commands_shardConnPoolStats_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_shardingState_failed serverStatus.metrics.commands.shardingState.
+# TYPE mongodb_ss_metrics_commands_shardingState_failed untyped
+mongodb_ss_metrics_commands_shardingState_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_shardingState_total serverStatus.metrics.commands.shardingState.
+# TYPE mongodb_ss_metrics_commands_shardingState_total untyped
+mongodb_ss_metrics_commands_shardingState_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_shardsvrShardCollection_failed serverStatus.metrics.commands._shardsvrShardCollection.
+# TYPE mongodb_ss_metrics_commands_shardsvrShardCollection_failed untyped
+mongodb_ss_metrics_commands_shardsvrShardCollection_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_shardsvrShardCollection_total serverStatus.metrics.commands._shardsvrShardCollection.
+# TYPE mongodb_ss_metrics_commands_shardsvrShardCollection_total untyped
+mongodb_ss_metrics_commands_shardsvrShardCollection_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_shutdown_failed serverStatus.metrics.commands.shutdown.
+# TYPE mongodb_ss_metrics_commands_shutdown_failed untyped
+mongodb_ss_metrics_commands_shutdown_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_shutdown_total serverStatus.metrics.commands.shutdown.
+# TYPE mongodb_ss_metrics_commands_shutdown_total untyped
+mongodb_ss_metrics_commands_shutdown_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_splitChunk_failed serverStatus.metrics.commands.splitChunk.
+# TYPE mongodb_ss_metrics_commands_splitChunk_failed untyped
+mongodb_ss_metrics_commands_splitChunk_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_splitChunk_total serverStatus.metrics.commands.splitChunk.
+# TYPE mongodb_ss_metrics_commands_splitChunk_total untyped
+mongodb_ss_metrics_commands_splitChunk_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_splitVector_failed serverStatus.metrics.commands.splitVector.
+# TYPE mongodb_ss_metrics_commands_splitVector_failed untyped
+mongodb_ss_metrics_commands_splitVector_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_splitVector_total serverStatus.metrics.commands.splitVector.
+# TYPE mongodb_ss_metrics_commands_splitVector_total untyped
+mongodb_ss_metrics_commands_splitVector_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_startSession_failed serverStatus.metrics.commands.startSession.
+# TYPE mongodb_ss_metrics_commands_startSession_failed untyped
+mongodb_ss_metrics_commands_startSession_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_startSession_total serverStatus.metrics.commands.startSession.
+# TYPE mongodb_ss_metrics_commands_startSession_total untyped
+mongodb_ss_metrics_commands_startSession_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_top_failed serverStatus.metrics.commands.top.
+# TYPE mongodb_ss_metrics_commands_top_failed untyped
+mongodb_ss_metrics_commands_top_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_top_total serverStatus.metrics.commands.top.
+# TYPE mongodb_ss_metrics_commands_top_total untyped
+mongodb_ss_metrics_commands_top_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 541
+# HELP mongodb_ss_metrics_commands_touch_failed serverStatus.metrics.commands.touch.
+# TYPE mongodb_ss_metrics_commands_touch_failed untyped
+mongodb_ss_metrics_commands_touch_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_touch_total serverStatus.metrics.commands.touch.
+# TYPE mongodb_ss_metrics_commands_touch_total untyped
+mongodb_ss_metrics_commands_touch_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_transferMods_failed serverStatus.metrics.commands._transferMods.
+# TYPE mongodb_ss_metrics_commands_transferMods_failed untyped
+mongodb_ss_metrics_commands_transferMods_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_transferMods_total serverStatus.metrics.commands._transferMods.
+# TYPE mongodb_ss_metrics_commands_transferMods_total untyped
+mongodb_ss_metrics_commands_transferMods_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_unsetSharding_failed serverStatus.metrics.commands.unsetSharding.
+# TYPE mongodb_ss_metrics_commands_unsetSharding_failed untyped
+mongodb_ss_metrics_commands_unsetSharding_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_unsetSharding_total serverStatus.metrics.commands.unsetSharding.
+# TYPE mongodb_ss_metrics_commands_unsetSharding_total untyped
+mongodb_ss_metrics_commands_unsetSharding_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_updateRole_failed serverStatus.metrics.commands.updateRole.
+# TYPE mongodb_ss_metrics_commands_updateRole_failed untyped
+mongodb_ss_metrics_commands_updateRole_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_updateRole_total serverStatus.metrics.commands.updateRole.
+# TYPE mongodb_ss_metrics_commands_updateRole_total untyped
+mongodb_ss_metrics_commands_updateRole_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_updateUser_failed serverStatus.metrics.commands.updateUser.
+# TYPE mongodb_ss_metrics_commands_updateUser_failed untyped
+mongodb_ss_metrics_commands_updateUser_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_updateUser_total serverStatus.metrics.commands.updateUser.
+# TYPE mongodb_ss_metrics_commands_updateUser_total untyped
+mongodb_ss_metrics_commands_updateUser_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_update_failed serverStatus.metrics.commands.update.
+# TYPE mongodb_ss_metrics_commands_update_failed untyped
+mongodb_ss_metrics_commands_update_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_update_total serverStatus.metrics.commands.update.
+# TYPE mongodb_ss_metrics_commands_update_total untyped
+mongodb_ss_metrics_commands_update_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 4
+# HELP mongodb_ss_metrics_commands_usersInfo_failed serverStatus.metrics.commands.usersInfo.
+# TYPE mongodb_ss_metrics_commands_usersInfo_failed untyped
+mongodb_ss_metrics_commands_usersInfo_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_usersInfo_total serverStatus.metrics.commands.usersInfo.
+# TYPE mongodb_ss_metrics_commands_usersInfo_total untyped
+mongodb_ss_metrics_commands_usersInfo_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_validate_failed serverStatus.metrics.commands.validate.
+# TYPE mongodb_ss_metrics_commands_validate_failed untyped
+mongodb_ss_metrics_commands_validate_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_validate_total serverStatus.metrics.commands.validate.
+# TYPE mongodb_ss_metrics_commands_validate_total untyped
+mongodb_ss_metrics_commands_validate_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_whatsmyuri_failed serverStatus.metrics.commands.whatsmyuri.
+# TYPE mongodb_ss_metrics_commands_whatsmyuri_failed untyped
+mongodb_ss_metrics_commands_whatsmyuri_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_commands_whatsmyuri_total serverStatus.metrics.commands.whatsmyuri.
+# TYPE mongodb_ss_metrics_commands_whatsmyuri_total untyped
+mongodb_ss_metrics_commands_whatsmyuri_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 134
+# HELP mongodb_ss_metrics_cursor_open serverStatus.metrics.cursor.open.
+# TYPE mongodb_ss_metrics_cursor_open untyped
+mongodb_ss_metrics_cursor_open{cl_id="6350129adfb0b7e3db4773bb",cl_role="",csr_type="noTimeout",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_metrics_cursor_open{cl_id="6350129adfb0b7e3db4773bb",cl_role="",csr_type="pinned",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_metrics_cursor_open{cl_id="6350129adfb0b7e3db4773bb",cl_role="",csr_type="total",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_cursor_timedOut serverStatus.metrics.cursor.
+# TYPE mongodb_ss_metrics_cursor_timedOut untyped
+mongodb_ss_metrics_cursor_timedOut{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_document serverStatus.metrics.document.
+# TYPE mongodb_ss_metrics_document untyped
+mongodb_ss_metrics_document{cl_id="6350129adfb0b7e3db4773bb",cl_role="",doc_op_type="deleted",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_metrics_document{cl_id="6350129adfb0b7e3db4773bb",cl_role="",doc_op_type="inserted",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_metrics_document{cl_id="6350129adfb0b7e3db4773bb",cl_role="",doc_op_type="returned",rs_nm="rs0",rs_state="1"} 1088
+mongodb_ss_metrics_document{cl_id="6350129adfb0b7e3db4773bb",cl_role="",doc_op_type="updated",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_getLastError_wtime_num serverStatus.metrics.getLastError.wtime.
+# TYPE mongodb_ss_metrics_getLastError_wtime_num untyped
+mongodb_ss_metrics_getLastError_wtime_num{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 5
+# HELP mongodb_ss_metrics_getLastError_wtime_totalMillis serverStatus.metrics.getLastError.wtime.
+# TYPE mongodb_ss_metrics_getLastError_wtime_totalMillis untyped
+mongodb_ss_metrics_getLastError_wtime_totalMillis{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_getLastError_wtimeouts serverStatus.metrics.getLastError.
+# TYPE mongodb_ss_metrics_getLastError_wtimeouts untyped
+mongodb_ss_metrics_getLastError_wtimeouts{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_operation_scanAndOrder serverStatus.metrics.operation.
+# TYPE mongodb_ss_metrics_operation_scanAndOrder untyped
+mongodb_ss_metrics_operation_scanAndOrder{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 3
+# HELP mongodb_ss_metrics_operation_writeConflicts serverStatus.metrics.operation.
+# TYPE mongodb_ss_metrics_operation_writeConflicts untyped
+mongodb_ss_metrics_operation_writeConflicts{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_queryExecutor_scanned serverStatus.metrics.queryExecutor.
+# TYPE mongodb_ss_metrics_queryExecutor_scanned untyped
+mongodb_ss_metrics_queryExecutor_scanned{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_queryExecutor_scannedObjects serverStatus.metrics.queryExecutor.
+# TYPE mongodb_ss_metrics_queryExecutor_scannedObjects untyped
+mongodb_ss_metrics_queryExecutor_scannedObjects{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1088
+# HELP mongodb_ss_metrics_query_planCacheTotalSizeEstimateBytes serverStatus.metrics.query.
+# TYPE mongodb_ss_metrics_query_planCacheTotalSizeEstimateBytes untyped
+mongodb_ss_metrics_query_planCacheTotalSizeEstimateBytes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_query_updateOneOpStyleBroadcastWithExactIDCount serverStatus.metrics.query.
+# TYPE mongodb_ss_metrics_query_updateOneOpStyleBroadcastWithExactIDCount counter
+mongodb_ss_metrics_query_updateOneOpStyleBroadcastWithExactIDCount{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_query_upsertReplacementCannotTargetByQueryCount serverStatus.metrics.query.
+# TYPE mongodb_ss_metrics_query_upsertReplacementCannotTargetByQueryCount counter
+mongodb_ss_metrics_query_upsertReplacementCannotTargetByQueryCount{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_record_moves serverStatus.metrics.record.
+# TYPE mongodb_ss_metrics_record_moves untyped
+mongodb_ss_metrics_record_moves{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_repl_apply_attemptsToBecomeSecondary serverStatus.metrics.repl.apply.
+# TYPE mongodb_ss_metrics_repl_apply_attemptsToBecomeSecondary untyped
+mongodb_ss_metrics_repl_apply_attemptsToBecomeSecondary{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_ss_metrics_repl_apply_batchSize serverStatus.metrics.repl.apply.
+# TYPE mongodb_ss_metrics_repl_apply_batchSize untyped
+mongodb_ss_metrics_repl_apply_batchSize{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_repl_apply_batches_num serverStatus.metrics.repl.apply.batches.
+# TYPE mongodb_ss_metrics_repl_apply_batches_num untyped
+mongodb_ss_metrics_repl_apply_batches_num{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_repl_apply_batches_totalMillis serverStatus.metrics.repl.apply.batches.
+# TYPE mongodb_ss_metrics_repl_apply_batches_totalMillis untyped
+mongodb_ss_metrics_repl_apply_batches_totalMillis{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_repl_apply_ops serverStatus.metrics.repl.apply.
+# TYPE mongodb_ss_metrics_repl_apply_ops untyped
+mongodb_ss_metrics_repl_apply_ops{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_repl_buffer_count serverStatus.metrics.repl.buffer.
+# TYPE mongodb_ss_metrics_repl_buffer_count counter
+mongodb_ss_metrics_repl_buffer_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_repl_buffer_maxSizeBytes serverStatus.metrics.repl.buffer.
+# TYPE mongodb_ss_metrics_repl_buffer_maxSizeBytes untyped
+mongodb_ss_metrics_repl_buffer_maxSizeBytes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 2.68435456e+08
+# HELP mongodb_ss_metrics_repl_buffer_sizeBytes serverStatus.metrics.repl.buffer.
+# TYPE mongodb_ss_metrics_repl_buffer_sizeBytes untyped
+mongodb_ss_metrics_repl_buffer_sizeBytes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_repl_executor_pool_inProgressCount serverStatus.metrics.repl.executor.pool.
+# TYPE mongodb_ss_metrics_repl_executor_pool_inProgressCount counter
+mongodb_ss_metrics_repl_executor_pool_inProgressCount{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_repl_executor_queues_networkInProgress serverStatus.metrics.repl.executor.queues.
+# TYPE mongodb_ss_metrics_repl_executor_queues_networkInProgress untyped
+mongodb_ss_metrics_repl_executor_queues_networkInProgress{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_repl_executor_queues_sleepers serverStatus.metrics.repl.executor.queues.
+# TYPE mongodb_ss_metrics_repl_executor_queues_sleepers untyped
+mongodb_ss_metrics_repl_executor_queues_sleepers{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_repl_executor_shuttingDown serverStatus.metrics.repl.executor.
+# TYPE mongodb_ss_metrics_repl_executor_shuttingDown untyped
+mongodb_ss_metrics_repl_executor_shuttingDown{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_repl_executor_unsignaledEvents serverStatus.metrics.repl.executor.
+# TYPE mongodb_ss_metrics_repl_executor_unsignaledEvents untyped
+mongodb_ss_metrics_repl_executor_unsignaledEvents{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_repl_initialSync_completed serverStatus.metrics.repl.initialSync.
+# TYPE mongodb_ss_metrics_repl_initialSync_completed untyped
+mongodb_ss_metrics_repl_initialSync_completed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_repl_initialSync_failedAttempts serverStatus.metrics.repl.initialSync.
+# TYPE mongodb_ss_metrics_repl_initialSync_failedAttempts untyped
+mongodb_ss_metrics_repl_initialSync_failedAttempts{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_repl_initialSync_failures serverStatus.metrics.repl.initialSync.
+# TYPE mongodb_ss_metrics_repl_initialSync_failures untyped
+mongodb_ss_metrics_repl_initialSync_failures{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_repl_network_bytes serverStatus.metrics.repl.network.
+# TYPE mongodb_ss_metrics_repl_network_bytes untyped
+mongodb_ss_metrics_repl_network_bytes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_repl_network_getmores_num serverStatus.metrics.repl.network.getmores.
+# TYPE mongodb_ss_metrics_repl_network_getmores_num untyped
+mongodb_ss_metrics_repl_network_getmores_num{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_repl_network_getmores_totalMillis serverStatus.metrics.repl.network.getmores.
+# TYPE mongodb_ss_metrics_repl_network_getmores_totalMillis untyped
+mongodb_ss_metrics_repl_network_getmores_totalMillis{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_repl_network_ops serverStatus.metrics.repl.network.
+# TYPE mongodb_ss_metrics_repl_network_ops untyped
+mongodb_ss_metrics_repl_network_ops{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_repl_network_readersCreated serverStatus.metrics.repl.network.
+# TYPE mongodb_ss_metrics_repl_network_readersCreated untyped
+mongodb_ss_metrics_repl_network_readersCreated{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_repl_preload_docs_num serverStatus.metrics.repl.preload.docs.
+# TYPE mongodb_ss_metrics_repl_preload_docs_num untyped
+mongodb_ss_metrics_repl_preload_docs_num{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_repl_preload_docs_totalMillis serverStatus.metrics.repl.preload.docs.
+# TYPE mongodb_ss_metrics_repl_preload_docs_totalMillis untyped
+mongodb_ss_metrics_repl_preload_docs_totalMillis{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_repl_preload_indexes_num serverStatus.metrics.repl.preload.indexes.
+# TYPE mongodb_ss_metrics_repl_preload_indexes_num untyped
+mongodb_ss_metrics_repl_preload_indexes_num{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_repl_preload_indexes_totalMillis serverStatus.metrics.repl.preload.indexes.
+# TYPE mongodb_ss_metrics_repl_preload_indexes_totalMillis untyped
+mongodb_ss_metrics_repl_preload_indexes_totalMillis{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_storage_freelist_search_bucketExhausted serverStatus.metrics.storage.freelist.search.
+# TYPE mongodb_ss_metrics_storage_freelist_search_bucketExhausted untyped
+mongodb_ss_metrics_storage_freelist_search_bucketExhausted{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_storage_freelist_search_requests serverStatus.metrics.storage.freelist.search.
+# TYPE mongodb_ss_metrics_storage_freelist_search_requests untyped
+mongodb_ss_metrics_storage_freelist_search_requests{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_storage_freelist_search_scanned serverStatus.metrics.storage.freelist.search.
+# TYPE mongodb_ss_metrics_storage_freelist_search_scanned untyped
+mongodb_ss_metrics_storage_freelist_search_scanned{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_ttl_deletedDocuments serverStatus.metrics.ttl.
+# TYPE mongodb_ss_metrics_ttl_deletedDocuments untyped
+mongodb_ss_metrics_ttl_deletedDocuments{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_metrics_ttl_passes serverStatus.metrics.ttl.
+# TYPE mongodb_ss_metrics_ttl_passes untyped
+mongodb_ss_metrics_ttl_passes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 22
+# HELP mongodb_ss_network_bytesIn serverStatus.network.
+# TYPE mongodb_ss_network_bytesIn untyped
+mongodb_ss_network_bytesIn{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 4.567291e+06
+# HELP mongodb_ss_network_bytesOut serverStatus.network.
+# TYPE mongodb_ss_network_bytesOut untyped
+mongodb_ss_network_bytesOut{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 8.7856959e+07
+# HELP mongodb_ss_network_compression_snappy_compressor_bytesIn serverStatus.network.compression.snappy.compressor.
+# TYPE mongodb_ss_network_compression_snappy_compressor_bytesIn untyped
+mongodb_ss_network_compression_snappy_compressor_bytesIn{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_network_compression_snappy_compressor_bytesOut serverStatus.network.compression.snappy.compressor.
+# TYPE mongodb_ss_network_compression_snappy_compressor_bytesOut untyped
+mongodb_ss_network_compression_snappy_compressor_bytesOut{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_network_compression_snappy_decompressor_bytesIn serverStatus.network.compression.snappy.decompressor.
+# TYPE mongodb_ss_network_compression_snappy_decompressor_bytesIn untyped
+mongodb_ss_network_compression_snappy_decompressor_bytesIn{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_network_compression_snappy_decompressor_bytesOut serverStatus.network.compression.snappy.decompressor.
+# TYPE mongodb_ss_network_compression_snappy_decompressor_bytesOut untyped
+mongodb_ss_network_compression_snappy_decompressor_bytesOut{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_network_numRequests serverStatus.network.
+# TYPE mongodb_ss_network_numRequests untyped
+mongodb_ss_network_numRequests{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 16676
+# HELP mongodb_ss_network_physicalBytesIn serverStatus.network.
+# TYPE mongodb_ss_network_physicalBytesIn untyped
+mongodb_ss_network_physicalBytesIn{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 4.567291e+06
+# HELP mongodb_ss_network_physicalBytesOut serverStatus.network.
+# TYPE mongodb_ss_network_physicalBytesOut untyped
+mongodb_ss_network_physicalBytesOut{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 8.7856959e+07
+# HELP mongodb_ss_network_serviceExecutorTaskStats_threadsRunning serverStatus.network.serviceExecutorTaskStats.
+# TYPE mongodb_ss_network_serviceExecutorTaskStats_threadsRunning untyped
+mongodb_ss_network_serviceExecutorTaskStats_threadsRunning{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 2
+# HELP mongodb_ss_ok serverStatus.
+# TYPE mongodb_ss_ok untyped
+mongodb_ss_ok{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_ss_opLatencies_latency mongodb_ss_opLatencies_latency
+# TYPE mongodb_ss_opLatencies_latency untyped
+mongodb_ss_opLatencies_latency{op_type="commands"} 2.695412e+06
+mongodb_ss_opLatencies_latency{op_type="reads"} 196719
+mongodb_ss_opLatencies_latency{op_type="transactions"} 0
+mongodb_ss_opLatencies_latency{op_type="writes"} 0
+# HELP mongodb_ss_opLatencies_ops mongodb_ss_opLatencies_ops
+# TYPE mongodb_ss_opLatencies_ops untyped
+mongodb_ss_opLatencies_ops{op_type="commands"} 14508
+mongodb_ss_opLatencies_ops{op_type="reads"} 2168
+mongodb_ss_opLatencies_ops{op_type="transactions"} 0
+mongodb_ss_opLatencies_ops{op_type="writes"} 0
+# HELP mongodb_ss_opReadConcernCounters serverStatus.opReadConcernCounters.
+# TYPE mongodb_ss_opReadConcernCounters untyped
+mongodb_ss_opReadConcernCounters{cl_id="6350129adfb0b7e3db4773bb",cl_role="",concern_type="available",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_opReadConcernCounters{cl_id="6350129adfb0b7e3db4773bb",cl_role="",concern_type="linearizable",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_opReadConcernCounters{cl_id="6350129adfb0b7e3db4773bb",cl_role="",concern_type="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_opReadConcernCounters{cl_id="6350129adfb0b7e3db4773bb",cl_role="",concern_type="majority",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_opReadConcernCounters{cl_id="6350129adfb0b7e3db4773bb",cl_role="",concern_type="none",rs_nm="rs0",rs_state="1"} 2176
+mongodb_ss_opReadConcernCounters{cl_id="6350129adfb0b7e3db4773bb",cl_role="",concern_type="snapshot",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_opcounters serverStatus.opcounters.
+# TYPE mongodb_ss_opcounters untyped
+mongodb_ss_opcounters{cl_id="6350129adfb0b7e3db4773bb",cl_role="",legacy_op_type="command",rs_nm="rs0",rs_state="1"} 14384
+mongodb_ss_opcounters{cl_id="6350129adfb0b7e3db4773bb",cl_role="",legacy_op_type="delete",rs_nm="rs0",rs_state="1"} 1
+mongodb_ss_opcounters{cl_id="6350129adfb0b7e3db4773bb",cl_role="",legacy_op_type="getmore",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_opcounters{cl_id="6350129adfb0b7e3db4773bb",cl_role="",legacy_op_type="insert",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_opcounters{cl_id="6350129adfb0b7e3db4773bb",cl_role="",legacy_op_type="query",rs_nm="rs0",rs_state="1"} 2176
+mongodb_ss_opcounters{cl_id="6350129adfb0b7e3db4773bb",cl_role="",legacy_op_type="update",rs_nm="rs0",rs_state="1"} 481
+# HELP mongodb_ss_opcountersRepl serverStatus.opcountersRepl.
+# TYPE mongodb_ss_opcountersRepl untyped
+mongodb_ss_opcountersRepl{cl_id="6350129adfb0b7e3db4773bb",cl_role="",legacy_op_type="command",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_opcountersRepl{cl_id="6350129adfb0b7e3db4773bb",cl_role="",legacy_op_type="delete",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_opcountersRepl{cl_id="6350129adfb0b7e3db4773bb",cl_role="",legacy_op_type="getmore",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_opcountersRepl{cl_id="6350129adfb0b7e3db4773bb",cl_role="",legacy_op_type="insert",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_opcountersRepl{cl_id="6350129adfb0b7e3db4773bb",cl_role="",legacy_op_type="query",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_opcountersRepl{cl_id="6350129adfb0b7e3db4773bb",cl_role="",legacy_op_type="update",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_oplogTruncation_totalTimeProcessingMicros serverStatus.oplogTruncation.
+# TYPE mongodb_ss_oplogTruncation_totalTimeProcessingMicros untyped
+mongodb_ss_oplogTruncation_totalTimeProcessingMicros{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 292
+# HELP mongodb_ss_oplogTruncation_totalTimeTruncatingMicros serverStatus.oplogTruncation.
+# TYPE mongodb_ss_oplogTruncation_totalTimeTruncatingMicros untyped
+mongodb_ss_oplogTruncation_totalTimeTruncatingMicros{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_oplogTruncation_truncateCount serverStatus.oplogTruncation.
+# TYPE mongodb_ss_oplogTruncation_truncateCount counter
+mongodb_ss_oplogTruncation_truncateCount{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_pid serverStatus.
+# TYPE mongodb_ss_pid untyped
+mongodb_ss_pid{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_ss_repl_ismaster serverStatus.repl.
+# TYPE mongodb_ss_repl_ismaster untyped
+mongodb_ss_repl_ismaster{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_ss_repl_lastWrite_lastWriteDate serverStatus.repl.lastWrite.
+# TYPE mongodb_ss_repl_lastWrite_lastWriteDate untyped
+mongodb_ss_repl_lastWrite_lastWriteDate{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.666193396e+12
+# HELP mongodb_ss_repl_lastWrite_majorityOpTime_t serverStatus.repl.lastWrite.majorityOpTime.
+# TYPE mongodb_ss_repl_lastWrite_majorityOpTime_t untyped
+mongodb_ss_repl_lastWrite_majorityOpTime_t{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 3
+# HELP mongodb_ss_repl_lastWrite_majorityWriteDate serverStatus.repl.lastWrite.
+# TYPE mongodb_ss_repl_lastWrite_majorityWriteDate untyped
+mongodb_ss_repl_lastWrite_majorityWriteDate{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.666193396e+12
+# HELP mongodb_ss_repl_lastWrite_opTime_t serverStatus.repl.lastWrite.opTime.
+# TYPE mongodb_ss_repl_lastWrite_opTime_t untyped
+mongodb_ss_repl_lastWrite_opTime_t{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 3
+# HELP mongodb_ss_repl_rbid serverStatus.repl.
+# TYPE mongodb_ss_repl_rbid untyped
+mongodb_ss_repl_rbid{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_ss_repl_secondary serverStatus.repl.
+# TYPE mongodb_ss_repl_secondary untyped
+mongodb_ss_repl_secondary{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_repl_setVersion serverStatus.repl.
+# TYPE mongodb_ss_repl_setVersion untyped
+mongodb_ss_repl_setVersion{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_ss_start serverStatus.
+# TYPE mongodb_ss_start untyped
+mongodb_ss_start{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.666193406e+12
+# HELP mongodb_ss_storageEngine_persistent serverStatus.storageEngine.
+# TYPE mongodb_ss_storageEngine_persistent untyped
+mongodb_ss_storageEngine_persistent{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_ss_storageEngine_readOnly serverStatus.storageEngine.
+# TYPE mongodb_ss_storageEngine_readOnly untyped
+mongodb_ss_storageEngine_readOnly{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_storageEngine_supportsCommittedReads serverStatus.storageEngine.
+# TYPE mongodb_ss_storageEngine_supportsCommittedReads untyped
+mongodb_ss_storageEngine_supportsCommittedReads{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_ss_storageEngine_supportsSnapshotReadConcern serverStatus.storageEngine.
+# TYPE mongodb_ss_storageEngine_supportsSnapshotReadConcern untyped
+mongodb_ss_storageEngine_supportsSnapshotReadConcern{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_ss_tcmalloc_generic_current_allocated_bytes serverStatus.tcmalloc.generic.
+# TYPE mongodb_ss_tcmalloc_generic_current_allocated_bytes untyped
+mongodb_ss_tcmalloc_generic_current_allocated_bytes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 7.7857536e+07
+# HELP mongodb_ss_tcmalloc_generic_heap_size serverStatus.tcmalloc.generic.
+# TYPE mongodb_ss_tcmalloc_generic_heap_size untyped
+mongodb_ss_tcmalloc_generic_heap_size{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 8.5004288e+07
+# HELP mongodb_ss_tcmalloc_tcmalloc_aggressive_memory_decommit serverStatus.tcmalloc.tcmalloc.
+# TYPE mongodb_ss_tcmalloc_tcmalloc_aggressive_memory_decommit untyped
+mongodb_ss_tcmalloc_tcmalloc_aggressive_memory_decommit{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_tcmalloc_tcmalloc_central_cache_free_bytes serverStatus.tcmalloc.tcmalloc.
+# TYPE mongodb_ss_tcmalloc_tcmalloc_central_cache_free_bytes untyped
+mongodb_ss_tcmalloc_tcmalloc_central_cache_free_bytes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 521112
+# HELP mongodb_ss_tcmalloc_tcmalloc_current_total_thread_cache_bytes serverStatus.tcmalloc.tcmalloc.
+# TYPE mongodb_ss_tcmalloc_tcmalloc_current_total_thread_cache_bytes untyped
+mongodb_ss_tcmalloc_tcmalloc_current_total_thread_cache_bytes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.111784e+06
+# HELP mongodb_ss_tcmalloc_tcmalloc_max_total_thread_cache_bytes serverStatus.tcmalloc.tcmalloc.
+# TYPE mongodb_ss_tcmalloc_tcmalloc_max_total_thread_cache_bytes untyped
+mongodb_ss_tcmalloc_tcmalloc_max_total_thread_cache_bytes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.073741824e+09
+# HELP mongodb_ss_tcmalloc_tcmalloc_pageheap_commit_count serverStatus.tcmalloc.tcmalloc.
+# TYPE mongodb_ss_tcmalloc_tcmalloc_pageheap_commit_count counter
+mongodb_ss_tcmalloc_tcmalloc_pageheap_commit_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 60
+# HELP mongodb_ss_tcmalloc_tcmalloc_pageheap_committed_bytes serverStatus.tcmalloc.tcmalloc.
+# TYPE mongodb_ss_tcmalloc_tcmalloc_pageheap_committed_bytes untyped
+mongodb_ss_tcmalloc_tcmalloc_pageheap_committed_bytes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 8.5000192e+07
+# HELP mongodb_ss_tcmalloc_tcmalloc_pageheap_decommit_count serverStatus.tcmalloc.tcmalloc.
+# TYPE mongodb_ss_tcmalloc_tcmalloc_pageheap_decommit_count counter
+mongodb_ss_tcmalloc_tcmalloc_pageheap_decommit_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_ss_tcmalloc_tcmalloc_pageheap_free_bytes serverStatus.tcmalloc.tcmalloc.
+# TYPE mongodb_ss_tcmalloc_tcmalloc_pageheap_free_bytes untyped
+mongodb_ss_tcmalloc_tcmalloc_pageheap_free_bytes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 3.56352e+06
+# HELP mongodb_ss_tcmalloc_tcmalloc_pageheap_reserve_count serverStatus.tcmalloc.tcmalloc.
+# TYPE mongodb_ss_tcmalloc_tcmalloc_pageheap_reserve_count counter
+mongodb_ss_tcmalloc_tcmalloc_pageheap_reserve_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 50
+# HELP mongodb_ss_tcmalloc_tcmalloc_pageheap_scavenge_count serverStatus.tcmalloc.tcmalloc.
+# TYPE mongodb_ss_tcmalloc_tcmalloc_pageheap_scavenge_count counter
+mongodb_ss_tcmalloc_tcmalloc_pageheap_scavenge_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_ss_tcmalloc_tcmalloc_pageheap_total_commit_bytes serverStatus.tcmalloc.tcmalloc.
+# TYPE mongodb_ss_tcmalloc_tcmalloc_pageheap_total_commit_bytes untyped
+mongodb_ss_tcmalloc_tcmalloc_pageheap_total_commit_bytes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 8.8567808e+07
+# HELP mongodb_ss_tcmalloc_tcmalloc_pageheap_total_decommit_bytes serverStatus.tcmalloc.tcmalloc.
+# TYPE mongodb_ss_tcmalloc_tcmalloc_pageheap_total_decommit_bytes untyped
+mongodb_ss_tcmalloc_tcmalloc_pageheap_total_decommit_bytes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 3.567616e+06
+# HELP mongodb_ss_tcmalloc_tcmalloc_pageheap_total_reserve_bytes serverStatus.tcmalloc.tcmalloc.
+# TYPE mongodb_ss_tcmalloc_tcmalloc_pageheap_total_reserve_bytes untyped
+mongodb_ss_tcmalloc_tcmalloc_pageheap_total_reserve_bytes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 8.5004288e+07
+# HELP mongodb_ss_tcmalloc_tcmalloc_pageheap_unmapped_bytes serverStatus.tcmalloc.tcmalloc.
+# TYPE mongodb_ss_tcmalloc_tcmalloc_pageheap_unmapped_bytes untyped
+mongodb_ss_tcmalloc_tcmalloc_pageheap_unmapped_bytes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 4096
+# HELP mongodb_ss_tcmalloc_tcmalloc_spinlock_total_delay_ns serverStatus.tcmalloc.tcmalloc.
+# TYPE mongodb_ss_tcmalloc_tcmalloc_spinlock_total_delay_ns untyped
+mongodb_ss_tcmalloc_tcmalloc_spinlock_total_delay_ns{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 3.454625e+06
+# HELP mongodb_ss_tcmalloc_tcmalloc_thread_cache_free_bytes serverStatus.tcmalloc.tcmalloc.
+# TYPE mongodb_ss_tcmalloc_tcmalloc_thread_cache_free_bytes untyped
+mongodb_ss_tcmalloc_tcmalloc_thread_cache_free_bytes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.111784e+06
+# HELP mongodb_ss_tcmalloc_tcmalloc_total_free_bytes serverStatus.tcmalloc.tcmalloc.
+# TYPE mongodb_ss_tcmalloc_tcmalloc_total_free_bytes untyped
+mongodb_ss_tcmalloc_tcmalloc_total_free_bytes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 3.579136e+06
+# HELP mongodb_ss_tcmalloc_tcmalloc_transfer_cache_free_bytes serverStatus.tcmalloc.tcmalloc.
+# TYPE mongodb_ss_tcmalloc_tcmalloc_transfer_cache_free_bytes untyped
+mongodb_ss_tcmalloc_tcmalloc_transfer_cache_free_bytes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.94624e+06
+# HELP mongodb_ss_transactions_currentActive serverStatus.transactions.
+# TYPE mongodb_ss_transactions_currentActive untyped
+mongodb_ss_transactions_currentActive{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_transactions_currentInactive serverStatus.transactions.
+# TYPE mongodb_ss_transactions_currentInactive untyped
+mongodb_ss_transactions_currentInactive{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_transactions_currentOpen serverStatus.transactions.
+# TYPE mongodb_ss_transactions_currentOpen untyped
+mongodb_ss_transactions_currentOpen{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_transactions_retriedCommandsCount serverStatus.transactions.
+# TYPE mongodb_ss_transactions_retriedCommandsCount counter
+mongodb_ss_transactions_retriedCommandsCount{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_transactions_retriedStatementsCount serverStatus.transactions.
+# TYPE mongodb_ss_transactions_retriedStatementsCount counter
+mongodb_ss_transactions_retriedStatementsCount{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_transactions_totalAborted serverStatus.transactions.
+# TYPE mongodb_ss_transactions_totalAborted untyped
+mongodb_ss_transactions_totalAborted{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_transactions_totalCommitted serverStatus.transactions.
+# TYPE mongodb_ss_transactions_totalCommitted untyped
+mongodb_ss_transactions_totalCommitted{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_transactions_totalStarted serverStatus.transactions.
+# TYPE mongodb_ss_transactions_totalStarted untyped
+mongodb_ss_transactions_totalStarted{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_transactions_transactionsCollectionWriteCount serverStatus.transactions.
+# TYPE mongodb_ss_transactions_transactionsCollectionWriteCount counter
+mongodb_ss_transactions_transactionsCollectionWriteCount{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_transportSecurity_1_0 serverStatus.transportSecurity.
+# TYPE mongodb_ss_transportSecurity_1_0 untyped
+mongodb_ss_transportSecurity_1_0{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_transportSecurity_1_1 serverStatus.transportSecurity.
+# TYPE mongodb_ss_transportSecurity_1_1 untyped
+mongodb_ss_transportSecurity_1_1{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_transportSecurity_1_2 serverStatus.transportSecurity.
+# TYPE mongodb_ss_transportSecurity_1_2 untyped
+mongodb_ss_transportSecurity_1_2{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_transportSecurity_1_3 serverStatus.transportSecurity.
+# TYPE mongodb_ss_transportSecurity_1_3 untyped
+mongodb_ss_transportSecurity_1_3{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_transportSecurity_unknown serverStatus.transportSecurity.
+# TYPE mongodb_ss_transportSecurity_unknown untyped
+mongodb_ss_transportSecurity_unknown{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_uptime serverStatus.
+# TYPE mongodb_ss_uptime untyped
+mongodb_ss_uptime{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1342
+# HELP mongodb_ss_uptimeEstimate serverStatus.
+# TYPE mongodb_ss_uptimeEstimate untyped
+mongodb_ss_uptimeEstimate{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1342
+# HELP mongodb_ss_uptimeMillis serverStatus.
+# TYPE mongodb_ss_uptimeMillis untyped
+mongodb_ss_uptimeMillis{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.342718e+06
+# HELP mongodb_ss_wt_LSM_application_work_units_currently_queued serverStatus.wiredTiger.LSM.
+# TYPE mongodb_ss_wt_LSM_application_work_units_currently_queued untyped
+mongodb_ss_wt_LSM_application_work_units_currently_queued{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_LSM_merge_work_units_currently_queued serverStatus.wiredTiger.LSM.
+# TYPE mongodb_ss_wt_LSM_merge_work_units_currently_queued untyped
+mongodb_ss_wt_LSM_merge_work_units_currently_queued{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_LSM_rows_merged_in_an_LSM_tree serverStatus.wiredTiger.LSM.
+# TYPE mongodb_ss_wt_LSM_rows_merged_in_an_LSM_tree untyped
+mongodb_ss_wt_LSM_rows_merged_in_an_LSM_tree{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_LSM_sleep_for_LSM_checkpoint_throttle serverStatus.wiredTiger.LSM.
+# TYPE mongodb_ss_wt_LSM_sleep_for_LSM_checkpoint_throttle untyped
+mongodb_ss_wt_LSM_sleep_for_LSM_checkpoint_throttle{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_LSM_sleep_for_LSM_merge_throttle serverStatus.wiredTiger.LSM.
+# TYPE mongodb_ss_wt_LSM_sleep_for_LSM_merge_throttle untyped
+mongodb_ss_wt_LSM_sleep_for_LSM_merge_throttle{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_LSM_switch_work_units_currently_queued serverStatus.wiredTiger.LSM.
+# TYPE mongodb_ss_wt_LSM_switch_work_units_currently_queued untyped
+mongodb_ss_wt_LSM_switch_work_units_currently_queued{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_LSM_tree_maintenance_operations_discarded serverStatus.wiredTiger.LSM.
+# TYPE mongodb_ss_wt_LSM_tree_maintenance_operations_discarded untyped
+mongodb_ss_wt_LSM_tree_maintenance_operations_discarded{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_LSM_tree_maintenance_operations_executed serverStatus.wiredTiger.LSM.
+# TYPE mongodb_ss_wt_LSM_tree_maintenance_operations_executed untyped
+mongodb_ss_wt_LSM_tree_maintenance_operations_executed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_LSM_tree_maintenance_operations_scheduled serverStatus.wiredTiger.LSM.
+# TYPE mongodb_ss_wt_LSM_tree_maintenance_operations_scheduled untyped
+mongodb_ss_wt_LSM_tree_maintenance_operations_scheduled{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_LSM_tree_queue_hit_maximum serverStatus.wiredTiger.LSM.
+# TYPE mongodb_ss_wt_LSM_tree_queue_hit_maximum untyped
+mongodb_ss_wt_LSM_tree_queue_hit_maximum{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_async_current_work_queue_length serverStatus.wiredTiger.async.
+# TYPE mongodb_ss_wt_async_current_work_queue_length untyped
+mongodb_ss_wt_async_current_work_queue_length{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_async_maximum_work_queue_length serverStatus.wiredTiger.async.
+# TYPE mongodb_ss_wt_async_maximum_work_queue_length untyped
+mongodb_ss_wt_async_maximum_work_queue_length{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_async_number_of_allocation_state_races serverStatus.wiredTiger.async.
+# TYPE mongodb_ss_wt_async_number_of_allocation_state_races untyped
+mongodb_ss_wt_async_number_of_allocation_state_races{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_async_number_of_flush_calls serverStatus.wiredTiger.async.
+# TYPE mongodb_ss_wt_async_number_of_flush_calls untyped
+mongodb_ss_wt_async_number_of_flush_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_async_number_of_operation_slots_viewed_for_allocation serverStatus.wiredTiger.async.
+# TYPE mongodb_ss_wt_async_number_of_operation_slots_viewed_for_allocation untyped
+mongodb_ss_wt_async_number_of_operation_slots_viewed_for_allocation{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_async_number_of_times_operation_allocation_failed serverStatus.wiredTiger.async.
+# TYPE mongodb_ss_wt_async_number_of_times_operation_allocation_failed untyped
+mongodb_ss_wt_async_number_of_times_operation_allocation_failed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_async_number_of_times_worker_found_no_work serverStatus.wiredTiger.async.
+# TYPE mongodb_ss_wt_async_number_of_times_worker_found_no_work untyped
+mongodb_ss_wt_async_number_of_times_worker_found_no_work{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_async_total_allocations serverStatus.wiredTiger.async.
+# TYPE mongodb_ss_wt_async_total_allocations untyped
+mongodb_ss_wt_async_total_allocations{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_async_total_compact_calls serverStatus.wiredTiger.async.
+# TYPE mongodb_ss_wt_async_total_compact_calls untyped
+mongodb_ss_wt_async_total_compact_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_async_total_insert_calls serverStatus.wiredTiger.async.
+# TYPE mongodb_ss_wt_async_total_insert_calls untyped
+mongodb_ss_wt_async_total_insert_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_async_total_remove_calls serverStatus.wiredTiger.async.
+# TYPE mongodb_ss_wt_async_total_remove_calls untyped
+mongodb_ss_wt_async_total_remove_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_async_total_search_calls serverStatus.wiredTiger.async.
+# TYPE mongodb_ss_wt_async_total_search_calls untyped
+mongodb_ss_wt_async_total_search_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_async_total_update_calls serverStatus.wiredTiger.async.
+# TYPE mongodb_ss_wt_async_total_update_calls untyped
+mongodb_ss_wt_async_total_update_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_block_manager_blocks_pre_loaded serverStatus.wiredTiger.block-manager.
+# TYPE mongodb_ss_wt_block_manager_blocks_pre_loaded untyped
+mongodb_ss_wt_block_manager_blocks_pre_loaded{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 20
+# HELP mongodb_ss_wt_block_manager_blocks_read serverStatus.wiredTiger.block-manager.
+# TYPE mongodb_ss_wt_block_manager_blocks_read untyped
+mongodb_ss_wt_block_manager_blocks_read{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 141
+# HELP mongodb_ss_wt_block_manager_blocks_written serverStatus.wiredTiger.block-manager.
+# TYPE mongodb_ss_wt_block_manager_blocks_written untyped
+mongodb_ss_wt_block_manager_blocks_written{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 398
+# HELP mongodb_ss_wt_block_manager_bytes_read serverStatus.wiredTiger.block-manager.
+# TYPE mongodb_ss_wt_block_manager_bytes_read untyped
+mongodb_ss_wt_block_manager_bytes_read{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 614400
+# HELP mongodb_ss_wt_block_manager_bytes_written serverStatus.wiredTiger.block-manager.
+# TYPE mongodb_ss_wt_block_manager_bytes_written untyped
+mongodb_ss_wt_block_manager_bytes_written{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 2.531328e+06
+# HELP mongodb_ss_wt_block_manager_bytes_written_for_checkpoint serverStatus.wiredTiger.block-manager.
+# TYPE mongodb_ss_wt_block_manager_bytes_written_for_checkpoint untyped
+mongodb_ss_wt_block_manager_bytes_written_for_checkpoint{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 2.531328e+06
+# HELP mongodb_ss_wt_block_manager_mapped_blocks_read serverStatus.wiredTiger.block-manager.
+# TYPE mongodb_ss_wt_block_manager_mapped_blocks_read untyped
+mongodb_ss_wt_block_manager_mapped_blocks_read{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_block_manager_mapped_bytes_read serverStatus.wiredTiger.block-manager.
+# TYPE mongodb_ss_wt_block_manager_mapped_bytes_read untyped
+mongodb_ss_wt_block_manager_mapped_bytes_read{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_application_threads_page_read_from_disk_to_cache_count serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_application_threads_page_read_from_disk_to_cache_count counter
+mongodb_ss_wt_cache_application_threads_page_read_from_disk_to_cache_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 18
+# HELP mongodb_ss_wt_cache_application_threads_page_read_from_disk_to_cache_time_usecs serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_application_threads_page_read_from_disk_to_cache_time_usecs untyped
+mongodb_ss_wt_cache_application_threads_page_read_from_disk_to_cache_time_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 117
+# HELP mongodb_ss_wt_cache_application_threads_page_write_from_cache_to_disk_count serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_application_threads_page_write_from_cache_to_disk_count counter
+mongodb_ss_wt_cache_application_threads_page_write_from_cache_to_disk_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 209
+# HELP mongodb_ss_wt_cache_application_threads_page_write_from_cache_to_disk_time_usecs serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_application_threads_page_write_from_cache_to_disk_time_usecs untyped
+mongodb_ss_wt_cache_application_threads_page_write_from_cache_to_disk_time_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 8424
+# HELP mongodb_ss_wt_cache_bytes_belonging_to_page_images_in_the_cache serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_bytes_belonging_to_page_images_in_the_cache untyped
+mongodb_ss_wt_cache_bytes_belonging_to_page_images_in_the_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 63403
+# HELP mongodb_ss_wt_cache_bytes_belonging_to_the_cache_overflow_table_in_the_cache serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_bytes_belonging_to_the_cache_overflow_table_in_the_cache untyped
+mongodb_ss_wt_cache_bytes_belonging_to_the_cache_overflow_table_in_the_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 182
+# HELP mongodb_ss_wt_cache_bytes_currently_in_the_cache serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_bytes_currently_in_the_cache untyped
+mongodb_ss_wt_cache_bytes_currently_in_the_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 534286
+# HELP mongodb_ss_wt_cache_bytes_dirty_in_the_cache_cumulative serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_bytes_dirty_in_the_cache_cumulative untyped
+mongodb_ss_wt_cache_bytes_dirty_in_the_cache_cumulative{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 653975
+# HELP mongodb_ss_wt_cache_bytes_not_belonging_to_page_images_in_the_cache serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_bytes_not_belonging_to_page_images_in_the_cache untyped
+mongodb_ss_wt_cache_bytes_not_belonging_to_page_images_in_the_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 470883
+# HELP mongodb_ss_wt_cache_bytes_read_into_cache serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_bytes_read_into_cache untyped
+mongodb_ss_wt_cache_bytes_read_into_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 58707
+# HELP mongodb_ss_wt_cache_bytes_written_from_cache serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_bytes_written_from_cache untyped
+mongodb_ss_wt_cache_bytes_written_from_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.72371e+06
+# HELP mongodb_ss_wt_cache_cache_overflow_cursor_application_thread_wait_time_usecs serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_cache_overflow_cursor_application_thread_wait_time_usecs untyped
+mongodb_ss_wt_cache_cache_overflow_cursor_application_thread_wait_time_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_cache_overflow_cursor_internal_thread_wait_time_usecs serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_cache_overflow_cursor_internal_thread_wait_time_usecs untyped
+mongodb_ss_wt_cache_cache_overflow_cursor_internal_thread_wait_time_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_cache_overflow_score serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_cache_overflow_score untyped
+mongodb_ss_wt_cache_cache_overflow_score{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_cache_overflow_table_entries serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_cache_overflow_table_entries untyped
+mongodb_ss_wt_cache_cache_overflow_table_entries{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_cache_overflow_table_insert_calls serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_cache_overflow_table_insert_calls untyped
+mongodb_ss_wt_cache_cache_overflow_table_insert_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_cache_overflow_table_max_on_disk_size serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_cache_overflow_table_max_on_disk_size untyped
+mongodb_ss_wt_cache_cache_overflow_table_max_on_disk_size{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_cache_overflow_table_on_disk_size serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_cache_overflow_table_on_disk_size untyped
+mongodb_ss_wt_cache_cache_overflow_table_on_disk_size{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_cache_overflow_table_remove_calls serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_cache_overflow_table_remove_calls untyped
+mongodb_ss_wt_cache_cache_overflow_table_remove_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_checkpoint_blocked_page_eviction serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_checkpoint_blocked_page_eviction untyped
+mongodb_ss_wt_cache_checkpoint_blocked_page_eviction{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_eviction_calls_to_get_a_page serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_eviction_calls_to_get_a_page untyped
+mongodb_ss_wt_cache_eviction_calls_to_get_a_page{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 15
+# HELP mongodb_ss_wt_cache_eviction_calls_to_get_a_page_found_queue_empty serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_eviction_calls_to_get_a_page_found_queue_empty untyped
+mongodb_ss_wt_cache_eviction_calls_to_get_a_page_found_queue_empty{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 15
+# HELP mongodb_ss_wt_cache_eviction_calls_to_get_a_page_found_queue_empty_after_locking serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_eviction_calls_to_get_a_page_found_queue_empty_after_locking untyped
+mongodb_ss_wt_cache_eviction_calls_to_get_a_page_found_queue_empty_after_locking{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_eviction_currently_operating_in_aggressive_mode serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_eviction_currently_operating_in_aggressive_mode untyped
+mongodb_ss_wt_cache_eviction_currently_operating_in_aggressive_mode{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_eviction_empty_score serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_eviction_empty_score untyped
+mongodb_ss_wt_cache_eviction_empty_score{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_eviction_passes_of_a_file serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_eviction_passes_of_a_file untyped
+mongodb_ss_wt_cache_eviction_passes_of_a_file{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_eviction_server_candidate_queue_empty_when_topping_up serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_eviction_server_candidate_queue_empty_when_topping_up untyped
+mongodb_ss_wt_cache_eviction_server_candidate_queue_empty_when_topping_up{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_eviction_server_candidate_queue_not_empty_when_topping_up serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_eviction_server_candidate_queue_not_empty_when_topping_up untyped
+mongodb_ss_wt_cache_eviction_server_candidate_queue_not_empty_when_topping_up{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_eviction_server_evicting_pages serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_eviction_server_evicting_pages untyped
+mongodb_ss_wt_cache_eviction_server_evicting_pages{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_eviction_server_slept_because_we_did_not_make_progress_with_eviction serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_eviction_server_slept_because_we_did_not_make_progress_with_eviction untyped
+mongodb_ss_wt_cache_eviction_server_slept_because_we_did_not_make_progress_with_eviction{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_eviction_server_unable_to_reach_eviction_goal serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_eviction_server_unable_to_reach_eviction_goal untyped
+mongodb_ss_wt_cache_eviction_server_unable_to_reach_eviction_goal{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_eviction_server_waiting_for_a_leaf_page serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_eviction_server_waiting_for_a_leaf_page untyped
+mongodb_ss_wt_cache_eviction_server_waiting_for_a_leaf_page{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_eviction_server_waiting_for_an_internal_page_sleep_usec serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_eviction_server_waiting_for_an_internal_page_sleep_usec untyped
+mongodb_ss_wt_cache_eviction_server_waiting_for_an_internal_page_sleep_usec{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_eviction_server_waiting_for_an_internal_page_yields serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_eviction_server_waiting_for_an_internal_page_yields untyped
+mongodb_ss_wt_cache_eviction_server_waiting_for_an_internal_page_yields{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_eviction_state serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_eviction_state untyped
+mongodb_ss_wt_cache_eviction_state{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 128
+# HELP mongodb_ss_wt_cache_eviction_walk_target_pages_histogram_0_9 serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_eviction_walk_target_pages_histogram_0_9 untyped
+mongodb_ss_wt_cache_eviction_walk_target_pages_histogram_0_9{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_eviction_walk_target_pages_histogram_10_31 serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_eviction_walk_target_pages_histogram_10_31 untyped
+mongodb_ss_wt_cache_eviction_walk_target_pages_histogram_10_31{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_eviction_walk_target_pages_histogram_128_and_higher serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_eviction_walk_target_pages_histogram_128_and_higher untyped
+mongodb_ss_wt_cache_eviction_walk_target_pages_histogram_128_and_higher{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_eviction_walk_target_pages_histogram_32_63 serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_eviction_walk_target_pages_histogram_32_63 untyped
+mongodb_ss_wt_cache_eviction_walk_target_pages_histogram_32_63{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_eviction_walk_target_pages_histogram_64_128 serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_eviction_walk_target_pages_histogram_64_128 untyped
+mongodb_ss_wt_cache_eviction_walk_target_pages_histogram_64_128{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_eviction_walks_abandoned serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_eviction_walks_abandoned untyped
+mongodb_ss_wt_cache_eviction_walks_abandoned{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_eviction_walks_gave_up_because_they_restarted_their_walk_twice serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_eviction_walks_gave_up_because_they_restarted_their_walk_twice untyped
+mongodb_ss_wt_cache_eviction_walks_gave_up_because_they_restarted_their_walk_twice{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_eviction_walks_gave_up_because_they_saw_too_many_pages_and_found_no_candidates serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_eviction_walks_gave_up_because_they_saw_too_many_pages_and_found_no_candidates untyped
+mongodb_ss_wt_cache_eviction_walks_gave_up_because_they_saw_too_many_pages_and_found_no_candidates{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_eviction_walks_gave_up_because_they_saw_too_many_pages_and_found_too_few_candidates serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_eviction_walks_gave_up_because_they_saw_too_many_pages_and_found_too_few_candidates untyped
+mongodb_ss_wt_cache_eviction_walks_gave_up_because_they_saw_too_many_pages_and_found_too_few_candidates{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_eviction_walks_reached_end_of_tree serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_eviction_walks_reached_end_of_tree untyped
+mongodb_ss_wt_cache_eviction_walks_reached_end_of_tree{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_eviction_walks_started_from_root_of_tree serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_eviction_walks_started_from_root_of_tree untyped
+mongodb_ss_wt_cache_eviction_walks_started_from_root_of_tree{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_eviction_walks_started_from_saved_location_in_tree serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_eviction_walks_started_from_saved_location_in_tree untyped
+mongodb_ss_wt_cache_eviction_walks_started_from_saved_location_in_tree{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_eviction_worker_thread_active serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_eviction_worker_thread_active untyped
+mongodb_ss_wt_cache_eviction_worker_thread_active{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 4
+# HELP mongodb_ss_wt_cache_eviction_worker_thread_created serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_eviction_worker_thread_created untyped
+mongodb_ss_wt_cache_eviction_worker_thread_created{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_eviction_worker_thread_evicting_pages serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_eviction_worker_thread_evicting_pages untyped
+mongodb_ss_wt_cache_eviction_worker_thread_evicting_pages{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_eviction_worker_thread_removed serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_eviction_worker_thread_removed untyped
+mongodb_ss_wt_cache_eviction_worker_thread_removed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_eviction_worker_thread_stable_number serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_eviction_worker_thread_stable_number untyped
+mongodb_ss_wt_cache_eviction_worker_thread_stable_number{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_files_with_active_eviction_walks serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_files_with_active_eviction_walks untyped
+mongodb_ss_wt_cache_files_with_active_eviction_walks{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_files_with_new_eviction_walks_started serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_files_with_new_eviction_walks_started untyped
+mongodb_ss_wt_cache_files_with_new_eviction_walks_started{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_force_re_tuning_of_eviction_workers_once_in_a_while serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_force_re_tuning_of_eviction_workers_once_in_a_while untyped
+mongodb_ss_wt_cache_force_re_tuning_of_eviction_workers_once_in_a_while{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_forced_eviction_pages_evicted_that_were_clean_count serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_forced_eviction_pages_evicted_that_were_clean_count counter
+mongodb_ss_wt_cache_forced_eviction_pages_evicted_that_were_clean_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_forced_eviction_pages_evicted_that_were_clean_time_usecs serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_forced_eviction_pages_evicted_that_were_clean_time_usecs untyped
+mongodb_ss_wt_cache_forced_eviction_pages_evicted_that_were_clean_time_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_forced_eviction_pages_evicted_that_were_dirty_count serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_forced_eviction_pages_evicted_that_were_dirty_count counter
+mongodb_ss_wt_cache_forced_eviction_pages_evicted_that_were_dirty_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_forced_eviction_pages_evicted_that_were_dirty_time_usecs serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_forced_eviction_pages_evicted_that_were_dirty_time_usecs untyped
+mongodb_ss_wt_cache_forced_eviction_pages_evicted_that_were_dirty_time_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_forced_eviction_pages_selected_because_of_too_many_deleted_items_count serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_forced_eviction_pages_selected_because_of_too_many_deleted_items_count counter
+mongodb_ss_wt_cache_forced_eviction_pages_selected_because_of_too_many_deleted_items_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_forced_eviction_pages_selected_count serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_forced_eviction_pages_selected_count counter
+mongodb_ss_wt_cache_forced_eviction_pages_selected_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_forced_eviction_pages_selected_unable_to_be_evicted_count serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_forced_eviction_pages_selected_unable_to_be_evicted_count counter
+mongodb_ss_wt_cache_forced_eviction_pages_selected_unable_to_be_evicted_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_forced_eviction_pages_selected_unable_to_be_evicted_time serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_forced_eviction_pages_selected_unable_to_be_evicted_time untyped
+mongodb_ss_wt_cache_forced_eviction_pages_selected_unable_to_be_evicted_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_hazard_pointer_blocked_page_eviction serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_hazard_pointer_blocked_page_eviction untyped
+mongodb_ss_wt_cache_hazard_pointer_blocked_page_eviction{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_hazard_pointer_check_calls serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_hazard_pointer_check_calls untyped
+mongodb_ss_wt_cache_hazard_pointer_check_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_hazard_pointer_check_entries_walked serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_hazard_pointer_check_entries_walked untyped
+mongodb_ss_wt_cache_hazard_pointer_check_entries_walked{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_hazard_pointer_maximum_array_length serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_hazard_pointer_maximum_array_length untyped
+mongodb_ss_wt_cache_hazard_pointer_maximum_array_length{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_in_memory_page_passed_criteria_to_be_split serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_in_memory_page_passed_criteria_to_be_split untyped
+mongodb_ss_wt_cache_in_memory_page_passed_criteria_to_be_split{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_in_memory_page_splits serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_in_memory_page_splits untyped
+mongodb_ss_wt_cache_in_memory_page_splits{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_internal_pages_evicted serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_internal_pages_evicted untyped
+mongodb_ss_wt_cache_internal_pages_evicted{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_internal_pages_split_during_eviction serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_internal_pages_split_during_eviction untyped
+mongodb_ss_wt_cache_internal_pages_split_during_eviction{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_leaf_pages_split_during_eviction serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_leaf_pages_split_during_eviction untyped
+mongodb_ss_wt_cache_leaf_pages_split_during_eviction{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_maximum_bytes_configured serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_maximum_bytes_configured untyped
+mongodb_ss_wt_cache_maximum_bytes_configured{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.6245587968e+10
+# HELP mongodb_ss_wt_cache_maximum_page_size_at_eviction serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_maximum_page_size_at_eviction untyped
+mongodb_ss_wt_cache_maximum_page_size_at_eviction{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_modified_pages_evicted serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_modified_pages_evicted untyped
+mongodb_ss_wt_cache_modified_pages_evicted{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_modified_pages_evicted_by_application_threads serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_modified_pages_evicted_by_application_threads untyped
+mongodb_ss_wt_cache_modified_pages_evicted_by_application_threads{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_operations_timed_out_waiting_for_space_in_cache serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_operations_timed_out_waiting_for_space_in_cache untyped
+mongodb_ss_wt_cache_operations_timed_out_waiting_for_space_in_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_overflow_pages_read_into_cache serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_overflow_pages_read_into_cache untyped
+mongodb_ss_wt_cache_overflow_pages_read_into_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_page_split_during_eviction_deepened_the_tree serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_page_split_during_eviction_deepened_the_tree untyped
+mongodb_ss_wt_cache_page_split_during_eviction_deepened_the_tree{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_page_written_requiring_cache_overflow_records serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_page_written_requiring_cache_overflow_records untyped
+mongodb_ss_wt_cache_page_written_requiring_cache_overflow_records{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_pages_currently_held_in_the_cache serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_pages_currently_held_in_the_cache untyped
+mongodb_ss_wt_cache_pages_currently_held_in_the_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 44
+# HELP mongodb_ss_wt_cache_pages_evicted_by_application_threads serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_pages_evicted_by_application_threads untyped
+mongodb_ss_wt_cache_pages_evicted_by_application_threads{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_pages_queued_for_eviction serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_pages_queued_for_eviction untyped
+mongodb_ss_wt_cache_pages_queued_for_eviction{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_pages_queued_for_eviction_post_lru_sorting serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_pages_queued_for_eviction_post_lru_sorting untyped
+mongodb_ss_wt_cache_pages_queued_for_eviction_post_lru_sorting{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_pages_queued_for_urgent_eviction serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_pages_queued_for_urgent_eviction untyped
+mongodb_ss_wt_cache_pages_queued_for_urgent_eviction{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_pages_queued_for_urgent_eviction_during_walk serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_pages_queued_for_urgent_eviction_during_walk untyped
+mongodb_ss_wt_cache_pages_queued_for_urgent_eviction_during_walk{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_pages_read_into_cache serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_pages_read_into_cache untyped
+mongodb_ss_wt_cache_pages_read_into_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 39
+# HELP mongodb_ss_wt_cache_pages_read_into_cache_after_truncate serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_pages_read_into_cache_after_truncate untyped
+mongodb_ss_wt_cache_pages_read_into_cache_after_truncate{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 2
+# HELP mongodb_ss_wt_cache_pages_read_into_cache_after_truncate_in_prepare_state serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_pages_read_into_cache_after_truncate_in_prepare_state untyped
+mongodb_ss_wt_cache_pages_read_into_cache_after_truncate_in_prepare_state{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_pages_read_into_cache_requiring_cache_overflow_entries serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_pages_read_into_cache_requiring_cache_overflow_entries untyped
+mongodb_ss_wt_cache_pages_read_into_cache_requiring_cache_overflow_entries{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_pages_read_into_cache_requiring_cache_overflow_for_checkpoint serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_pages_read_into_cache_requiring_cache_overflow_for_checkpoint untyped
+mongodb_ss_wt_cache_pages_read_into_cache_requiring_cache_overflow_for_checkpoint{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_pages_read_into_cache_skipping_older_cache_overflow_entries serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_pages_read_into_cache_skipping_older_cache_overflow_entries untyped
+mongodb_ss_wt_cache_pages_read_into_cache_skipping_older_cache_overflow_entries{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_pages_read_into_cache_with_skipped_cache_overflow_entries_needed_later serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_pages_read_into_cache_with_skipped_cache_overflow_entries_needed_later untyped
+mongodb_ss_wt_cache_pages_read_into_cache_with_skipped_cache_overflow_entries_needed_later{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_pages_read_into_cache_with_skipped_cache_overflow_entries_needed_later_by_checkpoint serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_pages_read_into_cache_with_skipped_cache_overflow_entries_needed_later_by_checkpoint untyped
+mongodb_ss_wt_cache_pages_read_into_cache_with_skipped_cache_overflow_entries_needed_later_by_checkpoint{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_pages_requested_from_the_cache serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_pages_requested_from_the_cache untyped
+mongodb_ss_wt_cache_pages_requested_from_the_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 32220
+# HELP mongodb_ss_wt_cache_pages_seen_by_eviction_walk serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_pages_seen_by_eviction_walk untyped
+mongodb_ss_wt_cache_pages_seen_by_eviction_walk{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_pages_selected_for_eviction_unable_to_be_evicted serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_pages_selected_for_eviction_unable_to_be_evicted untyped
+mongodb_ss_wt_cache_pages_selected_for_eviction_unable_to_be_evicted{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_pages_walked_for_eviction serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_pages_walked_for_eviction untyped
+mongodb_ss_wt_cache_pages_walked_for_eviction{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_pages_written_from_cache serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_pages_written_from_cache untyped
+mongodb_ss_wt_cache_pages_written_from_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 212
+# HELP mongodb_ss_wt_cache_pages_written_requiring_in_memory_restoration serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_pages_written_requiring_in_memory_restoration untyped
+mongodb_ss_wt_cache_pages_written_requiring_in_memory_restoration{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cache_percentage_overhead serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_percentage_overhead untyped
+mongodb_ss_wt_cache_percentage_overhead{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 8
+# HELP mongodb_ss_wt_cache_tracked_bytes_belonging_to_internal_pages_in_the_cache serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_tracked_bytes_belonging_to_internal_pages_in_the_cache untyped
+mongodb_ss_wt_cache_tracked_bytes_belonging_to_internal_pages_in_the_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 6911
+# HELP mongodb_ss_wt_cache_tracked_bytes_belonging_to_leaf_pages_in_the_cache serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_tracked_bytes_belonging_to_leaf_pages_in_the_cache untyped
+mongodb_ss_wt_cache_tracked_bytes_belonging_to_leaf_pages_in_the_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 527375
+# HELP mongodb_ss_wt_cache_tracked_dirty_bytes_in_the_cache serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_tracked_dirty_bytes_in_the_cache untyped
+mongodb_ss_wt_cache_tracked_dirty_bytes_in_the_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 260651
+# HELP mongodb_ss_wt_cache_tracked_dirty_pages_in_the_cache serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_tracked_dirty_pages_in_the_cache untyped
+mongodb_ss_wt_cache_tracked_dirty_pages_in_the_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 5
+# HELP mongodb_ss_wt_cache_unmodified_pages_evicted serverStatus.wiredTiger.cache.
+# TYPE mongodb_ss_wt_cache_unmodified_pages_evicted untyped
+mongodb_ss_wt_cache_unmodified_pages_evicted{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_capacity_background_fsync_file_handles_considered serverStatus.wiredTiger.capacity.
+# TYPE mongodb_ss_wt_capacity_background_fsync_file_handles_considered untyped
+mongodb_ss_wt_capacity_background_fsync_file_handles_considered{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_capacity_background_fsync_file_handles_synced serverStatus.wiredTiger.capacity.
+# TYPE mongodb_ss_wt_capacity_background_fsync_file_handles_synced untyped
+mongodb_ss_wt_capacity_background_fsync_file_handles_synced{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_capacity_background_fsync_time_msecs serverStatus.wiredTiger.capacity.
+# TYPE mongodb_ss_wt_capacity_background_fsync_time_msecs untyped
+mongodb_ss_wt_capacity_background_fsync_time_msecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_capacity_threshold_to_call_fsync serverStatus.wiredTiger.capacity.
+# TYPE mongodb_ss_wt_capacity_threshold_to_call_fsync untyped
+mongodb_ss_wt_capacity_threshold_to_call_fsync{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_capacity_throttled_bytes_read serverStatus.wiredTiger.capacity.
+# TYPE mongodb_ss_wt_capacity_throttled_bytes_read untyped
+mongodb_ss_wt_capacity_throttled_bytes_read{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_capacity_throttled_bytes_written_for_checkpoint serverStatus.wiredTiger.capacity.
+# TYPE mongodb_ss_wt_capacity_throttled_bytes_written_for_checkpoint untyped
+mongodb_ss_wt_capacity_throttled_bytes_written_for_checkpoint{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_capacity_throttled_bytes_written_for_eviction serverStatus.wiredTiger.capacity.
+# TYPE mongodb_ss_wt_capacity_throttled_bytes_written_for_eviction untyped
+mongodb_ss_wt_capacity_throttled_bytes_written_for_eviction{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_capacity_throttled_bytes_written_for_log serverStatus.wiredTiger.capacity.
+# TYPE mongodb_ss_wt_capacity_throttled_bytes_written_for_log untyped
+mongodb_ss_wt_capacity_throttled_bytes_written_for_log{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_capacity_throttled_bytes_written_total serverStatus.wiredTiger.capacity.
+# TYPE mongodb_ss_wt_capacity_throttled_bytes_written_total untyped
+mongodb_ss_wt_capacity_throttled_bytes_written_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_capacity_time_waiting_due_to_total_capacity_usecs serverStatus.wiredTiger.capacity.
+# TYPE mongodb_ss_wt_capacity_time_waiting_due_to_total_capacity_usecs untyped
+mongodb_ss_wt_capacity_time_waiting_due_to_total_capacity_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_capacity_time_waiting_during_checkpoint_usecs serverStatus.wiredTiger.capacity.
+# TYPE mongodb_ss_wt_capacity_time_waiting_during_checkpoint_usecs untyped
+mongodb_ss_wt_capacity_time_waiting_during_checkpoint_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_capacity_time_waiting_during_eviction_usecs serverStatus.wiredTiger.capacity.
+# TYPE mongodb_ss_wt_capacity_time_waiting_during_eviction_usecs untyped
+mongodb_ss_wt_capacity_time_waiting_during_eviction_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_capacity_time_waiting_during_logging_usecs serverStatus.wiredTiger.capacity.
+# TYPE mongodb_ss_wt_capacity_time_waiting_during_logging_usecs untyped
+mongodb_ss_wt_capacity_time_waiting_during_logging_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_capacity_time_waiting_during_read_usecs serverStatus.wiredTiger.capacity.
+# TYPE mongodb_ss_wt_capacity_time_waiting_during_read_usecs untyped
+mongodb_ss_wt_capacity_time_waiting_during_read_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_concurrentTransactions_available mongodb_ss_wt_concurrentTransactions_available
+# TYPE mongodb_ss_wt_concurrentTransactions_available untyped
+mongodb_ss_wt_concurrentTransactions_available{txn_rw="read"} 128
+mongodb_ss_wt_concurrentTransactions_available{txn_rw="write"} 128
+# HELP mongodb_ss_wt_concurrentTransactions_out mongodb_ss_wt_concurrentTransactions_out
+# TYPE mongodb_ss_wt_concurrentTransactions_out untyped
+mongodb_ss_wt_concurrentTransactions_out{txn_rw="read"} 0
+mongodb_ss_wt_concurrentTransactions_out{txn_rw="write"} 0
+# HELP mongodb_ss_wt_concurrentTransactions_totalTickets mongodb_ss_wt_concurrentTransactions_totalTickets
+# TYPE mongodb_ss_wt_concurrentTransactions_totalTickets untyped
+mongodb_ss_wt_concurrentTransactions_totalTickets{txn_rw="read"} 128
+mongodb_ss_wt_concurrentTransactions_totalTickets{txn_rw="write"} 128
+# HELP mongodb_ss_wt_connection_auto_adjusting_condition_resets serverStatus.wiredTiger.connection.
+# TYPE mongodb_ss_wt_connection_auto_adjusting_condition_resets untyped
+mongodb_ss_wt_connection_auto_adjusting_condition_resets{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 423
+# HELP mongodb_ss_wt_connection_auto_adjusting_condition_wait_calls serverStatus.wiredTiger.connection.
+# TYPE mongodb_ss_wt_connection_auto_adjusting_condition_wait_calls untyped
+mongodb_ss_wt_connection_auto_adjusting_condition_wait_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 8682
+# HELP mongodb_ss_wt_connection_detected_system_time_went_backwards serverStatus.wiredTiger.connection.
+# TYPE mongodb_ss_wt_connection_detected_system_time_went_backwards untyped
+mongodb_ss_wt_connection_detected_system_time_went_backwards{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_connection_files_currently_open serverStatus.wiredTiger.connection.
+# TYPE mongodb_ss_wt_connection_files_currently_open untyped
+mongodb_ss_wt_connection_files_currently_open{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 25
+# HELP mongodb_ss_wt_connection_memory_allocations serverStatus.wiredTiger.connection.
+# TYPE mongodb_ss_wt_connection_memory_allocations untyped
+mongodb_ss_wt_connection_memory_allocations{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 270133
+# HELP mongodb_ss_wt_connection_memory_frees serverStatus.wiredTiger.connection.
+# TYPE mongodb_ss_wt_connection_memory_frees untyped
+mongodb_ss_wt_connection_memory_frees{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 264430
+# HELP mongodb_ss_wt_connection_memory_re_allocations serverStatus.wiredTiger.connection.
+# TYPE mongodb_ss_wt_connection_memory_re_allocations untyped
+mongodb_ss_wt_connection_memory_re_allocations{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 20385
+# HELP mongodb_ss_wt_connection_pthread_mutex_condition_wait_calls serverStatus.wiredTiger.connection.
+# TYPE mongodb_ss_wt_connection_pthread_mutex_condition_wait_calls untyped
+mongodb_ss_wt_connection_pthread_mutex_condition_wait_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 22758
+# HELP mongodb_ss_wt_connection_pthread_mutex_shared_lock_read_lock_calls serverStatus.wiredTiger.connection.
+# TYPE mongodb_ss_wt_connection_pthread_mutex_shared_lock_read_lock_calls untyped
+mongodb_ss_wt_connection_pthread_mutex_shared_lock_read_lock_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 37535
+# HELP mongodb_ss_wt_connection_pthread_mutex_shared_lock_write_lock_calls serverStatus.wiredTiger.connection.
+# TYPE mongodb_ss_wt_connection_pthread_mutex_shared_lock_write_lock_calls untyped
+mongodb_ss_wt_connection_pthread_mutex_shared_lock_write_lock_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 5050
+# HELP mongodb_ss_wt_connection_total_fsync_I_Os serverStatus.wiredTiger.connection.
+# TYPE mongodb_ss_wt_connection_total_fsync_I_Os untyped
+mongodb_ss_wt_connection_total_fsync_I_Os{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 371
+# HELP mongodb_ss_wt_connection_total_read_I_Os serverStatus.wiredTiger.connection.
+# TYPE mongodb_ss_wt_connection_total_read_I_Os untyped
+mongodb_ss_wt_connection_total_read_I_Os{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1048
+# HELP mongodb_ss_wt_connection_total_write_I_Os serverStatus.wiredTiger.connection.
+# TYPE mongodb_ss_wt_connection_total_write_I_Os untyped
+mongodb_ss_wt_connection_total_write_I_Os{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 608
+# HELP mongodb_ss_wt_cursor_cached_cursor_count serverStatus.wiredTiger.cursor.
+# TYPE mongodb_ss_wt_cursor_cached_cursor_count counter
+mongodb_ss_wt_cursor_cached_cursor_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 42
+# HELP mongodb_ss_wt_cursor_cursor_close_calls_that_result_in_cache serverStatus.wiredTiger.cursor.
+# TYPE mongodb_ss_wt_cursor_cursor_close_calls_that_result_in_cache untyped
+mongodb_ss_wt_cursor_cursor_close_calls_that_result_in_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 7249
+# HELP mongodb_ss_wt_cursor_cursor_create_calls serverStatus.wiredTiger.cursor.
+# TYPE mongodb_ss_wt_cursor_cursor_create_calls untyped
+mongodb_ss_wt_cursor_cursor_create_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 4173
+# HELP mongodb_ss_wt_cursor_cursor_insert_calls serverStatus.wiredTiger.cursor.
+# TYPE mongodb_ss_wt_cursor_cursor_insert_calls untyped
+mongodb_ss_wt_cursor_cursor_insert_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 2226
+# HELP mongodb_ss_wt_cursor_cursor_modify_calls serverStatus.wiredTiger.cursor.
+# TYPE mongodb_ss_wt_cursor_cursor_modify_calls untyped
+mongodb_ss_wt_cursor_cursor_modify_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cursor_cursor_next_calls serverStatus.wiredTiger.cursor.
+# TYPE mongodb_ss_wt_cursor_cursor_next_calls untyped
+mongodb_ss_wt_cursor_cursor_next_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 4781
+# HELP mongodb_ss_wt_cursor_cursor_operation_restarted serverStatus.wiredTiger.cursor.
+# TYPE mongodb_ss_wt_cursor_cursor_operation_restarted untyped
+mongodb_ss_wt_cursor_cursor_operation_restarted{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cursor_cursor_prev_calls serverStatus.wiredTiger.cursor.
+# TYPE mongodb_ss_wt_cursor_cursor_prev_calls untyped
+mongodb_ss_wt_cursor_cursor_prev_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1096
+# HELP mongodb_ss_wt_cursor_cursor_remove_calls serverStatus.wiredTiger.cursor.
+# TYPE mongodb_ss_wt_cursor_cursor_remove_calls untyped
+mongodb_ss_wt_cursor_cursor_remove_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_ss_wt_cursor_cursor_reserve_calls serverStatus.wiredTiger.cursor.
+# TYPE mongodb_ss_wt_cursor_cursor_reserve_calls untyped
+mongodb_ss_wt_cursor_cursor_reserve_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cursor_cursor_reset_calls serverStatus.wiredTiger.cursor.
+# TYPE mongodb_ss_wt_cursor_cursor_reset_calls untyped
+mongodb_ss_wt_cursor_cursor_reset_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 39946
+# HELP mongodb_ss_wt_cursor_cursor_search_calls serverStatus.wiredTiger.cursor.
+# TYPE mongodb_ss_wt_cursor_cursor_search_calls untyped
+mongodb_ss_wt_cursor_cursor_search_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 25169
+# HELP mongodb_ss_wt_cursor_cursor_search_near_calls serverStatus.wiredTiger.cursor.
+# TYPE mongodb_ss_wt_cursor_cursor_search_near_calls untyped
+mongodb_ss_wt_cursor_cursor_search_near_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1393
+# HELP mongodb_ss_wt_cursor_cursor_sweep_buckets serverStatus.wiredTiger.cursor.
+# TYPE mongodb_ss_wt_cursor_cursor_sweep_buckets untyped
+mongodb_ss_wt_cursor_cursor_sweep_buckets{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 17124
+# HELP mongodb_ss_wt_cursor_cursor_sweep_cursors_closed serverStatus.wiredTiger.cursor.
+# TYPE mongodb_ss_wt_cursor_cursor_sweep_cursors_closed untyped
+mongodb_ss_wt_cursor_cursor_sweep_cursors_closed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cursor_cursor_sweep_cursors_examined serverStatus.wiredTiger.cursor.
+# TYPE mongodb_ss_wt_cursor_cursor_sweep_cursors_examined untyped
+mongodb_ss_wt_cursor_cursor_sweep_cursors_examined{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 416
+# HELP mongodb_ss_wt_cursor_cursor_sweeps serverStatus.wiredTiger.cursor.
+# TYPE mongodb_ss_wt_cursor_cursor_sweeps untyped
+mongodb_ss_wt_cursor_cursor_sweeps{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 2854
+# HELP mongodb_ss_wt_cursor_cursor_update_calls serverStatus.wiredTiger.cursor.
+# TYPE mongodb_ss_wt_cursor_cursor_update_calls untyped
+mongodb_ss_wt_cursor_cursor_update_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_cursor_cursors_reused_from_cache serverStatus.wiredTiger.cursor.
+# TYPE mongodb_ss_wt_cursor_cursors_reused_from_cache untyped
+mongodb_ss_wt_cursor_cursors_reused_from_cache{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 7202
+# HELP mongodb_ss_wt_cursor_open_cursor_count serverStatus.wiredTiger.cursor.
+# TYPE mongodb_ss_wt_cursor_open_cursor_count counter
+mongodb_ss_wt_cursor_open_cursor_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 24
+# HELP mongodb_ss_wt_cursor_truncate_calls serverStatus.wiredTiger.cursor.
+# TYPE mongodb_ss_wt_cursor_truncate_calls untyped
+mongodb_ss_wt_cursor_truncate_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_data_handle_connection_data_handles_currently_active serverStatus.wiredTiger.data-handle.
+# TYPE mongodb_ss_wt_data_handle_connection_data_handles_currently_active untyped
+mongodb_ss_wt_data_handle_connection_data_handles_currently_active{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 42
+# HELP mongodb_ss_wt_data_handle_connection_sweep_candidate_became_referenced serverStatus.wiredTiger.data-handle.
+# TYPE mongodb_ss_wt_data_handle_connection_sweep_candidate_became_referenced untyped
+mongodb_ss_wt_data_handle_connection_sweep_candidate_became_referenced{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_data_handle_connection_sweep_dhandles_closed serverStatus.wiredTiger.data-handle.
+# TYPE mongodb_ss_wt_data_handle_connection_sweep_dhandles_closed untyped
+mongodb_ss_wt_data_handle_connection_sweep_dhandles_closed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_data_handle_connection_sweep_dhandles_removed_from_hash_list serverStatus.wiredTiger.data-handle.
+# TYPE mongodb_ss_wt_data_handle_connection_sweep_dhandles_removed_from_hash_list untyped
+mongodb_ss_wt_data_handle_connection_sweep_dhandles_removed_from_hash_list{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 110
+# HELP mongodb_ss_wt_data_handle_connection_sweep_time_of_death_sets serverStatus.wiredTiger.data-handle.
+# TYPE mongodb_ss_wt_data_handle_connection_sweep_time_of_death_sets untyped
+mongodb_ss_wt_data_handle_connection_sweep_time_of_death_sets{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 2060
+# HELP mongodb_ss_wt_data_handle_connection_sweeps serverStatus.wiredTiger.data-handle.
+# TYPE mongodb_ss_wt_data_handle_connection_sweeps untyped
+mongodb_ss_wt_data_handle_connection_sweeps{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 666
+# HELP mongodb_ss_wt_data_handle_session_dhandles_swept serverStatus.wiredTiger.data-handle.
+# TYPE mongodb_ss_wt_data_handle_session_dhandles_swept untyped
+mongodb_ss_wt_data_handle_session_dhandles_swept{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_data_handle_session_sweep_attempts serverStatus.wiredTiger.data-handle.
+# TYPE mongodb_ss_wt_data_handle_session_sweep_attempts untyped
+mongodb_ss_wt_data_handle_session_sweep_attempts{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 68
+# HELP mongodb_ss_wt_lock_checkpoint_lock_acquisitions serverStatus.wiredTiger.lock.
+# TYPE mongodb_ss_wt_lock_checkpoint_lock_acquisitions untyped
+mongodb_ss_wt_lock_checkpoint_lock_acquisitions{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 23
+# HELP mongodb_ss_wt_lock_checkpoint_lock_application_thread_wait_time_usecs serverStatus.wiredTiger.lock.
+# TYPE mongodb_ss_wt_lock_checkpoint_lock_application_thread_wait_time_usecs untyped
+mongodb_ss_wt_lock_checkpoint_lock_application_thread_wait_time_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_lock_checkpoint_lock_internal_thread_wait_time_usecs serverStatus.wiredTiger.lock.
+# TYPE mongodb_ss_wt_lock_checkpoint_lock_internal_thread_wait_time_usecs untyped
+mongodb_ss_wt_lock_checkpoint_lock_internal_thread_wait_time_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_lock_commit_timestamp_queue_lock_application_thread_time_waiting_usecs serverStatus.wiredTiger.lock.
+# TYPE mongodb_ss_wt_lock_commit_timestamp_queue_lock_application_thread_time_waiting_usecs untyped
+mongodb_ss_wt_lock_commit_timestamp_queue_lock_application_thread_time_waiting_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_lock_commit_timestamp_queue_lock_internal_thread_time_waiting_usecs serverStatus.wiredTiger.lock.
+# TYPE mongodb_ss_wt_lock_commit_timestamp_queue_lock_internal_thread_time_waiting_usecs untyped
+mongodb_ss_wt_lock_commit_timestamp_queue_lock_internal_thread_time_waiting_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_lock_commit_timestamp_queue_read_lock_acquisitions serverStatus.wiredTiger.lock.
+# TYPE mongodb_ss_wt_lock_commit_timestamp_queue_read_lock_acquisitions untyped
+mongodb_ss_wt_lock_commit_timestamp_queue_read_lock_acquisitions{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_lock_commit_timestamp_queue_write_lock_acquisitions serverStatus.wiredTiger.lock.
+# TYPE mongodb_ss_wt_lock_commit_timestamp_queue_write_lock_acquisitions untyped
+mongodb_ss_wt_lock_commit_timestamp_queue_write_lock_acquisitions{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 612
+# HELP mongodb_ss_wt_lock_dhandle_lock_application_thread_time_waiting_usecs serverStatus.wiredTiger.lock.
+# TYPE mongodb_ss_wt_lock_dhandle_lock_application_thread_time_waiting_usecs untyped
+mongodb_ss_wt_lock_dhandle_lock_application_thread_time_waiting_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_ss_wt_lock_dhandle_lock_internal_thread_time_waiting_usecs serverStatus.wiredTiger.lock.
+# TYPE mongodb_ss_wt_lock_dhandle_lock_internal_thread_time_waiting_usecs untyped
+mongodb_ss_wt_lock_dhandle_lock_internal_thread_time_waiting_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_lock_dhandle_read_lock_acquisitions serverStatus.wiredTiger.lock.
+# TYPE mongodb_ss_wt_lock_dhandle_read_lock_acquisitions untyped
+mongodb_ss_wt_lock_dhandle_read_lock_acquisitions{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 5876
+# HELP mongodb_ss_wt_lock_dhandle_write_lock_acquisitions serverStatus.wiredTiger.lock.
+# TYPE mongodb_ss_wt_lock_dhandle_write_lock_acquisitions untyped
+mongodb_ss_wt_lock_dhandle_write_lock_acquisitions{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 262
+# HELP mongodb_ss_wt_lock_metadata_lock_acquisitions serverStatus.wiredTiger.lock.
+# TYPE mongodb_ss_wt_lock_metadata_lock_acquisitions untyped
+mongodb_ss_wt_lock_metadata_lock_acquisitions{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 23
+# HELP mongodb_ss_wt_lock_metadata_lock_application_thread_wait_time_usecs serverStatus.wiredTiger.lock.
+# TYPE mongodb_ss_wt_lock_metadata_lock_application_thread_wait_time_usecs untyped
+mongodb_ss_wt_lock_metadata_lock_application_thread_wait_time_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_ss_wt_lock_metadata_lock_internal_thread_wait_time_usecs serverStatus.wiredTiger.lock.
+# TYPE mongodb_ss_wt_lock_metadata_lock_internal_thread_wait_time_usecs untyped
+mongodb_ss_wt_lock_metadata_lock_internal_thread_wait_time_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_lock_read_timestamp_queue_lock_application_thread_time_waiting_usecs serverStatus.wiredTiger.lock.
+# TYPE mongodb_ss_wt_lock_read_timestamp_queue_lock_application_thread_time_waiting_usecs untyped
+mongodb_ss_wt_lock_read_timestamp_queue_lock_application_thread_time_waiting_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_lock_read_timestamp_queue_lock_internal_thread_time_waiting_usecs serverStatus.wiredTiger.lock.
+# TYPE mongodb_ss_wt_lock_read_timestamp_queue_lock_internal_thread_time_waiting_usecs untyped
+mongodb_ss_wt_lock_read_timestamp_queue_lock_internal_thread_time_waiting_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_lock_read_timestamp_queue_read_lock_acquisitions serverStatus.wiredTiger.lock.
+# TYPE mongodb_ss_wt_lock_read_timestamp_queue_read_lock_acquisitions untyped
+mongodb_ss_wt_lock_read_timestamp_queue_read_lock_acquisitions{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_lock_read_timestamp_queue_write_lock_acquisitions serverStatus.wiredTiger.lock.
+# TYPE mongodb_ss_wt_lock_read_timestamp_queue_write_lock_acquisitions untyped
+mongodb_ss_wt_lock_read_timestamp_queue_write_lock_acquisitions{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 549
+# HELP mongodb_ss_wt_lock_schema_lock_acquisitions serverStatus.wiredTiger.lock.
+# TYPE mongodb_ss_wt_lock_schema_lock_acquisitions untyped
+mongodb_ss_wt_lock_schema_lock_acquisitions{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 67
+# HELP mongodb_ss_wt_lock_schema_lock_application_thread_wait_time_usecs serverStatus.wiredTiger.lock.
+# TYPE mongodb_ss_wt_lock_schema_lock_application_thread_wait_time_usecs untyped
+mongodb_ss_wt_lock_schema_lock_application_thread_wait_time_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 487
+# HELP mongodb_ss_wt_lock_schema_lock_internal_thread_wait_time_usecs serverStatus.wiredTiger.lock.
+# TYPE mongodb_ss_wt_lock_schema_lock_internal_thread_wait_time_usecs untyped
+mongodb_ss_wt_lock_schema_lock_internal_thread_wait_time_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_lock_table_lock_application_thread_time_waiting_for_the_table_lock_usecs serverStatus.wiredTiger.lock.
+# TYPE mongodb_ss_wt_lock_table_lock_application_thread_time_waiting_for_the_table_lock_usecs untyped
+mongodb_ss_wt_lock_table_lock_application_thread_time_waiting_for_the_table_lock_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_lock_table_lock_internal_thread_time_waiting_for_the_table_lock_usecs serverStatus.wiredTiger.lock.
+# TYPE mongodb_ss_wt_lock_table_lock_internal_thread_time_waiting_for_the_table_lock_usecs untyped
+mongodb_ss_wt_lock_table_lock_internal_thread_time_waiting_for_the_table_lock_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_lock_table_read_lock_acquisitions serverStatus.wiredTiger.lock.
+# TYPE mongodb_ss_wt_lock_table_read_lock_acquisitions untyped
+mongodb_ss_wt_lock_table_read_lock_acquisitions{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_lock_table_write_lock_acquisitions serverStatus.wiredTiger.lock.
+# TYPE mongodb_ss_wt_lock_table_write_lock_acquisitions untyped
+mongodb_ss_wt_lock_table_write_lock_acquisitions{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1363
+# HELP mongodb_ss_wt_lock_txn_global_lock_application_thread_time_waiting_usecs serverStatus.wiredTiger.lock.
+# TYPE mongodb_ss_wt_lock_txn_global_lock_application_thread_time_waiting_usecs untyped
+mongodb_ss_wt_lock_txn_global_lock_application_thread_time_waiting_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_lock_txn_global_lock_internal_thread_time_waiting_usecs serverStatus.wiredTiger.lock.
+# TYPE mongodb_ss_wt_lock_txn_global_lock_internal_thread_time_waiting_usecs untyped
+mongodb_ss_wt_lock_txn_global_lock_internal_thread_time_waiting_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_lock_txn_global_read_lock_acquisitions serverStatus.wiredTiger.lock.
+# TYPE mongodb_ss_wt_lock_txn_global_read_lock_acquisitions untyped
+mongodb_ss_wt_lock_txn_global_read_lock_acquisitions{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 540
+# HELP mongodb_ss_wt_lock_txn_global_write_lock_acquisitions serverStatus.wiredTiger.lock.
+# TYPE mongodb_ss_wt_lock_txn_global_write_lock_acquisitions untyped
+mongodb_ss_wt_lock_txn_global_write_lock_acquisitions{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 613
+# HELP mongodb_ss_wt_log_busy_returns_attempting_to_switch_slots serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_busy_returns_attempting_to_switch_slots untyped
+mongodb_ss_wt_log_busy_returns_attempting_to_switch_slots{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_ss_wt_log_force_archive_time_sleeping_usecs serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_force_archive_time_sleeping_usecs untyped
+mongodb_ss_wt_log_force_archive_time_sleeping_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_log_log_bytes_of_payload_data serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_log_bytes_of_payload_data untyped
+mongodb_ss_wt_log_log_bytes_of_payload_data{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 197981
+# HELP mongodb_ss_wt_log_log_bytes_written serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_log_bytes_written untyped
+mongodb_ss_wt_log_log_bytes_written{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 264960
+# HELP mongodb_ss_wt_log_log_files_manually_zero_filled serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_log_files_manually_zero_filled untyped
+mongodb_ss_wt_log_log_files_manually_zero_filled{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_log_log_flush_operations serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_log_flush_operations untyped
+mongodb_ss_wt_log_log_flush_operations{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 13519
+# HELP mongodb_ss_wt_log_log_force_write_operations serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_log_force_write_operations untyped
+mongodb_ss_wt_log_log_force_write_operations{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 14982
+# HELP mongodb_ss_wt_log_log_force_write_operations_skipped serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_log_force_write_operations_skipped untyped
+mongodb_ss_wt_log_log_force_write_operations_skipped{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 14824
+# HELP mongodb_ss_wt_log_log_records_compressed serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_log_records_compressed untyped
+mongodb_ss_wt_log_log_records_compressed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 25
+# HELP mongodb_ss_wt_log_log_records_not_compressed serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_log_records_not_compressed untyped
+mongodb_ss_wt_log_log_records_not_compressed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 615
+# HELP mongodb_ss_wt_log_log_records_too_small_to_compress serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_log_records_too_small_to_compress untyped
+mongodb_ss_wt_log_log_records_too_small_to_compress{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 67
+# HELP mongodb_ss_wt_log_log_release_advances_write_LSN serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_log_release_advances_write_LSN untyped
+mongodb_ss_wt_log_log_release_advances_write_LSN{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 25
+# HELP mongodb_ss_wt_log_log_scan_operations serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_log_scan_operations untyped
+mongodb_ss_wt_log_log_scan_operations{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 4
+# HELP mongodb_ss_wt_log_log_scan_records_requiring_two_reads serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_log_scan_records_requiring_two_reads untyped
+mongodb_ss_wt_log_log_scan_records_requiring_two_reads{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 3
+# HELP mongodb_ss_wt_log_log_server_thread_advances_write_LSN serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_log_server_thread_advances_write_LSN untyped
+mongodb_ss_wt_log_log_server_thread_advances_write_LSN{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 157
+# HELP mongodb_ss_wt_log_log_server_thread_write_LSN_walk_skipped serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_log_server_thread_write_LSN_walk_skipped untyped
+mongodb_ss_wt_log_log_server_thread_write_LSN_walk_skipped{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 2183
+# HELP mongodb_ss_wt_log_log_sync_dir_operations serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_log_sync_dir_operations untyped
+mongodb_ss_wt_log_log_sync_dir_operations{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_ss_wt_log_log_sync_dir_time_duration_usecs serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_log_sync_dir_time_duration_usecs untyped
+mongodb_ss_wt_log_log_sync_dir_time_duration_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 3
+# HELP mongodb_ss_wt_log_log_sync_operations serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_log_sync_operations untyped
+mongodb_ss_wt_log_log_sync_operations{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 182
+# HELP mongodb_ss_wt_log_log_sync_time_duration_usecs serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_log_sync_time_duration_usecs untyped
+mongodb_ss_wt_log_log_sync_time_duration_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 163719
+# HELP mongodb_ss_wt_log_log_write_operations serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_log_write_operations untyped
+mongodb_ss_wt_log_log_write_operations{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 707
+# HELP mongodb_ss_wt_log_logging_bytes_consolidated serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_logging_bytes_consolidated untyped
+mongodb_ss_wt_log_logging_bytes_consolidated{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 264448
+# HELP mongodb_ss_wt_log_maximum_log_file_size serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_maximum_log_file_size untyped
+mongodb_ss_wt_log_maximum_log_file_size{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.048576e+08
+# HELP mongodb_ss_wt_log_number_of_pre_allocated_log_files_to_create serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_number_of_pre_allocated_log_files_to_create untyped
+mongodb_ss_wt_log_number_of_pre_allocated_log_files_to_create{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 2
+# HELP mongodb_ss_wt_log_pre_allocated_log_files_not_ready_and_missed serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_pre_allocated_log_files_not_ready_and_missed untyped
+mongodb_ss_wt_log_pre_allocated_log_files_not_ready_and_missed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_ss_wt_log_pre_allocated_log_files_prepared serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_pre_allocated_log_files_prepared untyped
+mongodb_ss_wt_log_pre_allocated_log_files_prepared{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 2
+# HELP mongodb_ss_wt_log_pre_allocated_log_files_used serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_pre_allocated_log_files_used untyped
+mongodb_ss_wt_log_pre_allocated_log_files_used{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_log_records_processed_by_log_scan serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_records_processed_by_log_scan untyped
+mongodb_ss_wt_log_records_processed_by_log_scan{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 14
+# HELP mongodb_ss_wt_log_slot_close_lost_race serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_slot_close_lost_race untyped
+mongodb_ss_wt_log_slot_close_lost_race{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_log_slot_close_unbuffered_waits serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_slot_close_unbuffered_waits untyped
+mongodb_ss_wt_log_slot_close_unbuffered_waits{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_log_slot_closures serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_slot_closures untyped
+mongodb_ss_wt_log_slot_closures{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 182
+# HELP mongodb_ss_wt_log_slot_join_atomic_update_races serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_slot_join_atomic_update_races untyped
+mongodb_ss_wt_log_slot_join_atomic_update_races{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_log_slot_join_calls_atomic_updates_raced serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_slot_join_calls_atomic_updates_raced untyped
+mongodb_ss_wt_log_slot_join_calls_atomic_updates_raced{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_log_slot_join_calls_did_not_yield serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_slot_join_calls_did_not_yield untyped
+mongodb_ss_wt_log_slot_join_calls_did_not_yield{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 707
+# HELP mongodb_ss_wt_log_slot_join_calls_found_active_slot_closed serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_slot_join_calls_found_active_slot_closed untyped
+mongodb_ss_wt_log_slot_join_calls_found_active_slot_closed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_log_slot_join_calls_slept serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_slot_join_calls_slept untyped
+mongodb_ss_wt_log_slot_join_calls_slept{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_log_slot_join_calls_yielded serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_slot_join_calls_yielded untyped
+mongodb_ss_wt_log_slot_join_calls_yielded{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_log_slot_join_found_active_slot_closed serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_slot_join_found_active_slot_closed untyped
+mongodb_ss_wt_log_slot_join_found_active_slot_closed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_log_slot_joins_yield_time_usecs serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_slot_joins_yield_time_usecs untyped
+mongodb_ss_wt_log_slot_joins_yield_time_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_log_slot_transitions_unable_to_find_free_slot serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_slot_transitions_unable_to_find_free_slot untyped
+mongodb_ss_wt_log_slot_transitions_unable_to_find_free_slot{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_log_slot_unbuffered_writes serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_slot_unbuffered_writes untyped
+mongodb_ss_wt_log_slot_unbuffered_writes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_log_total_in_memory_size_of_compressed_records serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_total_in_memory_size_of_compressed_records untyped
+mongodb_ss_wt_log_total_in_memory_size_of_compressed_records{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 117991
+# HELP mongodb_ss_wt_log_total_log_buffer_size serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_total_log_buffer_size untyped
+mongodb_ss_wt_log_total_log_buffer_size{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 3.3554432e+07
+# HELP mongodb_ss_wt_log_total_size_of_compressed_records serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_total_size_of_compressed_records untyped
+mongodb_ss_wt_log_total_size_of_compressed_records{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 34815
+# HELP mongodb_ss_wt_log_written_slots_coalesced serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_written_slots_coalesced untyped
+mongodb_ss_wt_log_written_slots_coalesced{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_log_yields_waiting_for_previous_log_file_close serverStatus.wiredTiger.log.
+# TYPE mongodb_ss_wt_log_yields_waiting_for_previous_log_file_close untyped
+mongodb_ss_wt_log_yields_waiting_for_previous_log_file_close{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_perf serverStatus.wiredTiger.perf.
+# TYPE mongodb_ss_wt_perf untyped
+mongodb_ss_wt_perf{cl_id="6350129adfb0b7e3db4773bb",cl_role="",perf_bucket="file system read latency histogram (bucket 1) - 10-49ms",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_wt_perf{cl_id="6350129adfb0b7e3db4773bb",cl_role="",perf_bucket="file system read latency histogram (bucket 2) - 50-99ms",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_wt_perf{cl_id="6350129adfb0b7e3db4773bb",cl_role="",perf_bucket="file system read latency histogram (bucket 3) - 100-249ms",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_wt_perf{cl_id="6350129adfb0b7e3db4773bb",cl_role="",perf_bucket="file system read latency histogram (bucket 4) - 250-499ms",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_wt_perf{cl_id="6350129adfb0b7e3db4773bb",cl_role="",perf_bucket="file system read latency histogram (bucket 5) - 500-999ms",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_wt_perf{cl_id="6350129adfb0b7e3db4773bb",cl_role="",perf_bucket="file system read latency histogram (bucket 6) - 1000ms+",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_wt_perf{cl_id="6350129adfb0b7e3db4773bb",cl_role="",perf_bucket="file system write latency histogram (bucket 1) - 10-49ms",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_wt_perf{cl_id="6350129adfb0b7e3db4773bb",cl_role="",perf_bucket="file system write latency histogram (bucket 2) - 50-99ms",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_wt_perf{cl_id="6350129adfb0b7e3db4773bb",cl_role="",perf_bucket="file system write latency histogram (bucket 3) - 100-249ms",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_wt_perf{cl_id="6350129adfb0b7e3db4773bb",cl_role="",perf_bucket="file system write latency histogram (bucket 4) - 250-499ms",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_wt_perf{cl_id="6350129adfb0b7e3db4773bb",cl_role="",perf_bucket="file system write latency histogram (bucket 5) - 500-999ms",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_wt_perf{cl_id="6350129adfb0b7e3db4773bb",cl_role="",perf_bucket="file system write latency histogram (bucket 6) - 1000ms+",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_wt_perf{cl_id="6350129adfb0b7e3db4773bb",cl_role="",perf_bucket="operation read latency histogram (bucket 1) - 100-249us",rs_nm="rs0",rs_state="1"} 8
+mongodb_ss_wt_perf{cl_id="6350129adfb0b7e3db4773bb",cl_role="",perf_bucket="operation read latency histogram (bucket 2) - 250-499us",rs_nm="rs0",rs_state="1"} 2
+mongodb_ss_wt_perf{cl_id="6350129adfb0b7e3db4773bb",cl_role="",perf_bucket="operation read latency histogram (bucket 3) - 500-999us",rs_nm="rs0",rs_state="1"} 1
+mongodb_ss_wt_perf{cl_id="6350129adfb0b7e3db4773bb",cl_role="",perf_bucket="operation read latency histogram (bucket 4) - 1000-9999us",rs_nm="rs0",rs_state="1"} 2
+mongodb_ss_wt_perf{cl_id="6350129adfb0b7e3db4773bb",cl_role="",perf_bucket="operation read latency histogram (bucket 5) - 10000us+",rs_nm="rs0",rs_state="1"} 1
+mongodb_ss_wt_perf{cl_id="6350129adfb0b7e3db4773bb",cl_role="",perf_bucket="operation write latency histogram (bucket 1) - 100-249us",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_wt_perf{cl_id="6350129adfb0b7e3db4773bb",cl_role="",perf_bucket="operation write latency histogram (bucket 2) - 250-499us",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_wt_perf{cl_id="6350129adfb0b7e3db4773bb",cl_role="",perf_bucket="operation write latency histogram (bucket 3) - 500-999us",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_wt_perf{cl_id="6350129adfb0b7e3db4773bb",cl_role="",perf_bucket="operation write latency histogram (bucket 4) - 1000-9999us",rs_nm="rs0",rs_state="1"} 0
+mongodb_ss_wt_perf{cl_id="6350129adfb0b7e3db4773bb",cl_role="",perf_bucket="operation write latency histogram (bucket 5) - 10000us+",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_reconciliation_fast_path_pages_deleted serverStatus.wiredTiger.reconciliation.
+# TYPE mongodb_ss_wt_reconciliation_fast_path_pages_deleted untyped
+mongodb_ss_wt_reconciliation_fast_path_pages_deleted{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_reconciliation_page_reconciliation_calls serverStatus.wiredTiger.reconciliation.
+# TYPE mongodb_ss_wt_reconciliation_page_reconciliation_calls untyped
+mongodb_ss_wt_reconciliation_page_reconciliation_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 201
+# HELP mongodb_ss_wt_reconciliation_page_reconciliation_calls_for_eviction serverStatus.wiredTiger.reconciliation.
+# TYPE mongodb_ss_wt_reconciliation_page_reconciliation_calls_for_eviction untyped
+mongodb_ss_wt_reconciliation_page_reconciliation_calls_for_eviction{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_reconciliation_pages_deleted serverStatus.wiredTiger.reconciliation.
+# TYPE mongodb_ss_wt_reconciliation_pages_deleted untyped
+mongodb_ss_wt_reconciliation_pages_deleted{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_reconciliation_split_bytes_currently_awaiting_free serverStatus.wiredTiger.reconciliation.
+# TYPE mongodb_ss_wt_reconciliation_split_bytes_currently_awaiting_free untyped
+mongodb_ss_wt_reconciliation_split_bytes_currently_awaiting_free{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_reconciliation_split_objects_currently_awaiting_free serverStatus.wiredTiger.reconciliation.
+# TYPE mongodb_ss_wt_reconciliation_split_objects_currently_awaiting_free untyped
+mongodb_ss_wt_reconciliation_split_objects_currently_awaiting_free{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_session_open_session_count serverStatus.wiredTiger.session.
+# TYPE mongodb_ss_wt_session_open_session_count counter
+mongodb_ss_wt_session_open_session_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 20
+# HELP mongodb_ss_wt_session_session_query_timestamp_calls serverStatus.wiredTiger.session.
+# TYPE mongodb_ss_wt_session_session_query_timestamp_calls untyped
+mongodb_ss_wt_session_session_query_timestamp_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_session_table_alter_failed_calls serverStatus.wiredTiger.session.
+# TYPE mongodb_ss_wt_session_table_alter_failed_calls untyped
+mongodb_ss_wt_session_table_alter_failed_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_session_table_alter_successful_calls serverStatus.wiredTiger.session.
+# TYPE mongodb_ss_wt_session_table_alter_successful_calls untyped
+mongodb_ss_wt_session_table_alter_successful_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_session_table_alter_unchanged_and_skipped serverStatus.wiredTiger.session.
+# TYPE mongodb_ss_wt_session_table_alter_unchanged_and_skipped untyped
+mongodb_ss_wt_session_table_alter_unchanged_and_skipped{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_session_table_compact_failed_calls serverStatus.wiredTiger.session.
+# TYPE mongodb_ss_wt_session_table_compact_failed_calls untyped
+mongodb_ss_wt_session_table_compact_failed_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_session_table_compact_successful_calls serverStatus.wiredTiger.session.
+# TYPE mongodb_ss_wt_session_table_compact_successful_calls untyped
+mongodb_ss_wt_session_table_compact_successful_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_session_table_create_failed_calls serverStatus.wiredTiger.session.
+# TYPE mongodb_ss_wt_session_table_create_failed_calls untyped
+mongodb_ss_wt_session_table_create_failed_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_session_table_create_successful_calls serverStatus.wiredTiger.session.
+# TYPE mongodb_ss_wt_session_table_create_successful_calls untyped
+mongodb_ss_wt_session_table_create_successful_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_ss_wt_session_table_drop_failed_calls serverStatus.wiredTiger.session.
+# TYPE mongodb_ss_wt_session_table_drop_failed_calls untyped
+mongodb_ss_wt_session_table_drop_failed_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_session_table_drop_successful_calls serverStatus.wiredTiger.session.
+# TYPE mongodb_ss_wt_session_table_drop_successful_calls untyped
+mongodb_ss_wt_session_table_drop_successful_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_session_table_rebalance_failed_calls serverStatus.wiredTiger.session.
+# TYPE mongodb_ss_wt_session_table_rebalance_failed_calls untyped
+mongodb_ss_wt_session_table_rebalance_failed_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_session_table_rebalance_successful_calls serverStatus.wiredTiger.session.
+# TYPE mongodb_ss_wt_session_table_rebalance_successful_calls untyped
+mongodb_ss_wt_session_table_rebalance_successful_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_session_table_rename_failed_calls serverStatus.wiredTiger.session.
+# TYPE mongodb_ss_wt_session_table_rename_failed_calls untyped
+mongodb_ss_wt_session_table_rename_failed_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_session_table_rename_successful_calls serverStatus.wiredTiger.session.
+# TYPE mongodb_ss_wt_session_table_rename_successful_calls untyped
+mongodb_ss_wt_session_table_rename_successful_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_session_table_salvage_failed_calls serverStatus.wiredTiger.session.
+# TYPE mongodb_ss_wt_session_table_salvage_failed_calls untyped
+mongodb_ss_wt_session_table_salvage_failed_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_session_table_salvage_successful_calls serverStatus.wiredTiger.session.
+# TYPE mongodb_ss_wt_session_table_salvage_successful_calls untyped
+mongodb_ss_wt_session_table_salvage_successful_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_session_table_truncate_failed_calls serverStatus.wiredTiger.session.
+# TYPE mongodb_ss_wt_session_table_truncate_failed_calls untyped
+mongodb_ss_wt_session_table_truncate_failed_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_session_table_truncate_successful_calls serverStatus.wiredTiger.session.
+# TYPE mongodb_ss_wt_session_table_truncate_successful_calls untyped
+mongodb_ss_wt_session_table_truncate_successful_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_session_table_verify_failed_calls serverStatus.wiredTiger.session.
+# TYPE mongodb_ss_wt_session_table_verify_failed_calls untyped
+mongodb_ss_wt_session_table_verify_failed_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_session_table_verify_successful_calls serverStatus.wiredTiger.session.
+# TYPE mongodb_ss_wt_session_table_verify_successful_calls untyped
+mongodb_ss_wt_session_table_verify_successful_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_thread_state_active_filesystem_fsync_calls serverStatus.wiredTiger.thread-state.
+# TYPE mongodb_ss_wt_thread_state_active_filesystem_fsync_calls untyped
+mongodb_ss_wt_thread_state_active_filesystem_fsync_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_thread_state_active_filesystem_read_calls serverStatus.wiredTiger.thread-state.
+# TYPE mongodb_ss_wt_thread_state_active_filesystem_read_calls untyped
+mongodb_ss_wt_thread_state_active_filesystem_read_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_thread_state_active_filesystem_write_calls serverStatus.wiredTiger.thread-state.
+# TYPE mongodb_ss_wt_thread_state_active_filesystem_write_calls untyped
+mongodb_ss_wt_thread_state_active_filesystem_write_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_thread_yield_application_thread_time_evicting_usecs serverStatus.wiredTiger.thread-yield.
+# TYPE mongodb_ss_wt_thread_yield_application_thread_time_evicting_usecs untyped
+mongodb_ss_wt_thread_yield_application_thread_time_evicting_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_thread_yield_application_thread_time_waiting_for_cache_usecs serverStatus.wiredTiger.thread-yield.
+# TYPE mongodb_ss_wt_thread_yield_application_thread_time_waiting_for_cache_usecs untyped
+mongodb_ss_wt_thread_yield_application_thread_time_waiting_for_cache_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_thread_yield_connection_close_blocked_waiting_for_transaction_state_stabilization serverStatus.wiredTiger.thread-yield.
+# TYPE mongodb_ss_wt_thread_yield_connection_close_blocked_waiting_for_transaction_state_stabilization untyped
+mongodb_ss_wt_thread_yield_connection_close_blocked_waiting_for_transaction_state_stabilization{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_thread_yield_connection_close_yielded_for_lsm_manager_shutdown serverStatus.wiredTiger.thread-yield.
+# TYPE mongodb_ss_wt_thread_yield_connection_close_yielded_for_lsm_manager_shutdown untyped
+mongodb_ss_wt_thread_yield_connection_close_yielded_for_lsm_manager_shutdown{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_thread_yield_data_handle_lock_yielded serverStatus.wiredTiger.thread-yield.
+# TYPE mongodb_ss_wt_thread_yield_data_handle_lock_yielded untyped
+mongodb_ss_wt_thread_yield_data_handle_lock_yielded{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_thread_yield_get_reference_for_page_index_and_slot_time_sleeping_usecs serverStatus.wiredTiger.thread-yield.
+# TYPE mongodb_ss_wt_thread_yield_get_reference_for_page_index_and_slot_time_sleeping_usecs untyped
+mongodb_ss_wt_thread_yield_get_reference_for_page_index_and_slot_time_sleeping_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_thread_yield_log_server_sync_yielded_for_log_write serverStatus.wiredTiger.thread-yield.
+# TYPE mongodb_ss_wt_thread_yield_log_server_sync_yielded_for_log_write untyped
+mongodb_ss_wt_thread_yield_log_server_sync_yielded_for_log_write{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_thread_yield_page_access_yielded_due_to_prepare_state_change serverStatus.wiredTiger.thread-yield.
+# TYPE mongodb_ss_wt_thread_yield_page_access_yielded_due_to_prepare_state_change untyped
+mongodb_ss_wt_thread_yield_page_access_yielded_due_to_prepare_state_change{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_thread_yield_page_acquire_busy_blocked serverStatus.wiredTiger.thread-yield.
+# TYPE mongodb_ss_wt_thread_yield_page_acquire_busy_blocked untyped
+mongodb_ss_wt_thread_yield_page_acquire_busy_blocked{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_thread_yield_page_acquire_eviction_blocked serverStatus.wiredTiger.thread-yield.
+# TYPE mongodb_ss_wt_thread_yield_page_acquire_eviction_blocked untyped
+mongodb_ss_wt_thread_yield_page_acquire_eviction_blocked{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_thread_yield_page_acquire_locked_blocked serverStatus.wiredTiger.thread-yield.
+# TYPE mongodb_ss_wt_thread_yield_page_acquire_locked_blocked untyped
+mongodb_ss_wt_thread_yield_page_acquire_locked_blocked{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_thread_yield_page_acquire_read_blocked serverStatus.wiredTiger.thread-yield.
+# TYPE mongodb_ss_wt_thread_yield_page_acquire_read_blocked untyped
+mongodb_ss_wt_thread_yield_page_acquire_read_blocked{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_thread_yield_page_acquire_time_sleeping_usecs serverStatus.wiredTiger.thread-yield.
+# TYPE mongodb_ss_wt_thread_yield_page_acquire_time_sleeping_usecs untyped
+mongodb_ss_wt_thread_yield_page_acquire_time_sleeping_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_thread_yield_page_delete_rollback_time_sleeping_for_state_change_usecs serverStatus.wiredTiger.thread-yield.
+# TYPE mongodb_ss_wt_thread_yield_page_delete_rollback_time_sleeping_for_state_change_usecs untyped
+mongodb_ss_wt_thread_yield_page_delete_rollback_time_sleeping_for_state_change_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_thread_yield_page_reconciliation_yielded_due_to_child_modification serverStatus.wiredTiger.thread-yield.
+# TYPE mongodb_ss_wt_thread_yield_page_reconciliation_yielded_due_to_child_modification untyped
+mongodb_ss_wt_thread_yield_page_reconciliation_yielded_due_to_child_modification{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_txn_Number_of_prepared_updates serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_Number_of_prepared_updates untyped
+mongodb_ss_wt_txn_Number_of_prepared_updates{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_txn_Number_of_prepared_updates_added_to_cache_overflow serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_Number_of_prepared_updates_added_to_cache_overflow untyped
+mongodb_ss_wt_txn_Number_of_prepared_updates_added_to_cache_overflow{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_txn_Number_of_prepared_updates_resolved serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_Number_of_prepared_updates_resolved untyped
+mongodb_ss_wt_txn_Number_of_prepared_updates_resolved{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_txn_commit_timestamp_queue_entries_walked serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_commit_timestamp_queue_entries_walked untyped
+mongodb_ss_wt_txn_commit_timestamp_queue_entries_walked{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 68
+# HELP mongodb_ss_wt_txn_commit_timestamp_queue_insert_to_empty serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_commit_timestamp_queue_insert_to_empty untyped
+mongodb_ss_wt_txn_commit_timestamp_queue_insert_to_empty{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 544
+# HELP mongodb_ss_wt_txn_commit_timestamp_queue_inserts_to_head serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_commit_timestamp_queue_inserts_to_head untyped
+mongodb_ss_wt_txn_commit_timestamp_queue_inserts_to_head{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 68
+# HELP mongodb_ss_wt_txn_commit_timestamp_queue_inserts_total serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_commit_timestamp_queue_inserts_total untyped
+mongodb_ss_wt_txn_commit_timestamp_queue_inserts_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 612
+# HELP mongodb_ss_wt_txn_commit_timestamp_queue_length serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_commit_timestamp_queue_length untyped
+mongodb_ss_wt_txn_commit_timestamp_queue_length{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_ss_wt_txn_number_of_named_snapshots_created serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_number_of_named_snapshots_created untyped
+mongodb_ss_wt_txn_number_of_named_snapshots_created{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_txn_number_of_named_snapshots_dropped serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_number_of_named_snapshots_dropped untyped
+mongodb_ss_wt_txn_number_of_named_snapshots_dropped{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_txn_prepared_transactions serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_prepared_transactions untyped
+mongodb_ss_wt_txn_prepared_transactions{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_txn_prepared_transactions_committed serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_prepared_transactions_committed untyped
+mongodb_ss_wt_txn_prepared_transactions_committed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_txn_prepared_transactions_currently_active serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_prepared_transactions_currently_active untyped
+mongodb_ss_wt_txn_prepared_transactions_currently_active{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_txn_prepared_transactions_rolled_back serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_prepared_transactions_rolled_back untyped
+mongodb_ss_wt_txn_prepared_transactions_rolled_back{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_txn_query_timestamp_calls serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_query_timestamp_calls untyped
+mongodb_ss_wt_txn_query_timestamp_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 270
+# HELP mongodb_ss_wt_txn_read_timestamp_queue_entries_walked serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_read_timestamp_queue_entries_walked untyped
+mongodb_ss_wt_txn_read_timestamp_queue_entries_walked{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 160
+# HELP mongodb_ss_wt_txn_read_timestamp_queue_insert_to_empty serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_read_timestamp_queue_insert_to_empty untyped
+mongodb_ss_wt_txn_read_timestamp_queue_insert_to_empty{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 389
+# HELP mongodb_ss_wt_txn_read_timestamp_queue_inserts_to_head serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_read_timestamp_queue_inserts_to_head untyped
+mongodb_ss_wt_txn_read_timestamp_queue_inserts_to_head{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 159
+# HELP mongodb_ss_wt_txn_read_timestamp_queue_inserts_total serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_read_timestamp_queue_inserts_total untyped
+mongodb_ss_wt_txn_read_timestamp_queue_inserts_total{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 549
+# HELP mongodb_ss_wt_txn_read_timestamp_queue_length serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_read_timestamp_queue_length untyped
+mongodb_ss_wt_txn_read_timestamp_queue_length{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_ss_wt_txn_rollback_to_stable_calls serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_rollback_to_stable_calls untyped
+mongodb_ss_wt_txn_rollback_to_stable_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_txn_rollback_to_stable_updates_aborted serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_rollback_to_stable_updates_aborted untyped
+mongodb_ss_wt_txn_rollback_to_stable_updates_aborted{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_txn_rollback_to_stable_updates_removed_from_cache_overflow serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_rollback_to_stable_updates_removed_from_cache_overflow untyped
+mongodb_ss_wt_txn_rollback_to_stable_updates_removed_from_cache_overflow{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_txn_set_timestamp_calls serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_set_timestamp_calls untyped
+mongodb_ss_wt_txn_set_timestamp_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 272
+# HELP mongodb_ss_wt_txn_set_timestamp_commit_calls serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_set_timestamp_commit_calls untyped
+mongodb_ss_wt_txn_set_timestamp_commit_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_txn_set_timestamp_commit_updates serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_set_timestamp_commit_updates untyped
+mongodb_ss_wt_txn_set_timestamp_commit_updates{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_txn_set_timestamp_oldest_calls serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_set_timestamp_oldest_calls untyped
+mongodb_ss_wt_txn_set_timestamp_oldest_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 136
+# HELP mongodb_ss_wt_txn_set_timestamp_oldest_updates serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_set_timestamp_oldest_updates untyped
+mongodb_ss_wt_txn_set_timestamp_oldest_updates{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 134
+# HELP mongodb_ss_wt_txn_set_timestamp_stable_calls serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_set_timestamp_stable_calls untyped
+mongodb_ss_wt_txn_set_timestamp_stable_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 136
+# HELP mongodb_ss_wt_txn_set_timestamp_stable_updates serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_set_timestamp_stable_updates untyped
+mongodb_ss_wt_txn_set_timestamp_stable_updates{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 136
+# HELP mongodb_ss_wt_txn_transaction_begins serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_transaction_begins untyped
+mongodb_ss_wt_txn_transaction_begins{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 8550
+# HELP mongodb_ss_wt_txn_transaction_checkpoint_currently_running serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_transaction_checkpoint_currently_running untyped
+mongodb_ss_wt_txn_transaction_checkpoint_currently_running{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_txn_transaction_checkpoint_generation serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_transaction_checkpoint_generation untyped
+mongodb_ss_wt_txn_transaction_checkpoint_generation{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 24
+# HELP mongodb_ss_wt_txn_transaction_checkpoint_max_time_msecs serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_transaction_checkpoint_max_time_msecs untyped
+mongodb_ss_wt_txn_transaction_checkpoint_max_time_msecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 18
+# HELP mongodb_ss_wt_txn_transaction_checkpoint_min_time_msecs serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_transaction_checkpoint_min_time_msecs untyped
+mongodb_ss_wt_txn_transaction_checkpoint_min_time_msecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 2
+# HELP mongodb_ss_wt_txn_transaction_checkpoint_most_recent_time_msecs serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_transaction_checkpoint_most_recent_time_msecs untyped
+mongodb_ss_wt_txn_transaction_checkpoint_most_recent_time_msecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 4
+# HELP mongodb_ss_wt_txn_transaction_checkpoint_scrub_dirty_target serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_transaction_checkpoint_scrub_dirty_target untyped
+mongodb_ss_wt_txn_transaction_checkpoint_scrub_dirty_target{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_txn_transaction_checkpoint_scrub_time_msecs serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_transaction_checkpoint_scrub_time_msecs untyped
+mongodb_ss_wt_txn_transaction_checkpoint_scrub_time_msecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_txn_transaction_checkpoint_total_time_msecs serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_transaction_checkpoint_total_time_msecs untyped
+mongodb_ss_wt_txn_transaction_checkpoint_total_time_msecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 127
+# HELP mongodb_ss_wt_txn_transaction_checkpoints serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_transaction_checkpoints untyped
+mongodb_ss_wt_txn_transaction_checkpoints{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 23
+# HELP mongodb_ss_wt_txn_transaction_checkpoints_skipped_because_database_was_clean serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_transaction_checkpoints_skipped_because_database_was_clean untyped
+mongodb_ss_wt_txn_transaction_checkpoints_skipped_because_database_was_clean{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_txn_transaction_failures_due_to_cache_overflow serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_transaction_failures_due_to_cache_overflow untyped
+mongodb_ss_wt_txn_transaction_failures_due_to_cache_overflow{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_txn_transaction_fsync_calls_for_checkpoint_after_allocating_the_transaction_ID serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_transaction_fsync_calls_for_checkpoint_after_allocating_the_transaction_ID untyped
+mongodb_ss_wt_txn_transaction_fsync_calls_for_checkpoint_after_allocating_the_transaction_ID{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 23
+# HELP mongodb_ss_wt_txn_transaction_fsync_duration_for_checkpoint_after_allocating_the_transaction_ID_usecs serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_transaction_fsync_duration_for_checkpoint_after_allocating_the_transaction_ID_usecs untyped
+mongodb_ss_wt_txn_transaction_fsync_duration_for_checkpoint_after_allocating_the_transaction_ID_usecs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1234
+# HELP mongodb_ss_wt_txn_transaction_range_of_IDs_currently_pinned serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_transaction_range_of_IDs_currently_pinned untyped
+mongodb_ss_wt_txn_transaction_range_of_IDs_currently_pinned{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_txn_transaction_range_of_IDs_currently_pinned_by_a_checkpoint serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_transaction_range_of_IDs_currently_pinned_by_a_checkpoint untyped
+mongodb_ss_wt_txn_transaction_range_of_IDs_currently_pinned_by_a_checkpoint{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_txn_transaction_range_of_IDs_currently_pinned_by_named_snapshots serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_transaction_range_of_IDs_currently_pinned_by_named_snapshots untyped
+mongodb_ss_wt_txn_transaction_range_of_IDs_currently_pinned_by_named_snapshots{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_txn_transaction_range_of_timestamps_currently_pinned serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_transaction_range_of_timestamps_currently_pinned untyped
+mongodb_ss_wt_txn_transaction_range_of_timestamps_currently_pinned{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 4.294967296e+10
+# HELP mongodb_ss_wt_txn_transaction_range_of_timestamps_pinned_by_a_checkpoint serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_transaction_range_of_timestamps_pinned_by_a_checkpoint untyped
+mongodb_ss_wt_txn_transaction_range_of_timestamps_pinned_by_a_checkpoint{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 7.156246144631177e+18
+# HELP mongodb_ss_wt_txn_transaction_range_of_timestamps_pinned_by_the_oldest_timestamp serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_transaction_range_of_timestamps_pinned_by_the_oldest_timestamp untyped
+mongodb_ss_wt_txn_transaction_range_of_timestamps_pinned_by_the_oldest_timestamp{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 4.294967296e+10
+# HELP mongodb_ss_wt_txn_transaction_sync_calls serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_transaction_sync_calls untyped
+mongodb_ss_wt_txn_transaction_sync_calls{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_ss_wt_txn_transactions_committed serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_transactions_committed untyped
+mongodb_ss_wt_txn_transactions_committed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 637
+# HELP mongodb_ss_wt_txn_transactions_rolled_back serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_transactions_rolled_back untyped
+mongodb_ss_wt_txn_transactions_rolled_back{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 7913
+# HELP mongodb_ss_wt_txn_update_conflicts serverStatus.wiredTiger.transaction.
+# TYPE mongodb_ss_wt_txn_update_conflicts untyped
+mongodb_ss_wt_txn_update_conflicts{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_start start
+# TYPE mongodb_start untyped
+mongodb_start{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.666193406e+12
+# HELP mongodb_syncSourceId syncSourceId
+# TYPE mongodb_syncSourceId untyped
+mongodb_syncSourceId{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} -1
+# HELP mongodb_sys_cpu_btime systemMetrics.cpu.
+# TYPE mongodb_sys_cpu_btime untyped
+mongodb_sys_cpu_btime{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.666023373e+09
+# HELP mongodb_sys_cpu_ctxt systemMetrics.cpu.
+# TYPE mongodb_sys_cpu_ctxt untyped
+mongodb_sys_cpu_ctxt{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 2.654653544e+09
+# HELP mongodb_sys_cpu_guest_ms systemMetrics.cpu.
+# TYPE mongodb_sys_cpu_guest_ms untyped
+mongodb_sys_cpu_guest_ms{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_cpu_guest_nice_ms systemMetrics.cpu.
+# TYPE mongodb_sys_cpu_guest_nice_ms untyped
+mongodb_sys_cpu_guest_nice_ms{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_cpu_idle_ms systemMetrics.cpu.
+# TYPE mongodb_sys_cpu_idle_ms untyped
+mongodb_sys_cpu_idle_ms{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.22762372e+09
+# HELP mongodb_sys_cpu_iowait_ms systemMetrics.cpu.
+# TYPE mongodb_sys_cpu_iowait_ms untyped
+mongodb_sys_cpu_iowait_ms{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.3567e+06
+# HELP mongodb_sys_cpu_irq_ms systemMetrics.cpu.
+# TYPE mongodb_sys_cpu_irq_ms untyped
+mongodb_sys_cpu_irq_ms{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_cpu_nice_ms systemMetrics.cpu.
+# TYPE mongodb_sys_cpu_nice_ms untyped
+mongodb_sys_cpu_nice_ms{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 160
+# HELP mongodb_sys_cpu_num_cpus systemMetrics.cpu.
+# TYPE mongodb_sys_cpu_num_cpus untyped
+mongodb_sys_cpu_num_cpus{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 8
+# HELP mongodb_sys_cpu_processes systemMetrics.cpu.
+# TYPE mongodb_sys_cpu_processes untyped
+mongodb_sys_cpu_processes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 5.254639e+06
+# HELP mongodb_sys_cpu_procs_blocked systemMetrics.cpu.
+# TYPE mongodb_sys_cpu_procs_blocked untyped
+mongodb_sys_cpu_procs_blocked{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_cpu_procs_running systemMetrics.cpu.
+# TYPE mongodb_sys_cpu_procs_running untyped
+mongodb_sys_cpu_procs_running{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 11
+# HELP mongodb_sys_cpu_softirq_ms systemMetrics.cpu.
+# TYPE mongodb_sys_cpu_softirq_ms untyped
+mongodb_sys_cpu_softirq_ms{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 2.06503e+06
+# HELP mongodb_sys_cpu_steal_ms systemMetrics.cpu.
+# TYPE mongodb_sys_cpu_steal_ms untyped
+mongodb_sys_cpu_steal_ms{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 3.54418e+06
+# HELP mongodb_sys_cpu_system_ms systemMetrics.cpu.
+# TYPE mongodb_sys_cpu_system_ms untyped
+mongodb_sys_cpu_system_ms{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 3.548011e+07
+# HELP mongodb_sys_cpu_user_ms systemMetrics.cpu.
+# TYPE mongodb_sys_cpu_user_ms untyped
+mongodb_sys_cpu_user_ms{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 6.845908e+07
+# HELP mongodb_sys_disks_vda_io_in_progress systemMetrics.disks.vda.
+# TYPE mongodb_sys_disks_vda_io_in_progress untyped
+mongodb_sys_disks_vda_io_in_progress{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_disks_vda_io_queued_ms systemMetrics.disks.vda.
+# TYPE mongodb_sys_disks_vda_io_queued_ms untyped
+mongodb_sys_disks_vda_io_queued_ms{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.5003112e+07
+# HELP mongodb_sys_disks_vda_io_time_ms systemMetrics.disks.vda.
+# TYPE mongodb_sys_disks_vda_io_time_ms untyped
+mongodb_sys_disks_vda_io_time_ms{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.109432e+06
+# HELP mongodb_sys_disks_vda_read_sectors systemMetrics.disks.vda.
+# TYPE mongodb_sys_disks_vda_read_sectors untyped
+mongodb_sys_disks_vda_read_sectors{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.1317453e+07
+# HELP mongodb_sys_disks_vda_read_time_ms systemMetrics.disks.vda.
+# TYPE mongodb_sys_disks_vda_read_time_ms untyped
+mongodb_sys_disks_vda_read_time_ms{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 439092
+# HELP mongodb_sys_disks_vda_reads systemMetrics.disks.vda.
+# TYPE mongodb_sys_disks_vda_reads untyped
+mongodb_sys_disks_vda_reads{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 111605
+# HELP mongodb_sys_disks_vda_reads_merged systemMetrics.disks.vda.
+# TYPE mongodb_sys_disks_vda_reads_merged untyped
+mongodb_sys_disks_vda_reads_merged{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 333
+# HELP mongodb_sys_disks_vda_write_sectors systemMetrics.disks.vda.
+# TYPE mongodb_sys_disks_vda_write_sectors untyped
+mongodb_sys_disks_vda_write_sectors{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 3.71682043e+08
+# HELP mongodb_sys_disks_vda_write_time_ms systemMetrics.disks.vda.
+# TYPE mongodb_sys_disks_vda_write_time_ms untyped
+mongodb_sys_disks_vda_write_time_ms{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 2.0415708e+07
+# HELP mongodb_sys_disks_vda_writes systemMetrics.disks.vda.
+# TYPE mongodb_sys_disks_vda_writes untyped
+mongodb_sys_disks_vda_writes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 9.190157e+06
+# HELP mongodb_sys_disks_vda_writes_merged systemMetrics.disks.vda.
+# TYPE mongodb_sys_disks_vda_writes_merged untyped
+mongodb_sys_disks_vda_writes_merged{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.162592e+06
+# HELP mongodb_sys_end systemMetrics.
+# TYPE mongodb_sys_end untyped
+mongodb_sys_end{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.666193406002e+12
+# HELP mongodb_sys_memory_Active_anon_kb systemMetrics.memory.
+# TYPE mongodb_sys_memory_Active_anon_kb untyped
+mongodb_sys_memory_Active_anon_kb{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 7.920348e+06
+# HELP mongodb_sys_memory_Active_file_kb systemMetrics.memory.
+# TYPE mongodb_sys_memory_Active_file_kb untyped
+mongodb_sys_memory_Active_file_kb{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 5.809992e+06
+# HELP mongodb_sys_memory_Active_kb systemMetrics.memory.
+# TYPE mongodb_sys_memory_Active_kb untyped
+mongodb_sys_memory_Active_kb{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.373034e+07
+# HELP mongodb_sys_memory_Buffers_kb systemMetrics.memory.
+# TYPE mongodb_sys_memory_Buffers_kb untyped
+mongodb_sys_memory_Buffers_kb{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1060
+# HELP mongodb_sys_memory_Cached_kb systemMetrics.memory.
+# TYPE mongodb_sys_memory_Cached_kb untyped
+mongodb_sys_memory_Cached_kb{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.852484e+07
+# HELP mongodb_sys_memory_Dirty_kb systemMetrics.memory.
+# TYPE mongodb_sys_memory_Dirty_kb untyped
+mongodb_sys_memory_Dirty_kb{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 432
+# HELP mongodb_sys_memory_Inactive_anon_kb systemMetrics.memory.
+# TYPE mongodb_sys_memory_Inactive_anon_kb untyped
+mongodb_sys_memory_Inactive_anon_kb{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 38004
+# HELP mongodb_sys_memory_Inactive_file_kb systemMetrics.memory.
+# TYPE mongodb_sys_memory_Inactive_file_kb untyped
+mongodb_sys_memory_Inactive_file_kb{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.267116e+07
+# HELP mongodb_sys_memory_Inactive_kb systemMetrics.memory.
+# TYPE mongodb_sys_memory_Inactive_kb untyped
+mongodb_sys_memory_Inactive_kb{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.2709164e+07
+# HELP mongodb_sys_memory_MemFree_kb systemMetrics.memory.
+# TYPE mongodb_sys_memory_MemFree_kb untyped
+mongodb_sys_memory_MemFree_kb{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 3.464416e+06
+# HELP mongodb_sys_memory_MemTotal_kb systemMetrics.memory.
+# TYPE mongodb_sys_memory_MemTotal_kb untyped
+mongodb_sys_memory_MemTotal_kb{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 3.2779824e+07
+# HELP mongodb_sys_memory_SwapCached_kb systemMetrics.memory.
+# TYPE mongodb_sys_memory_SwapCached_kb untyped
+mongodb_sys_memory_SwapCached_kb{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_memory_SwapFree_kb systemMetrics.memory.
+# TYPE mongodb_sys_memory_SwapFree_kb untyped
+mongodb_sys_memory_SwapFree_kb{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_memory_SwapTotal_kb systemMetrics.memory.
+# TYPE mongodb_sys_memory_SwapTotal_kb untyped
+mongodb_sys_memory_SwapTotal_kb{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_IpExt_InBcastOctets systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_IpExt_InBcastOctets untyped
+mongodb_sys_netstat_IpExt_InBcastOctets{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_IpExt_InBcastPkts systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_IpExt_InBcastPkts untyped
+mongodb_sys_netstat_IpExt_InBcastPkts{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_IpExt_InCEPkts systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_IpExt_InCEPkts untyped
+mongodb_sys_netstat_IpExt_InCEPkts{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_IpExt_InCsumErrors systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_IpExt_InCsumErrors untyped
+mongodb_sys_netstat_IpExt_InCsumErrors{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_IpExt_InECT0Pkts systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_IpExt_InECT0Pkts untyped
+mongodb_sys_netstat_IpExt_InECT0Pkts{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_IpExt_InECT1Pkts systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_IpExt_InECT1Pkts untyped
+mongodb_sys_netstat_IpExt_InECT1Pkts{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_IpExt_InMcastOctets systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_IpExt_InMcastOctets untyped
+mongodb_sys_netstat_IpExt_InMcastOctets{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_IpExt_InMcastPkts systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_IpExt_InMcastPkts untyped
+mongodb_sys_netstat_IpExt_InMcastPkts{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_IpExt_InNoECTPkts systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_IpExt_InNoECTPkts untyped
+mongodb_sys_netstat_IpExt_InNoECTPkts{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 58214
+# HELP mongodb_sys_netstat_IpExt_InNoRoutes systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_IpExt_InNoRoutes untyped
+mongodb_sys_netstat_IpExt_InNoRoutes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_IpExt_InOctets systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_IpExt_InOctets untyped
+mongodb_sys_netstat_IpExt_InOctets{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 9.6779818e+07
+# HELP mongodb_sys_netstat_IpExt_InTruncatedPkts systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_IpExt_InTruncatedPkts untyped
+mongodb_sys_netstat_IpExt_InTruncatedPkts{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_IpExt_OutBcastOctets systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_IpExt_OutBcastOctets untyped
+mongodb_sys_netstat_IpExt_OutBcastOctets{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_IpExt_OutBcastPkts systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_IpExt_OutBcastPkts untyped
+mongodb_sys_netstat_IpExt_OutBcastPkts{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_IpExt_OutMcastOctets systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_IpExt_OutMcastOctets untyped
+mongodb_sys_netstat_IpExt_OutMcastOctets{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_IpExt_OutMcastPkts systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_IpExt_OutMcastPkts untyped
+mongodb_sys_netstat_IpExt_OutMcastPkts{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_IpExt_OutOctets systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_IpExt_OutOctets untyped
+mongodb_sys_netstat_IpExt_OutOctets{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.18340408e+08
+# HELP mongodb_sys_netstat_IpExt_ReasmOverlaps systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_IpExt_ReasmOverlaps untyped
+mongodb_sys_netstat_IpExt_ReasmOverlaps{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_Ip_DefaultTTL systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_Ip_DefaultTTL untyped
+mongodb_sys_netstat_Ip_DefaultTTL{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 64
+# HELP mongodb_sys_netstat_Ip_ForwDatagrams systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_Ip_ForwDatagrams untyped
+mongodb_sys_netstat_Ip_ForwDatagrams{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_Ip_Forwarding systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_Ip_Forwarding untyped
+mongodb_sys_netstat_Ip_Forwarding{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_sys_netstat_Ip_FragCreates systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_Ip_FragCreates untyped
+mongodb_sys_netstat_Ip_FragCreates{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_Ip_FragFails systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_Ip_FragFails untyped
+mongodb_sys_netstat_Ip_FragFails{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_Ip_FragOKs systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_Ip_FragOKs untyped
+mongodb_sys_netstat_Ip_FragOKs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_Ip_InAddrErrors systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_Ip_InAddrErrors untyped
+mongodb_sys_netstat_Ip_InAddrErrors{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_Ip_InDelivers systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_Ip_InDelivers untyped
+mongodb_sys_netstat_Ip_InDelivers{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 58214
+# HELP mongodb_sys_netstat_Ip_InDiscards systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_Ip_InDiscards untyped
+mongodb_sys_netstat_Ip_InDiscards{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_Ip_InHdrErrors systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_Ip_InHdrErrors untyped
+mongodb_sys_netstat_Ip_InHdrErrors{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_Ip_InReceives systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_Ip_InReceives untyped
+mongodb_sys_netstat_Ip_InReceives{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 58214
+# HELP mongodb_sys_netstat_Ip_InUnknownProtos systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_Ip_InUnknownProtos untyped
+mongodb_sys_netstat_Ip_InUnknownProtos{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_Ip_OutDiscards systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_Ip_OutDiscards untyped
+mongodb_sys_netstat_Ip_OutDiscards{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_Ip_OutNoRoutes systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_Ip_OutNoRoutes untyped
+mongodb_sys_netstat_Ip_OutNoRoutes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_Ip_OutRequests systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_Ip_OutRequests untyped
+mongodb_sys_netstat_Ip_OutRequests{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 57320
+# HELP mongodb_sys_netstat_Ip_ReasmFails systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_Ip_ReasmFails untyped
+mongodb_sys_netstat_Ip_ReasmFails{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_Ip_ReasmOKs systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_Ip_ReasmOKs untyped
+mongodb_sys_netstat_Ip_ReasmOKs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_Ip_ReasmReqds systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_Ip_ReasmReqds untyped
+mongodb_sys_netstat_Ip_ReasmReqds{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_Ip_ReasmTimeout systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_Ip_ReasmTimeout untyped
+mongodb_sys_netstat_Ip_ReasmTimeout{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_ArpFilter systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_ArpFilter untyped
+mongodb_sys_netstat_TcpExt_ArpFilter{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_BusyPollRxPackets systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_BusyPollRxPackets untyped
+mongodb_sys_netstat_TcpExt_BusyPollRxPackets{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_DelayedACKLocked systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_DelayedACKLocked untyped
+mongodb_sys_netstat_TcpExt_DelayedACKLocked{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_DelayedACKLost systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_DelayedACKLost untyped
+mongodb_sys_netstat_TcpExt_DelayedACKLost{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_sys_netstat_TcpExt_DelayedACKs systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_DelayedACKs untyped
+mongodb_sys_netstat_TcpExt_DelayedACKs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 588
+# HELP mongodb_sys_netstat_TcpExt_EmbryonicRsts systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_EmbryonicRsts untyped
+mongodb_sys_netstat_TcpExt_EmbryonicRsts{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_IPReversePathFilter systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_IPReversePathFilter untyped
+mongodb_sys_netstat_TcpExt_IPReversePathFilter{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_ListenDrops systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_ListenDrops untyped
+mongodb_sys_netstat_TcpExt_ListenDrops{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_ListenOverflows systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_ListenOverflows untyped
+mongodb_sys_netstat_TcpExt_ListenOverflows{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_LockDroppedIcmps systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_LockDroppedIcmps untyped
+mongodb_sys_netstat_TcpExt_LockDroppedIcmps{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_OfoPruned systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_OfoPruned untyped
+mongodb_sys_netstat_TcpExt_OfoPruned{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_OutOfWindowIcmps systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_OutOfWindowIcmps untyped
+mongodb_sys_netstat_TcpExt_OutOfWindowIcmps{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_PAWSActive systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_PAWSActive untyped
+mongodb_sys_netstat_TcpExt_PAWSActive{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_PAWSEstab systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_PAWSEstab untyped
+mongodb_sys_netstat_TcpExt_PAWSEstab{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_PAWSPassive systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_PAWSPassive untyped
+mongodb_sys_netstat_TcpExt_PAWSPassive{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_PruneCalled systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_PruneCalled untyped
+mongodb_sys_netstat_TcpExt_PruneCalled{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_RcvPruned systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_RcvPruned untyped
+mongodb_sys_netstat_TcpExt_RcvPruned{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_SyncookiesFailed systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_SyncookiesFailed untyped
+mongodb_sys_netstat_TcpExt_SyncookiesFailed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_SyncookiesRecv systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_SyncookiesRecv untyped
+mongodb_sys_netstat_TcpExt_SyncookiesRecv{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_SyncookiesSent systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_SyncookiesSent untyped
+mongodb_sys_netstat_TcpExt_SyncookiesSent{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPACKSkippedChallenge systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPACKSkippedChallenge untyped
+mongodb_sys_netstat_TcpExt_TCPACKSkippedChallenge{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPACKSkippedFinWait2 systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPACKSkippedFinWait2 untyped
+mongodb_sys_netstat_TcpExt_TCPACKSkippedFinWait2{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPACKSkippedPAWS systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPACKSkippedPAWS untyped
+mongodb_sys_netstat_TcpExt_TCPACKSkippedPAWS{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPACKSkippedSeq systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPACKSkippedSeq untyped
+mongodb_sys_netstat_TcpExt_TCPACKSkippedSeq{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPACKSkippedSynRecv systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPACKSkippedSynRecv untyped
+mongodb_sys_netstat_TcpExt_TCPACKSkippedSynRecv{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPACKSkippedTimeWait systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPACKSkippedTimeWait untyped
+mongodb_sys_netstat_TcpExt_TCPACKSkippedTimeWait{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPAbortFailed systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPAbortFailed untyped
+mongodb_sys_netstat_TcpExt_TCPAbortFailed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPAbortOnClose systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPAbortOnClose untyped
+mongodb_sys_netstat_TcpExt_TCPAbortOnClose{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_sys_netstat_TcpExt_TCPAbortOnData systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPAbortOnData untyped
+mongodb_sys_netstat_TcpExt_TCPAbortOnData{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPAbortOnLinger systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPAbortOnLinger untyped
+mongodb_sys_netstat_TcpExt_TCPAbortOnLinger{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPAbortOnMemory systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPAbortOnMemory untyped
+mongodb_sys_netstat_TcpExt_TCPAbortOnMemory{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPAbortOnTimeout systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPAbortOnTimeout untyped
+mongodb_sys_netstat_TcpExt_TCPAbortOnTimeout{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPAutoCorking systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPAutoCorking untyped
+mongodb_sys_netstat_TcpExt_TCPAutoCorking{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPBacklogDrop systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPBacklogDrop untyped
+mongodb_sys_netstat_TcpExt_TCPBacklogDrop{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPChallengeACK systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPChallengeACK untyped
+mongodb_sys_netstat_TcpExt_TCPChallengeACK{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 15
+# HELP mongodb_sys_netstat_TcpExt_TCPDSACKIgnoredNoUndo systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPDSACKIgnoredNoUndo untyped
+mongodb_sys_netstat_TcpExt_TCPDSACKIgnoredNoUndo{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_sys_netstat_TcpExt_TCPDSACKIgnoredOld systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPDSACKIgnoredOld untyped
+mongodb_sys_netstat_TcpExt_TCPDSACKIgnoredOld{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPDSACKOfoRecv systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPDSACKOfoRecv untyped
+mongodb_sys_netstat_TcpExt_TCPDSACKOfoRecv{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPDSACKOfoSent systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPDSACKOfoSent untyped
+mongodb_sys_netstat_TcpExt_TCPDSACKOfoSent{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPDSACKOldSent systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPDSACKOldSent untyped
+mongodb_sys_netstat_TcpExt_TCPDSACKOldSent{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_sys_netstat_TcpExt_TCPDSACKRecv systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPDSACKRecv untyped
+mongodb_sys_netstat_TcpExt_TCPDSACKRecv{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_sys_netstat_TcpExt_TCPDSACKUndo systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPDSACKUndo untyped
+mongodb_sys_netstat_TcpExt_TCPDSACKUndo{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPDeferAcceptDrop systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPDeferAcceptDrop untyped
+mongodb_sys_netstat_TcpExt_TCPDeferAcceptDrop{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPDirectCopyFromBacklog systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPDirectCopyFromBacklog untyped
+mongodb_sys_netstat_TcpExt_TCPDirectCopyFromBacklog{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPDirectCopyFromPrequeue systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPDirectCopyFromPrequeue untyped
+mongodb_sys_netstat_TcpExt_TCPDirectCopyFromPrequeue{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 173392
+# HELP mongodb_sys_netstat_TcpExt_TCPFACKReorder systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPFACKReorder untyped
+mongodb_sys_netstat_TcpExt_TCPFACKReorder{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPFastOpenActive systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPFastOpenActive untyped
+mongodb_sys_netstat_TcpExt_TCPFastOpenActive{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPFastOpenActiveFail systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPFastOpenActiveFail untyped
+mongodb_sys_netstat_TcpExt_TCPFastOpenActiveFail{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPFastOpenCookieReqd systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPFastOpenCookieReqd untyped
+mongodb_sys_netstat_TcpExt_TCPFastOpenCookieReqd{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPFastOpenListenOverflow systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPFastOpenListenOverflow untyped
+mongodb_sys_netstat_TcpExt_TCPFastOpenListenOverflow{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPFastOpenPassive systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPFastOpenPassive untyped
+mongodb_sys_netstat_TcpExt_TCPFastOpenPassive{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPFastOpenPassiveFail systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPFastOpenPassiveFail untyped
+mongodb_sys_netstat_TcpExt_TCPFastOpenPassiveFail{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPFastRetrans systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPFastRetrans untyped
+mongodb_sys_netstat_TcpExt_TCPFastRetrans{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPForwardRetrans systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPForwardRetrans untyped
+mongodb_sys_netstat_TcpExt_TCPForwardRetrans{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPFromZeroWindowAdv systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPFromZeroWindowAdv untyped
+mongodb_sys_netstat_TcpExt_TCPFromZeroWindowAdv{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPFullUndo systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPFullUndo untyped
+mongodb_sys_netstat_TcpExt_TCPFullUndo{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPHPAcks systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPHPAcks untyped
+mongodb_sys_netstat_TcpExt_TCPHPAcks{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 2980
+# HELP mongodb_sys_netstat_TcpExt_TCPHPHits systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPHPHits untyped
+mongodb_sys_netstat_TcpExt_TCPHPHits{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 7002
+# HELP mongodb_sys_netstat_TcpExt_TCPHPHitsToUser systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPHPHitsToUser untyped
+mongodb_sys_netstat_TcpExt_TCPHPHitsToUser{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPHystartDelayCwnd systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPHystartDelayCwnd untyped
+mongodb_sys_netstat_TcpExt_TCPHystartDelayCwnd{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPHystartDelayDetect systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPHystartDelayDetect untyped
+mongodb_sys_netstat_TcpExt_TCPHystartDelayDetect{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPHystartTrainCwnd systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPHystartTrainCwnd untyped
+mongodb_sys_netstat_TcpExt_TCPHystartTrainCwnd{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 115
+# HELP mongodb_sys_netstat_TcpExt_TCPHystartTrainDetect systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPHystartTrainDetect untyped
+mongodb_sys_netstat_TcpExt_TCPHystartTrainDetect{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 5
+# HELP mongodb_sys_netstat_TcpExt_TCPLossFailures systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPLossFailures untyped
+mongodb_sys_netstat_TcpExt_TCPLossFailures{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPLossProbeRecovery systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPLossProbeRecovery untyped
+mongodb_sys_netstat_TcpExt_TCPLossProbeRecovery{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPLossProbes systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPLossProbes untyped
+mongodb_sys_netstat_TcpExt_TCPLossProbes{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_sys_netstat_TcpExt_TCPLossUndo systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPLossUndo untyped
+mongodb_sys_netstat_TcpExt_TCPLossUndo{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPLostRetransmit systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPLostRetransmit untyped
+mongodb_sys_netstat_TcpExt_TCPLostRetransmit{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPMD5NotFound systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPMD5NotFound untyped
+mongodb_sys_netstat_TcpExt_TCPMD5NotFound{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPMD5Unexpected systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPMD5Unexpected untyped
+mongodb_sys_netstat_TcpExt_TCPMD5Unexpected{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPMemoryPressures systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPMemoryPressures untyped
+mongodb_sys_netstat_TcpExt_TCPMemoryPressures{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPMinTTLDrop systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPMinTTLDrop untyped
+mongodb_sys_netstat_TcpExt_TCPMinTTLDrop{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPOFODrop systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPOFODrop untyped
+mongodb_sys_netstat_TcpExt_TCPOFODrop{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPOFOMerge systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPOFOMerge untyped
+mongodb_sys_netstat_TcpExt_TCPOFOMerge{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPOFOQueue systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPOFOQueue untyped
+mongodb_sys_netstat_TcpExt_TCPOFOQueue{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPOrigDataSent systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPOrigDataSent untyped
+mongodb_sys_netstat_TcpExt_TCPOrigDataSent{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 53952
+# HELP mongodb_sys_netstat_TcpExt_TCPPartialUndo systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPPartialUndo untyped
+mongodb_sys_netstat_TcpExt_TCPPartialUndo{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPPrequeueDropped systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPPrequeueDropped untyped
+mongodb_sys_netstat_TcpExt_TCPPrequeueDropped{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPPrequeued systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPPrequeued untyped
+mongodb_sys_netstat_TcpExt_TCPPrequeued{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 16053
+# HELP mongodb_sys_netstat_TcpExt_TCPPureAcks systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPPureAcks untyped
+mongodb_sys_netstat_TcpExt_TCPPureAcks{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 14117
+# HELP mongodb_sys_netstat_TcpExt_TCPRcvCoalesce systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPRcvCoalesce untyped
+mongodb_sys_netstat_TcpExt_TCPRcvCoalesce{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPRcvCollapsed systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPRcvCollapsed untyped
+mongodb_sys_netstat_TcpExt_TCPRcvCollapsed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPRenoFailures systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPRenoFailures untyped
+mongodb_sys_netstat_TcpExt_TCPRenoFailures{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPRenoRecovery systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPRenoRecovery untyped
+mongodb_sys_netstat_TcpExt_TCPRenoRecovery{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPRenoRecoveryFail systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPRenoRecoveryFail untyped
+mongodb_sys_netstat_TcpExt_TCPRenoRecoveryFail{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPRenoReorder systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPRenoReorder untyped
+mongodb_sys_netstat_TcpExt_TCPRenoReorder{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPReqQFullDoCookies systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPReqQFullDoCookies untyped
+mongodb_sys_netstat_TcpExt_TCPReqQFullDoCookies{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPReqQFullDrop systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPReqQFullDrop untyped
+mongodb_sys_netstat_TcpExt_TCPReqQFullDrop{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPRetransFail systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPRetransFail untyped
+mongodb_sys_netstat_TcpExt_TCPRetransFail{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPSACKDiscard systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPSACKDiscard untyped
+mongodb_sys_netstat_TcpExt_TCPSACKDiscard{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPSACKReneging systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPSACKReneging untyped
+mongodb_sys_netstat_TcpExt_TCPSACKReneging{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPSACKReorder systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPSACKReorder untyped
+mongodb_sys_netstat_TcpExt_TCPSACKReorder{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPSYNChallenge systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPSYNChallenge untyped
+mongodb_sys_netstat_TcpExt_TCPSYNChallenge{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPSackFailures systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPSackFailures untyped
+mongodb_sys_netstat_TcpExt_TCPSackFailures{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPSackMerged systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPSackMerged untyped
+mongodb_sys_netstat_TcpExt_TCPSackMerged{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPSackRecovery systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPSackRecovery untyped
+mongodb_sys_netstat_TcpExt_TCPSackRecovery{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPSackRecoveryFail systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPSackRecoveryFail untyped
+mongodb_sys_netstat_TcpExt_TCPSackRecoveryFail{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPSackShiftFallback systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPSackShiftFallback untyped
+mongodb_sys_netstat_TcpExt_TCPSackShiftFallback{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPSackShifted systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPSackShifted untyped
+mongodb_sys_netstat_TcpExt_TCPSackShifted{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPSchedulerFailed systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPSchedulerFailed untyped
+mongodb_sys_netstat_TcpExt_TCPSchedulerFailed{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPSlowStartRetrans systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPSlowStartRetrans untyped
+mongodb_sys_netstat_TcpExt_TCPSlowStartRetrans{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPSpuriousRTOs systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPSpuriousRTOs untyped
+mongodb_sys_netstat_TcpExt_TCPSpuriousRTOs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPSpuriousRtxHostQueues systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPSpuriousRtxHostQueues untyped
+mongodb_sys_netstat_TcpExt_TCPSpuriousRtxHostQueues{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPSynRetrans systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPSynRetrans untyped
+mongodb_sys_netstat_TcpExt_TCPSynRetrans{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPTSReorder systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPTSReorder untyped
+mongodb_sys_netstat_TcpExt_TCPTSReorder{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPTimeWaitOverflow systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPTimeWaitOverflow untyped
+mongodb_sys_netstat_TcpExt_TCPTimeWaitOverflow{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPTimeouts systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPTimeouts untyped
+mongodb_sys_netstat_TcpExt_TCPTimeouts{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPToZeroWindowAdv systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPToZeroWindowAdv untyped
+mongodb_sys_netstat_TcpExt_TCPToZeroWindowAdv{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TCPWantZeroWindowAdv systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TCPWantZeroWindowAdv untyped
+mongodb_sys_netstat_TcpExt_TCPWantZeroWindowAdv{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TW systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TW untyped
+mongodb_sys_netstat_TcpExt_TW{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1662
+# HELP mongodb_sys_netstat_TcpExt_TWKilled systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TWKilled untyped
+mongodb_sys_netstat_TcpExt_TWKilled{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_TcpExt_TWRecycled systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_TcpExt_TWRecycled untyped
+mongodb_sys_netstat_TcpExt_TWRecycled{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_Tcp_ActiveOpens systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_Tcp_ActiveOpens untyped
+mongodb_sys_netstat_Tcp_ActiveOpens{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 3509
+# HELP mongodb_sys_netstat_Tcp_AttemptFails systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_Tcp_AttemptFails untyped
+mongodb_sys_netstat_Tcp_AttemptFails{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1702
+# HELP mongodb_sys_netstat_Tcp_CurrEstab systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_Tcp_CurrEstab untyped
+mongodb_sys_netstat_Tcp_CurrEstab{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 5
+# HELP mongodb_sys_netstat_Tcp_EstabResets systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_Tcp_EstabResets untyped
+mongodb_sys_netstat_Tcp_EstabResets{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 558
+# HELP mongodb_sys_netstat_Tcp_InCsumErrors systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_Tcp_InCsumErrors untyped
+mongodb_sys_netstat_Tcp_InCsumErrors{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_Tcp_InErrs systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_Tcp_InErrs untyped
+mongodb_sys_netstat_Tcp_InErrs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_sys_netstat_Tcp_InSegs systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_Tcp_InSegs untyped
+mongodb_sys_netstat_Tcp_InSegs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 61572
+# HELP mongodb_sys_netstat_Tcp_OutRsts systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_Tcp_OutRsts untyped
+mongodb_sys_netstat_Tcp_OutRsts{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1712
+# HELP mongodb_sys_netstat_Tcp_OutSegs systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_Tcp_OutSegs untyped
+mongodb_sys_netstat_Tcp_OutSegs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 71459
+# HELP mongodb_sys_netstat_Tcp_PassiveOpens systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_Tcp_PassiveOpens untyped
+mongodb_sys_netstat_Tcp_PassiveOpens{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 2356
+# HELP mongodb_sys_netstat_Tcp_RetransSegs systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_Tcp_RetransSegs untyped
+mongodb_sys_netstat_Tcp_RetransSegs{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_sys_netstat_Tcp_RtoAlgorithm systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_Tcp_RtoAlgorithm untyped
+mongodb_sys_netstat_Tcp_RtoAlgorithm{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1
+# HELP mongodb_sys_netstat_Tcp_RtoMax systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_Tcp_RtoMax untyped
+mongodb_sys_netstat_Tcp_RtoMax{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 120000
+# HELP mongodb_sys_netstat_Tcp_RtoMin systemMetrics.netstat.
+# TYPE mongodb_sys_netstat_Tcp_RtoMin untyped
+mongodb_sys_netstat_Tcp_RtoMin{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 200
+# HELP mongodb_sys_start systemMetrics.
+# TYPE mongodb_sys_start untyped
+mongodb_sys_start{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 1.666193406001e+12
+# HELP mongodb_term term
+# TYPE mongodb_term untyped
+mongodb_term{cl_id="6350129adfb0b7e3db4773bb",cl_role="",rs_nm="rs0",rs_state="1"} 3
+# HELP mongodb_top_commands_count top.commands.
+# TYPE mongodb_top_commands_count counter
+mongodb_top_commands_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="oplog.rs",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_commands_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.election",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_commands_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.minvalid",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_commands_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.oplogTruncateAfterPoint",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_commands_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="startup_log",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_commands_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.keys",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_commands_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.replset",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_commands_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.roles",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_commands_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.rollback.id",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_commands_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.sessions",database="config",rs_nm="rs0",rs_state="1"} 9
+mongodb_top_commands_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.users",database="admin",rs_nm="rs0",rs_state="1"} 1358
+mongodb_top_commands_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.version",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_commands_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="transactions",database="config",rs_nm="rs0",rs_state="1"} 1
+mongodb_top_commands_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="version",database="config",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_top_commands_time top.commands.
+# TYPE mongodb_top_commands_time untyped
+mongodb_top_commands_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="oplog.rs",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_commands_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.election",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_commands_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.minvalid",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_commands_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.oplogTruncateAfterPoint",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_commands_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="startup_log",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_commands_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.keys",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_commands_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.replset",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_commands_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.roles",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_commands_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.rollback.id",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_commands_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.sessions",database="config",rs_nm="rs0",rs_state="1"} 1076
+mongodb_top_commands_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.users",database="admin",rs_nm="rs0",rs_state="1"} 713044
+mongodb_top_commands_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.version",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_commands_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="transactions",database="config",rs_nm="rs0",rs_state="1"} 16
+mongodb_top_commands_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="version",database="config",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_top_getmore_count top.getmore.
+# TYPE mongodb_top_getmore_count counter
+mongodb_top_getmore_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="oplog.rs",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_getmore_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.election",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_getmore_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.minvalid",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_getmore_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.oplogTruncateAfterPoint",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_getmore_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="startup_log",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_getmore_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.keys",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_getmore_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.replset",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_getmore_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.roles",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_getmore_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.rollback.id",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_getmore_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.sessions",database="config",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_getmore_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.users",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_getmore_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.version",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_getmore_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="transactions",database="config",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_getmore_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="version",database="config",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_top_getmore_time top.getmore.
+# TYPE mongodb_top_getmore_time untyped
+mongodb_top_getmore_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="oplog.rs",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_getmore_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.election",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_getmore_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.minvalid",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_getmore_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.oplogTruncateAfterPoint",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_getmore_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="startup_log",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_getmore_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.keys",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_getmore_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.replset",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_getmore_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.roles",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_getmore_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.rollback.id",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_getmore_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.sessions",database="config",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_getmore_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.users",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_getmore_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.version",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_getmore_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="transactions",database="config",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_getmore_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="version",database="config",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_top_insert_count top.insert.
+# TYPE mongodb_top_insert_count counter
+mongodb_top_insert_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="oplog.rs",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_insert_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.election",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_insert_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.minvalid",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_insert_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.oplogTruncateAfterPoint",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_insert_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="startup_log",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_insert_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.keys",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_insert_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.replset",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_insert_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.roles",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_insert_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.rollback.id",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_insert_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.sessions",database="config",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_insert_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.users",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_insert_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.version",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_insert_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="transactions",database="config",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_insert_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="version",database="config",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_top_insert_time top.insert.
+# TYPE mongodb_top_insert_time untyped
+mongodb_top_insert_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="oplog.rs",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_insert_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.election",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_insert_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.minvalid",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_insert_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.oplogTruncateAfterPoint",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_insert_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="startup_log",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_insert_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.keys",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_insert_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.replset",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_insert_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.roles",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_insert_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.rollback.id",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_insert_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.sessions",database="config",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_insert_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.users",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_insert_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.version",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_insert_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="transactions",database="config",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_insert_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="version",database="config",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_top_queries_count top.queries.
+# TYPE mongodb_top_queries_count counter
+mongodb_top_queries_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="oplog.rs",database="local",rs_nm="rs0",rs_state="1"} 1084
+mongodb_top_queries_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.election",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_queries_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.minvalid",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_queries_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.oplogTruncateAfterPoint",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_queries_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="startup_log",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_queries_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.keys",database="admin",rs_nm="rs0",rs_state="1"} 3
+mongodb_top_queries_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.replset",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_queries_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.roles",database="admin",rs_nm="rs0",rs_state="1"} 1
+mongodb_top_queries_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.rollback.id",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_queries_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.sessions",database="config",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_queries_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.users",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_queries_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.version",database="admin",rs_nm="rs0",rs_state="1"} 544
+mongodb_top_queries_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="transactions",database="config",rs_nm="rs0",rs_state="1"} 4
+mongodb_top_queries_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="version",database="config",rs_nm="rs0",rs_state="1"} 544
+# HELP mongodb_top_queries_time top.queries.
+# TYPE mongodb_top_queries_time untyped
+mongodb_top_queries_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="oplog.rs",database="local",rs_nm="rs0",rs_state="1"} 107381
+mongodb_top_queries_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.election",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_queries_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.minvalid",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_queries_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.oplogTruncateAfterPoint",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_queries_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="startup_log",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_queries_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.keys",database="admin",rs_nm="rs0",rs_state="1"} 1392
+mongodb_top_queries_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.replset",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_queries_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.roles",database="admin",rs_nm="rs0",rs_state="1"} 73
+mongodb_top_queries_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.rollback.id",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_queries_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.sessions",database="config",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_queries_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.users",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_queries_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.version",database="admin",rs_nm="rs0",rs_state="1"} 38088
+mongodb_top_queries_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="transactions",database="config",rs_nm="rs0",rs_state="1"} 1288
+mongodb_top_queries_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="version",database="config",rs_nm="rs0",rs_state="1"} 25545
+# HELP mongodb_top_readLock_count top.readLock.
+# TYPE mongodb_top_readLock_count counter
+mongodb_top_readLock_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="oplog.rs",database="local",rs_nm="rs0",rs_state="1"} 5114
+mongodb_top_readLock_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.election",database="local",rs_nm="rs0",rs_state="1"} 3
+mongodb_top_readLock_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.minvalid",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_readLock_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.oplogTruncateAfterPoint",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_readLock_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="startup_log",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_readLock_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.keys",database="admin",rs_nm="rs0",rs_state="1"} 3
+mongodb_top_readLock_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.replset",database="local",rs_nm="rs0",rs_state="1"} 2
+mongodb_top_readLock_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.roles",database="admin",rs_nm="rs0",rs_state="1"} 1
+mongodb_top_readLock_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.rollback.id",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_readLock_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.sessions",database="config",rs_nm="rs0",rs_state="1"} 9
+mongodb_top_readLock_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.users",database="admin",rs_nm="rs0",rs_state="1"} 1358
+mongodb_top_readLock_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.version",database="admin",rs_nm="rs0",rs_state="1"} 545
+mongodb_top_readLock_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="transactions",database="config",rs_nm="rs0",rs_state="1"} 4
+mongodb_top_readLock_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="version",database="config",rs_nm="rs0",rs_state="1"} 544
+# HELP mongodb_top_readLock_time top.readLock.
+# TYPE mongodb_top_readLock_time untyped
+mongodb_top_readLock_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="oplog.rs",database="local",rs_nm="rs0",rs_state="1"} 2.474605e+06
+mongodb_top_readLock_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.election",database="local",rs_nm="rs0",rs_state="1"} 12060
+mongodb_top_readLock_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.minvalid",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_readLock_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.oplogTruncateAfterPoint",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_readLock_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="startup_log",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_readLock_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.keys",database="admin",rs_nm="rs0",rs_state="1"} 1392
+mongodb_top_readLock_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.replset",database="local",rs_nm="rs0",rs_state="1"} 6959
+mongodb_top_readLock_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.roles",database="admin",rs_nm="rs0",rs_state="1"} 73
+mongodb_top_readLock_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.rollback.id",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_readLock_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.sessions",database="config",rs_nm="rs0",rs_state="1"} 1076
+mongodb_top_readLock_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.users",database="admin",rs_nm="rs0",rs_state="1"} 713044
+mongodb_top_readLock_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.version",database="admin",rs_nm="rs0",rs_state="1"} 38483
+mongodb_top_readLock_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="transactions",database="config",rs_nm="rs0",rs_state="1"} 1288
+mongodb_top_readLock_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="version",database="config",rs_nm="rs0",rs_state="1"} 25545
+# HELP mongodb_top_remove_count top.remove.
+# TYPE mongodb_top_remove_count counter
+mongodb_top_remove_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="oplog.rs",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_remove_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.election",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_remove_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.minvalid",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_remove_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.oplogTruncateAfterPoint",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_remove_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="startup_log",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_remove_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.keys",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_remove_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.replset",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_remove_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.roles",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_remove_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.rollback.id",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_remove_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.sessions",database="config",rs_nm="rs0",rs_state="1"} 1
+mongodb_top_remove_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.users",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_remove_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.version",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_remove_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="transactions",database="config",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_remove_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="version",database="config",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_top_remove_time top.remove.
+# TYPE mongodb_top_remove_time untyped
+mongodb_top_remove_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="oplog.rs",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_remove_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.election",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_remove_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.minvalid",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_remove_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.oplogTruncateAfterPoint",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_remove_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="startup_log",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_remove_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.keys",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_remove_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.replset",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_remove_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.roles",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_remove_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.rollback.id",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_remove_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.sessions",database="config",rs_nm="rs0",rs_state="1"} 51
+mongodb_top_remove_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.users",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_remove_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.version",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_remove_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="transactions",database="config",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_remove_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="version",database="config",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_top_total_count top.total.
+# TYPE mongodb_top_total_count counter
+mongodb_top_total_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="oplog.rs",database="local",rs_nm="rs0",rs_state="1"} 5115
+mongodb_top_total_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.election",database="local",rs_nm="rs0",rs_state="1"} 5
+mongodb_top_total_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.minvalid",database="local",rs_nm="rs0",rs_state="1"} 1
+mongodb_top_total_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.oplogTruncateAfterPoint",database="local",rs_nm="rs0",rs_state="1"} 1
+mongodb_top_total_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="startup_log",database="local",rs_nm="rs0",rs_state="1"} 1
+mongodb_top_total_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.keys",database="admin",rs_nm="rs0",rs_state="1"} 4
+mongodb_top_total_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.replset",database="local",rs_nm="rs0",rs_state="1"} 3
+mongodb_top_total_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.roles",database="admin",rs_nm="rs0",rs_state="1"} 1
+mongodb_top_total_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.rollback.id",database="local",rs_nm="rs0",rs_state="1"} 1
+mongodb_top_total_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.sessions",database="config",rs_nm="rs0",rs_state="1"} 492
+mongodb_top_total_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.users",database="admin",rs_nm="rs0",rs_state="1"} 1359
+mongodb_top_total_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.version",database="admin",rs_nm="rs0",rs_state="1"} 546
+mongodb_top_total_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="transactions",database="config",rs_nm="rs0",rs_state="1"} 6
+mongodb_top_total_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="version",database="config",rs_nm="rs0",rs_state="1"} 544
+# HELP mongodb_top_total_time top.total.
+# TYPE mongodb_top_total_time untyped
+mongodb_top_total_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="oplog.rs",database="local",rs_nm="rs0",rs_state="1"} 2.47461e+06
+mongodb_top_total_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.election",database="local",rs_nm="rs0",rs_state="1"} 12211
+mongodb_top_total_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.minvalid",database="local",rs_nm="rs0",rs_state="1"} 1
+mongodb_top_total_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.oplogTruncateAfterPoint",database="local",rs_nm="rs0",rs_state="1"} 1
+mongodb_top_total_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="startup_log",database="local",rs_nm="rs0",rs_state="1"} 1
+mongodb_top_total_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.keys",database="admin",rs_nm="rs0",rs_state="1"} 1415
+mongodb_top_total_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.replset",database="local",rs_nm="rs0",rs_state="1"} 6959
+mongodb_top_total_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.roles",database="admin",rs_nm="rs0",rs_state="1"} 73
+mongodb_top_total_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.rollback.id",database="local",rs_nm="rs0",rs_state="1"} 1
+mongodb_top_total_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.sessions",database="config",rs_nm="rs0",rs_state="1"} 18494
+mongodb_top_total_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.users",database="admin",rs_nm="rs0",rs_state="1"} 713046
+mongodb_top_total_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.version",database="admin",rs_nm="rs0",rs_state="1"} 38485
+mongodb_top_total_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="transactions",database="config",rs_nm="rs0",rs_state="1"} 1306
+mongodb_top_total_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="version",database="config",rs_nm="rs0",rs_state="1"} 25545
+# HELP mongodb_top_update_count top.update.
+# TYPE mongodb_top_update_count counter
+mongodb_top_update_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="oplog.rs",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_update_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.election",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_update_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.minvalid",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_update_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.oplogTruncateAfterPoint",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_update_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="startup_log",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_update_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.keys",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_update_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.replset",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_update_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.roles",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_update_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.rollback.id",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_update_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.sessions",database="config",rs_nm="rs0",rs_state="1"} 481
+mongodb_top_update_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.users",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_update_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.version",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_update_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="transactions",database="config",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_update_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="version",database="config",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_top_update_time top.update.
+# TYPE mongodb_top_update_time untyped
+mongodb_top_update_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="oplog.rs",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_update_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.election",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_update_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.minvalid",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_update_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.oplogTruncateAfterPoint",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_update_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="startup_log",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_update_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.keys",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_update_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.replset",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_update_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.roles",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_update_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.rollback.id",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_update_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.sessions",database="config",rs_nm="rs0",rs_state="1"} 17365
+mongodb_top_update_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.users",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_update_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.version",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_update_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="transactions",database="config",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_update_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="version",database="config",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_top_writeLock_count top.writeLock.
+# TYPE mongodb_top_writeLock_count counter
+mongodb_top_writeLock_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="oplog.rs",database="local",rs_nm="rs0",rs_state="1"} 1
+mongodb_top_writeLock_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.election",database="local",rs_nm="rs0",rs_state="1"} 2
+mongodb_top_writeLock_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.minvalid",database="local",rs_nm="rs0",rs_state="1"} 1
+mongodb_top_writeLock_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.oplogTruncateAfterPoint",database="local",rs_nm="rs0",rs_state="1"} 1
+mongodb_top_writeLock_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="startup_log",database="local",rs_nm="rs0",rs_state="1"} 1
+mongodb_top_writeLock_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.keys",database="admin",rs_nm="rs0",rs_state="1"} 1
+mongodb_top_writeLock_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.replset",database="local",rs_nm="rs0",rs_state="1"} 1
+mongodb_top_writeLock_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.roles",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_writeLock_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.rollback.id",database="local",rs_nm="rs0",rs_state="1"} 1
+mongodb_top_writeLock_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.sessions",database="config",rs_nm="rs0",rs_state="1"} 483
+mongodb_top_writeLock_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.users",database="admin",rs_nm="rs0",rs_state="1"} 1
+mongodb_top_writeLock_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.version",database="admin",rs_nm="rs0",rs_state="1"} 1
+mongodb_top_writeLock_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="transactions",database="config",rs_nm="rs0",rs_state="1"} 2
+mongodb_top_writeLock_count{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="version",database="config",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_top_writeLock_time top.writeLock.
+# TYPE mongodb_top_writeLock_time untyped
+mongodb_top_writeLock_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="oplog.rs",database="local",rs_nm="rs0",rs_state="1"} 5
+mongodb_top_writeLock_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.election",database="local",rs_nm="rs0",rs_state="1"} 151
+mongodb_top_writeLock_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.minvalid",database="local",rs_nm="rs0",rs_state="1"} 1
+mongodb_top_writeLock_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="replset.oplogTruncateAfterPoint",database="local",rs_nm="rs0",rs_state="1"} 1
+mongodb_top_writeLock_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="startup_log",database="local",rs_nm="rs0",rs_state="1"} 1
+mongodb_top_writeLock_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.keys",database="admin",rs_nm="rs0",rs_state="1"} 23
+mongodb_top_writeLock_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.replset",database="local",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_writeLock_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.roles",database="admin",rs_nm="rs0",rs_state="1"} 0
+mongodb_top_writeLock_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.rollback.id",database="local",rs_nm="rs0",rs_state="1"} 1
+mongodb_top_writeLock_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.sessions",database="config",rs_nm="rs0",rs_state="1"} 17418
+mongodb_top_writeLock_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.users",database="admin",rs_nm="rs0",rs_state="1"} 2
+mongodb_top_writeLock_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="system.version",database="admin",rs_nm="rs0",rs_state="1"} 2
+mongodb_top_writeLock_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="transactions",database="config",rs_nm="rs0",rs_state="1"} 18
+mongodb_top_writeLock_time{cl_id="6350129adfb0b7e3db4773bb",cl_role="",collection="version",database="config",rs_nm="rs0",rs_state="1"} 0
+# HELP mongodb_up Whether MongoDB is up.
+# TYPE mongodb_up gauge
+mongodb_up 1
+# HELP mongodb_version_info The server version
+# TYPE mongodb_version_info gauge
+mongodb_version_info{mongodb="4.0.14"} 1
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 92.59
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 1024
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 15
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 2.7725824e+07
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.66619202701e+09
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 7.38951168e+08
+# HELP process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
+# TYPE process_virtual_memory_max_bytes gauge
+process_virtual_memory_max_bytes 1.8446744073709552e+19

--- a/solution-base/deps.yaml
+++ b/solution-base/deps.yaml
@@ -6,13 +6,13 @@ mongodb:
   tag: 4.0.14-debian-9-r24
 mongodb-exporter:
   image: bitnami/mongodb-exporter
-  tag: 0.11.2-debian-10-r410
+  tag: 0.34.0-debian-11-r24
 mongodb-sharded:
   image: bitnami/mongodb-sharded
   tag: 4.0.27-debian-9-r111
 mongodb-sharded-exporter:
   image: bitnami/mongodb-exporter
-  tag: 0.11.2-debian-10-r382
+  tag: 0.34.0-debian-11-r24
 mongodb-shell:
   image: bitnami/bitnami-shell
   tag: 11-debian-11-r42

--- a/solution-base/mongodb/charts/mongodb-sharded/values.yaml
+++ b/solution-base/mongodb/charts/mongodb-sharded/values.yaml
@@ -1132,7 +1132,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mongodb-exporter
-    tag: 0.11.2-debian-10-r382
+    tag: 0.34.0-debian-11-r24
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -1145,7 +1145,9 @@ metrics:
   ## @param metrics.extraArgs String with extra arguments to the metrics exporter
   ## ref: https://github.com/dcu/mongodb_exporter/blob/master/mongodb_exporter.go
   ##
-  extraArgs: ""
+  ## We use "--compatible-mode" flag to export old metric: "mongodb_mongod_replset_oplog_head_timestamp"
+  ## for mongoDB and backbeat dashboards.
+  extraArgs: "--collector.diagnosticdata --collector.replicasetstatus --collector.dbstats --collector.topmetrics --compatible-mode"
   ## @param metrics.resources Metrics exporter resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
   ##

--- a/solution-base/mongodb/charts/mongodb/custom-values.yaml
+++ b/solution-base/mongodb/charts/mongodb/custom-values.yaml
@@ -441,7 +441,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mongodb-exporter
-    tag: 0.10.0-debian-9-r104
+    tag: 0.34.0-debian-11-r24
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -452,7 +452,10 @@ metrics:
 
   ## String with extra arguments to the metrics exporter
   ## ref: https://github.com/percona/mongodb_exporter/blob/master/mongodb_exporter.go
-  extraArgs: ""
+  ##
+  ## We use "--compatible-mode" flag to export old metric: "mongodb_mongod_replset_oplog_head_timestamp"
+  ## for mongoDB and backbeat dashboards.
+  extraArgs: "--collector.diagnosticdata --collector.replicasetstatus --collector.dbstats --collector.topmetrics --compatible-mode"
 
   ## Metrics exporter resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/solution-base/mongodb/charts/mongodb/values-production.yaml
+++ b/solution-base/mongodb/charts/mongodb/values-production.yaml
@@ -437,7 +437,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mongodb-exporter
-    tag: 0.10.0-debian-9-r104
+    tag: 0.34.0-debian-11-r24
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -448,7 +448,10 @@ metrics:
 
   ## String with extra arguments to the metrics exporter
   ## ref: https://github.com/percona/mongodb_exporter/blob/master/mongodb_exporter.go
-  extraArgs: ""
+  ##
+  ## We use "--compatible-mode" flag to export old metric: "mongodb_mongod_replset_oplog_head_timestamp"
+  ## for mongoDB and backbeat dashboards.
+  extraArgs: "--collector.diagnosticdata --collector.replicasetstatus --collector.dbstats --collector.topmetrics --compatible-mode"
 
   ## Metrics exporter resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/solution-base/mongodb/charts/mongodb/values.yaml
+++ b/solution-base/mongodb/charts/mongodb/values.yaml
@@ -439,7 +439,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mongodb-exporter
-    tag: 0.10.0-debian-9-r104
+    tag: 0.34.0-debian-11-r24
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -447,10 +447,12 @@ metrics:
     ##
     # pullSecrets:
     #   - myRegistryKeySecretName
-
   ## String with extra arguments to the metrics exporter
   ## ref: https://github.com/percona/mongodb_exporter/blob/master/mongodb_exporter.go
-  extraArgs: ""
+  ##
+  ## We use "--compatible-mode" flag to export old metric: "mongodb_mongod_replset_oplog_head_timestamp"
+  ## for mongoDB and backbeat dashboards.
+  extraArgs: "--collector.diagnosticdata --collector.replicasetstatus --collector.dbstats --collector.topmetrics --compatible-mode"
 
   ## Metrics exporter resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
We use "--compatible-mode" flag to export old metric: "mongodb_mongod_replset_oplog_head_timestamp" for mongoDB and backbeat dashboards.


**Note**: The backbeat dashboard seems to only use the `mongodb_mongod_replset_oplog_head_timestamp` metric accessible thanks to the compatible mode.