### PR TITLE
bugfix: ZENKO-4387 bump python in e2e image

### DIFF
--- a/tests/zenko_tests/Dockerfile
+++ b/tests/zenko_tests/Dockerfile
@@ -29,6 +29,9 @@ RUN apt-get update && apt-get install -y \
     libssl1.0-dev && \
     mkdir -p /usr/local/bin/tests/node_tests
 
+RUN apt-get install -y python3.7
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 2
+
 COPY ./node_tests/package.json ./node_tests/package-lock.json /usr/local/bin/tests/node_tests/
 COPY ./requirements.txt /tmp
 


### PR DESCRIPTION
Issue: [ZENKO-4387](https://scality.atlassian.net/browse/ZENKO-4387)

Fix E2E configuration failing with the following error:
```
Traceback (most recent call last):
  File "configuration.py", line 10, in <module>
    from bravado.client import SwaggerClient
  File "/usr/local/lib/python3.6/dist-packages/bravado/client.py", line 53, in <module>
    from bravado_core.param import marshal_param
  File "/usr/local/lib/python3.6/dist-packages/bravado_core/param.py", line 13, in <module>
    from bravado_core.marshal import marshal_schema_object
  File "/usr/local/lib/python3.6/dist-packages/bravado_core/marshal.py", line 11, in <module>
    from bravado_core.model import Model
  File "/usr/local/lib/python3.6/dist-packages/bravado_core/model.py", line 13, in <module>
    from swagger_spec_validator.ref_validators import attach_scope
  File "/usr/local/lib/python3.6/dist-packages/swagger_spec_validator/__init__.py", line 1, in <module>
    from swagger_spec_validator.common import SwaggerValidationError
  File "/usr/local/lib/python3.6/dist-packages/swagger_spec_validator/common.py", line 1
    from __future__ import annotations
    ^
SyntaxError: future feature annotations is not defined
```