### PR TITLE
zenko-base: Upgrade PodDisruptionBudget to stable API

### DIFF
--- a/solution-base/mongodb/charts/mongodb-sharded/templates/config-server/config-server-poddisruptionbudget.yaml
+++ b/solution-base/mongodb/charts/mongodb-sharded/templates/config-server/config-server-poddisruptionbudget.yaml
@@ -1,6 +1,6 @@
 {{- if and (not .Values.configsvr.external.host) .Values.configsvr.pdb.enabled -}}
 kind: PodDisruptionBudget
-apiVersion: policy/v1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" $ }}
 metadata:
   name: {{ include "common.names.fullname" . }}-configsvr
   labels: {{- include "common.labels.standard" . | nindent 4 }}

--- a/solution-base/mongodb/charts/mongodb-sharded/templates/config-server/config-server-poddisruptionbudget.yaml
+++ b/solution-base/mongodb/charts/mongodb-sharded/templates/config-server/config-server-poddisruptionbudget.yaml
@@ -1,6 +1,6 @@
 {{- if and (not .Values.configsvr.external.host) .Values.configsvr.pdb.enabled -}}
 kind: PodDisruptionBudget
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 metadata:
   name: {{ include "common.names.fullname" . }}-configsvr
   labels: {{- include "common.labels.standard" . | nindent 4 }}

--- a/solution-base/mongodb/charts/mongodb-sharded/templates/mongos/mongos-poddisruptionbudget.yaml
+++ b/solution-base/mongodb/charts/mongodb-sharded/templates/mongos/mongos-poddisruptionbudget.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.mongos.pdb.enabled -}}
 kind: PodDisruptionBudget
-apiVersion: policy/v1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" $ }}
 metadata:
   name: {{ include "common.names.fullname" . }}-mongos
   labels: {{- include "common.labels.standard" . | nindent 4 }}

--- a/solution-base/mongodb/charts/mongodb-sharded/templates/mongos/mongos-poddisruptionbudget.yaml
+++ b/solution-base/mongodb/charts/mongodb-sharded/templates/mongos/mongos-poddisruptionbudget.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.mongos.pdb.enabled -}}
 kind: PodDisruptionBudget
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 metadata:
   name: {{ include "common.names.fullname" . }}-mongos
   labels: {{- include "common.labels.standard" . | nindent 4 }}

--- a/solution-base/mongodb/charts/mongodb-sharded/templates/shard/shard-data-poddisruptionbudget.yaml
+++ b/solution-base/mongodb/charts/mongodb-sharded/templates/shard/shard-data-poddisruptionbudget.yaml
@@ -2,7 +2,7 @@
 {{- $replicas := .Values.shards | int -}}
 {{- range $i, $e := until $replicas -}}
 kind: PodDisruptionBudget
-apiVersion: policy/v1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" $ }}
 metadata:
   name: {{ printf "%s-shard%d-data" (include "common.names.fullname" $ ) $i }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}

--- a/solution-base/mongodb/charts/mongodb-sharded/templates/shard/shard-data-poddisruptionbudget.yaml
+++ b/solution-base/mongodb/charts/mongodb-sharded/templates/shard/shard-data-poddisruptionbudget.yaml
@@ -2,7 +2,7 @@
 {{- $replicas := .Values.shards | int -}}
 {{- range $i, $e := until $replicas -}}
 kind: PodDisruptionBudget
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 metadata:
   name: {{ printf "%s-shard%d-data" (include "common.names.fullname" $ ) $i }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}

