### PR TITLE
Improvement/zenko 4484 ctst iam policies for assume role user

### DIFF
--- a/tests/ctst/common/hooks.ts
+++ b/tests/ctst/common/hooks.ts
@@ -26,4 +26,9 @@ Given('a {type} type', async function (type) {
     await this.setupEntity(type);
 });
 
+Given('a {string} AssumeRole user', async function (crossAccount: string) {
+    await this.prepareAssumeRole(crossAccount === 'cross account');
+    this.saved.type = EntityType.ASSUME_ROLE_USER;
+});
+
 export default worlds;

--- a/tests/ctst/features/iam-policies/AssumeRole.feature
+++ b/tests/ctst/features/iam-policies/AssumeRole.feature
@@ -1,0 +1,99 @@
+Feature: IAM Policies for Assume Role Session Users
+  This feature allows you to create and attach IAM policies for IAM users.
+  IAM users should have the permissions to perform the actions that they are granted in their IAM policies.
+
+
+  @2.6.0
+  @PreMerge
+  @IamPoliciesAssumeRole
+  Scenario Outline: Assume Role User is not authorized to perform the actions with no IAM policy attached to the role
+    Given an existing bucket "" "without" versioning, "without" ObjectLock "" retention mode
+    And an object "" that "<objectExists>"
+    And a "<ifCrossAccount>" AssumeRole user
+    When the user tries to perform "<action>" on the bucket
+    Then the user should receive "AccessDenied" error
+
+    Examples:
+      | action         | objectExists   | ifCrossAccount |
+      | MetadataSearch | does not exist |                |
+      | MetadataSearch | does not exist | cross account  |
+      | GetObject      | exists         |                |
+      | GetObject      | exists         | cross account  |
+
+  @2.6.0
+  @PreMerge
+  @IamPoliciesAssumeRole
+  Scenario Outline: Assume Role User is authorized to perform the actions if the IAM policies that attached to the role have the right permission
+    Given an existing bucket "<bucketName>" "without" versioning, "without" ObjectLock "" retention mode
+    And an object "<objectName>" that "<objectExists>"
+    And a "<ifCrossAccount>" AssumeRole user
+    And an IAM policy attached to the entity "role" with "Allow" effect to perform "<action>" on "<resource>"
+    When the user tries to perform "<action>" on the bucket
+    Then the user should be able to perform successfully the "<action>" action
+
+    Examples:
+      | action         | resource                | bucketName    | objectExists   | objectName | ifCrossAccount |
+      | MetadataSearch | *                       |               | does not exist |            |                |
+      | MetadataSearch | *                       |               | does not exist |            | cross account  |
+      | GetObject      | *                       |               | exists         |            |                |
+      | GetObject      | *                       |               | exists         |            | cross account  |
+      | MetadataSearch | ar-md-bucket1           | ar-md-bucket1 | does not exist |            |                |
+      | MetadataSearch | ar-md-bucket2           | ar-md-bucket2 | does not exist |            | cross account  |
+      | GetObject      | ar-go-bucket1/*         | ar-go-bucket1 | exists         |            |                |
+      | GetObject      | ar-go-bucket2/*         | ar-go-bucket2 | exists         |            | cross account  |
+      | GetObject      | ar-go-bucket3/go-object | ar-go-bucket3 | exists         | go-object  |                |
+      | GetObject      | ar-go-bucket4/go-object | ar-go-bucket4 | exists         | go-object  | cross account  |
+
+  @2.6.0
+  @PreMerge
+  @IamPoliciesAssumeRole
+  Scenario Outline: Assume Role User is not authorized to perform the actions on the resource when they don't have permissions for or explicitly denied in the IAM policies that attached the role that the User assumed
+    Given an existing bucket "<bucketName>" "without" versioning, "without" ObjectLock "" retention mode
+    And an object "<objectName>" that "<objectExists>"
+    And a "<ifCrossAccount>" AssumeRole user
+    And an IAM policy attached to the entity "role" with "<effect>" effect to perform "<action>" on "<resource>"
+    When the user tries to perform "<action>" on the bucket
+    Then the user should receive "AccessDenied" error
+
+    Examples:
+      | action         | effect | resource                 | bucketName     | objectExists   | objectName | ifCrossAccount |
+      | MetadataSearch | Allow  | ar-md-bucket3-1          | ar-md-bucket3  | does not exist |            |                |
+      | MetadataSearch | Allow  | ar-md-bucket4-1          | ar-md-bucket4  | does not exist |            | cross account  |
+      | MetadataSearch | Deny   | *                        |                | does not exist |            |                |
+      | MetadataSearch | Deny   | *                        |                | does not exist |            | cross account  |
+      | MetadataSearch | Deny   | ar-md-bucket5            | ar-md-bucket5  | does not exist |            |                |
+      | MetadataSearch | Deny   | ar-md-bucket6            | ar-md-bucket6  | does not exist |            | cross account  |
+      | GetObject      | Allow  | ar-go-bucket5-1/*        | ar-go-bucket5  | exists         |            |                |
+      | GetObject      | Allow  | ar-go-bucket6-1/*        | ar-go-bucket6  | exists         |            | cross account  |
+      | GetObject      | Allow  | ar-go-bucket7/go-object1 | ar-go-bucket7  | exists         | go-object  |                |
+      | GetObject      | Allow  | ar-go-bucket8/go-object1 | ar-go-bucket8  | exists         | go-object  | cross account  |
+      | GetObject      | Deny   | *                        | ar-go-bucket9  | exists         |            |                |
+      | GetObject      | Deny   | *                        | ar-go-bucket10 | exists         |            | cross account  |
+      | GetObject      | Deny   | ar-go-bucket11/*         | ar-go-bucket11 | exists         |            |                |
+      | GetObject      | Deny   | ar-go-bucket12/*         | ar-go-bucket12 | exists         |            | cross account  |
+      | GetObject      | Deny   | ar-go-bucket13/go-object | ar-go-bucket13 | exists         | go-object  |                |
+      | GetObject      | Deny   | ar-go-bucket14/go-object | ar-go-bucket14 | exists         | go-object  | cross account  |
+
+  @2.6.0
+  @PreMerge
+  @IamPoliciesAssumeRole
+  Scenario Outline: Assume Role User is not authorized to perform the actions on the resource if Allow and Denied are both specified in the IAM policies that attached to the role the User assumed
+    Given an existing bucket "<bucketName>" "without" versioning, "without" ObjectLock "" retention mode
+    And an object "<objectName>" that "<objectExists>"
+    And a "<ifCrossAccount>" AssumeRole user
+    And an IAM policy attached to the entity "role" with "Allow" effect to perform "<action>" on "<resource>"
+    And an IAM policy attached to the entity "role" with "Deny" effect to perform "<action>" on "<resource>"
+    When the user tries to perform "<action>" on the bucket
+    Then the user should receive "AccessDenied" error
+    Examples:
+      | action         | resource                 | bucketName     | objectExists   | objectName | ifCrossAccount |
+      | MetadataSearch | *                        | ar-md-bucket7  | does not exist |            |                |
+      | MetadataSearch | *                        | ar-md-bucket8  | does not exist |            | cross account  |
+      | MetadataSearch | ar-md-bucket9            | ar-md-bucket9  | does not exist |            |                |
+      | MetadataSearch | ar-md-bucket10           | ar-md-bucket10 | does not exist |            | cross account  |
+      | GetObject      | *                        | ar-go-bucket15 | exists         |            |                |
+      | GetObject      | *                        | ar-go-bucket16 | exists         |            | cross account  |
+      | GetObject      | ar-go-bucket17/*         | ar-go-bucket17 | exists         |            |                |
+      | GetObject      | ar-go-bucket18/*         | ar-go-bucket18 | exists         |            | cross account  |
+      | GetObject      | ar-go-bucket19/go-object | ar-go-bucket19 | exists         | go-object  |                |
+      | GetObject      | ar-go-bucket20/go-object | ar-go-bucket20 | exists         | go-object  | cross account  |

--- a/tests/ctst/features/iam-policies/IAMUser.feature
+++ b/tests/ctst/features/iam-policies/IAMUser.feature
@@ -24,7 +24,7 @@ Feature: IAM Policies for IAM Users
     Given an existing bucket "<bucketName>" "without" versioning, "without" ObjectLock "" retention mode
     And an object "<objectName>" that "<objectExists>"
     And a IAM_USER type
-    And an IAM policy attached to the user with "Allow" effect to perform "<action>" on "<resource>"
+    And an IAM policy attached to the entity "user" with "Allow" effect to perform "<action>" on "<resource>"
     When the user tries to perform "<action>" on the bucket
     Then the user should be able to perform successfully the "<action>" action
 
@@ -43,7 +43,7 @@ Feature: IAM Policies for IAM Users
     Given an existing bucket "<bucketName>" "without" versioning, "without" ObjectLock "" retention mode
     And an object "<objectName>" that "<objectExists>"
     And a IAM_USER type
-    And an IAM policy attached to the user with "<effect>" effect to perform "<action>" on "<resource>"
+    And an IAM policy attached to the entity "user" with "<effect>" effect to perform "<action>" on "<resource>"
     When the user tries to perform "<action>" on the bucket
     Then the user should receive "AccessDenied" error
 
@@ -65,8 +65,8 @@ Feature: IAM Policies for IAM Users
     Given an existing bucket "<bucketName>" "without" versioning, "without" ObjectLock "" retention mode
     And an object "<objectName>" that "<objectExists>"
     And a IAM_USER type
-    And an IAM policy attached to the user with "Allow" effect to perform "<action>" on "<resource>"
-    And an IAM policy attached to the user with "Deny" effect to perform "<action>" on "<resource>"
+    And an IAM policy attached to the entity "user" with "Allow" effect to perform "<action>" on "<resource>"
+    And an IAM policy attached to the entity "user" with "Deny" effect to perform "<action>" on "<resource>"
     When the user tries to perform "<action>" on the bucket
     Then the user should receive "AccessDenied" error
     Examples:

--- a/tests/ctst/package.json
+++ b/tests/ctst/package.json
@@ -14,6 +14,6 @@
     "prometheus-query": "^3.2.0"
   },
   "devDependencies": {
-    "cli-testing": "github:scality/cli-testing.git#0.2.2"
+    "cli-testing": "github:scality/cli-testing.git#0.2.3"
   }
 }

--- a/tests/ctst/steps/iam-policies/IAMUser.ts
+++ b/tests/ctst/steps/iam-policies/IAMUser.ts
@@ -1,27 +1,10 @@
 import { Given, setDefaultTimeout } from '@cucumber/cucumber';
 import { Constants, IAM, Utils } from 'cli-testing';
+import {extractPropertyFromResults} from "../../common/utils";
 
 setDefaultTimeout(Constants.DEFAULT_TIMEOUT);
 
-/**
- * Policy are using ARN, not names. This helper will dynamically extract a policy
- * ARN from a CLI result
- * @param {object} results - results from the command line
- * @return {string} - the policy arn, or null if an error occured when
- * parsing results.
- */
-function extractPolicyArnFromResults(results: any) {
-    try {
-        if (results.stdout) {
-            return JSON.parse(results.stdout).Policy.Arn;
-        }
-        return null;
-    } catch (err) {
-        return null;
-    }
-}
-
-Given('an IAM policy attached to the user with {string} effect to perform {string} on {string}', async function (effect: string, action: string, resource: string) {
+Given('an IAM policy attached to the entity {string} with {string} effect to perform {string} on {string}', async function (entity: string, effect: string, action: string, resource: string) {
     this.cleanupEntity();
     this.resetCommand();
     this.saved.action = action;
@@ -39,10 +22,19 @@ Given('an IAM policy attached to the user with {string} effect to perform {strin
             ],
         })
     });
-    this.saved.policyArn = extractPolicyArnFromResults(await IAM.createPolicy(this.getCommandParameters()));
+    this.saved.policyArn = extractPropertyFromResults(await IAM.createPolicy(this.getCommandParameters()), 'Policy', 'Arn');
+
     // attach the IAM policy to the user
     this.resetCommand();
-    this.addCommandParameter({userName: this.saved.userName});
-    this.addCommandParameter({policyArn: this.saved.policyArn});
-    await IAM.attachUserPolicy(this.getCommandParameters());
+    this.addCommandParameter({ policyArn: this.saved.policyArn });
+    if (entity === 'user') {
+        this.addCommandParameter({ userName: this.saved.userName });
+        await IAM.attachUserPolicy(this.getCommandParameters());
+    } else if (entity === 'role') {
+        this.addCommandParameter({ roleName: this.saved.roleName });
+        await IAM.attachRolePolicy(this.getCommandParameters());
+    } else if (entity === 'group') {
+        this.addCommandParameter({ groupName: this.saved.groupName });
+        await IAM.attachGroupPolicy(this.getCommandParameters());
+    }
 });

--- a/tests/ctst/steps/iam-policies/common.ts
+++ b/tests/ctst/steps/iam-policies/common.ts
@@ -12,6 +12,7 @@ When('the user tries to perform {string} on the bucket', async function (action:
         this.resumeRootOrIamUser();
     } else {
         userCredentials = this.parameters.AssumedSession;
+        this.resumeAssumedRole();
     }
     switch (action) {
         case 'MetadataSearch': {

--- a/tests/ctst/yarn.lock
+++ b/tests/ctst/yarn.lock
@@ -1492,9 +1492,9 @@ cli-table3@^0.6.0:
   optionalDependencies:
     "@colors/colors" "1.5.0"
 
-"cli-testing@github:scality/cli-testing.git#0.2.2":
-  version "0.2.2"
-  resolved "git+ssh://git@github.com/scality/cli-testing.git#f1d0de3a1dadb18023d1f264283ef8a64d4987e0"
+"cli-testing@github:scality/cli-testing.git#449ae371265505b55e3f2894a8195e24d38708a2":
+  version "0.2.1"
+  resolved "git+ssh://git@github.com/scality/cli-testing.git#449ae371265505b55e3f2894a8195e24d38708a2"
   dependencies:
     "@cucumber/cucumber" "7.3.1"
     "@cucumber/pretty-formatter" "^1.0.0-alpha.1"


### PR DESCRIPTION
based on [this PR](https://github.com/scality/Zenko/pull/1802)
translated the [s3 iam-policies end2end tests for AssumeRole User](https://github.com/scality/Zenko/blob/development/2.6/tests/zenko_tests/node_tests/iam_policies/cloudserver/AssumeRole.js) to ctst, will eventually remove the original tests.

and add a world function `prepareAssumeRole` to do all the preparation work for assuming a role within an account or cross account