--- a/solution-base/mongodb/charts/mongodb/templates/poddisruptionbudget-arbiter-rs.yaml
+++ b/solution-base/mongodb/charts/mongodb/templates/poddisruptionbudget-arbiter-rs.yaml
@@ -1,5 +1,5 @@
 {{- if and (and .Values.replicaSet.enabled .Values.replicaSet.pdb.enabled) (gt .Values.replicaSet.replicas.arbiter 0) }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:

--- a/solution-base/mongodb/charts/mongodb/templates/poddisruptionbudget-secondary-rs.yaml
+++ b/solution-base/mongodb/charts/mongodb/templates/poddisruptionbudget-secondary-rs.yaml
@@ -1,5 +1,5 @@
 {{- if and (and .Values.replicaSet.enabled .Values.replicaSet.pdb.enabled) (gt .Values.replicaSet.replicas.secondary 0) }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:

--- a/solution-base/mongodb/patches/fix-poddisruptionbudget-api.patch
+++ b/solution-base/mongodb/patches/fix-poddisruptionbudget-api.patch
@@ -1,37 +1,37 @@
 diff --git a/solution-base/mongodb/charts/mongodb-sharded/templates/config-server/config-server-poddisruptionbudget.yaml b/solution-base/mongodb/charts/mongodb-sharded/templates/config-server/config-server-poddisruptionbudget.yaml
-index 9f1492f5..e5ca7a54 100644
+index 9f1492f5..7665fd10 100644
 --- a/solution-base/mongodb/charts/mongodb-sharded/templates/config-server/config-server-poddisruptionbudget.yaml
 +++ b/solution-base/mongodb/charts/mongodb-sharded/templates/config-server/config-server-poddisruptionbudget.yaml
 @@ -1,6 +1,6 @@
  {{- if and (not .Values.configsvr.external.host) .Values.configsvr.pdb.enabled -}}
  kind: PodDisruptionBudget
--apiVersion: policy/v1beta1
-+apiVersion: policy/v1
+-apiVersion: policy/v1
++apiVersion: {{ include "common.capabilities.policy.apiVersion" $ }}
  metadata:
    name: {{ include "common.names.fullname" . }}-configsvr
    labels: {{- include "common.labels.standard" . | nindent 4 }}
 diff --git a/solution-base/mongodb/charts/mongodb-sharded/templates/mongos/mongos-poddisruptionbudget.yaml b/solution-base/mongodb/charts/mongodb-sharded/templates/mongos/mongos-poddisruptionbudget.yaml
-index 6a0bfc86..925753ed 100644
+index 6a0bfc86..8c6e8d93 100644
 --- a/solution-base/mongodb/charts/mongodb-sharded/templates/mongos/mongos-poddisruptionbudget.yaml
 +++ b/solution-base/mongodb/charts/mongodb-sharded/templates/mongos/mongos-poddisruptionbudget.yaml
 @@ -1,6 +1,6 @@
  {{- if .Values.mongos.pdb.enabled -}}
  kind: PodDisruptionBudget
--apiVersion: policy/v1beta1
-+apiVersion: policy/v1
+-apiVersion: policy/v1
++apiVersion: {{ include "common.capabilities.policy.apiVersion" $ }}
  metadata:
    name: {{ include "common.names.fullname" . }}-mongos
    labels: {{- include "common.labels.standard" . | nindent 4 }}
 diff --git a/solution-base/mongodb/charts/mongodb-sharded/templates/shard/shard-data-poddisruptionbudget.yaml b/solution-base/mongodb/charts/mongodb-sharded/templates/shard/shard-data-poddisruptionbudget.yaml
-index 43cd645b..a6793779 100644
+index 43cd645b..46ac9e25 100644
 --- a/solution-base/mongodb/charts/mongodb-sharded/templates/shard/shard-data-poddisruptionbudget.yaml
 +++ b/solution-base/mongodb/charts/mongodb-sharded/templates/shard/shard-data-poddisruptionbudget.yaml
 @@ -2,7 +2,7 @@
  {{- $replicas := .Values.shards | int -}}
  {{- range $i, $e := until $replicas -}}
  kind: PodDisruptionBudget
--apiVersion: policy/v1beta1
-+apiVersion: policy/v1
+-apiVersion: policy/v1
++apiVersion: {{ include "common.capabilities.policy.apiVersion" $ }}
  metadata:
    name: {{ printf "%s-shard%d-data" (include "common.names.fullname" $ ) $i }}
    labels: {{- include "common.labels.standard" $ | nindent 4 }}

--- a/solution-base/mongodb/patches/fix-poddisruptionbudget-api.patch
+++ b/solution-base/mongodb/patches/fix-poddisruptionbudget-api.patch
@@ -1,0 +1,59 @@
+diff --git a/solution-base/mongodb/charts/mongodb-sharded/templates/config-server/config-server-poddisruptionbudget.yaml b/solution-base/mongodb/charts/mongodb-sharded/templates/config-server/config-server-poddisruptionbudget.yaml
+index 9f1492f5..e5ca7a54 100644
+--- a/solution-base/mongodb/charts/mongodb-sharded/templates/config-server/config-server-poddisruptionbudget.yaml
++++ b/solution-base/mongodb/charts/mongodb-sharded/templates/config-server/config-server-poddisruptionbudget.yaml
+@@ -1,6 +1,6 @@
+ {{- if and (not .Values.configsvr.external.host) .Values.configsvr.pdb.enabled -}}
+ kind: PodDisruptionBudget
+-apiVersion: policy/v1beta1
++apiVersion: policy/v1
+ metadata:
+   name: {{ include "common.names.fullname" . }}-configsvr
+   labels: {{- include "common.labels.standard" . | nindent 4 }}
+diff --git a/solution-base/mongodb/charts/mongodb-sharded/templates/mongos/mongos-poddisruptionbudget.yaml b/solution-base/mongodb/charts/mongodb-sharded/templates/mongos/mongos-poddisruptionbudget.yaml
+index 6a0bfc86..925753ed 100644
+--- a/solution-base/mongodb/charts/mongodb-sharded/templates/mongos/mongos-poddisruptionbudget.yaml
++++ b/solution-base/mongodb/charts/mongodb-sharded/templates/mongos/mongos-poddisruptionbudget.yaml
+@@ -1,6 +1,6 @@
+ {{- if .Values.mongos.pdb.enabled -}}
+ kind: PodDisruptionBudget
+-apiVersion: policy/v1beta1
++apiVersion: policy/v1
+ metadata:
+   name: {{ include "common.names.fullname" . }}-mongos
+   labels: {{- include "common.labels.standard" . | nindent 4 }}
+diff --git a/solution-base/mongodb/charts/mongodb-sharded/templates/shard/shard-data-poddisruptionbudget.yaml b/solution-base/mongodb/charts/mongodb-sharded/templates/shard/shard-data-poddisruptionbudget.yaml
+index 43cd645b..a6793779 100644
+--- a/solution-base/mongodb/charts/mongodb-sharded/templates/shard/shard-data-poddisruptionbudget.yaml
++++ b/solution-base/mongodb/charts/mongodb-sharded/templates/shard/shard-data-poddisruptionbudget.yaml
+@@ -2,7 +2,7 @@
+ {{- $replicas := .Values.shards | int -}}
+ {{- range $i, $e := until $replicas -}}
+ kind: PodDisruptionBudget
+-apiVersion: policy/v1beta1
++apiVersion: policy/v1
+ metadata:
+   name: {{ printf "%s-shard%d-data" (include "common.names.fullname" $ ) $i }}
+   labels: {{- include "common.labels.standard" $ | nindent 4 }}
+diff --git a/solution-base/mongodb/charts/mongodb/templates/poddisruptionbudget-arbiter-rs.yaml b/solution-base/mongodb/charts/mongodb/templates/poddisruptionbudget-arbiter-rs.yaml
+index d5ad8760..85f0c657 100644
+--- a/solution-base/mongodb/charts/mongodb/templates/poddisruptionbudget-arbiter-rs.yaml
++++ b/solution-base/mongodb/charts/mongodb/templates/poddisruptionbudget-arbiter-rs.yaml
+@@ -1,5 +1,5 @@
+ {{- if and (and .Values.replicaSet.enabled .Values.replicaSet.pdb.enabled) (gt .Values.replicaSet.replicas.arbiter 0) }}
+-apiVersion: policy/v1beta1
++apiVersion: policy/v1
+ kind: PodDisruptionBudget
+ metadata:
+   labels:
+diff --git a/solution-base/mongodb/charts/mongodb/templates/poddisruptionbudget-secondary-rs.yaml b/solution-base/mongodb/charts/mongodb/templates/poddisruptionbudget-secondary-rs.yaml
+index c64efa51..91be500f 100644
+--- a/solution-base/mongodb/charts/mongodb/templates/poddisruptionbudget-secondary-rs.yaml
++++ b/solution-base/mongodb/charts/mongodb/templates/poddisruptionbudget-secondary-rs.yaml
+@@ -1,5 +1,5 @@
+ {{- if and (and .Values.replicaSet.enabled .Values.replicaSet.pdb.enabled) (gt .Values.replicaSet.replicas.secondary 0) }}
+-apiVersion: policy/v1beta1
++apiVersion: policy/v1
+ kind: PodDisruptionBudget
+ metadata:
+   labels:


### PR DESCRIPTION
Migrate from `policy/v1beta1` to `policy/v1`, to support running on k8s
1.25. This changes the minimum supported k8s version to 1.21.

Issue: ZENKO-4496
