### PR TITLE
improvement: ZENKO-4516 fix hardcoded test log name for all end2end t…

### DIFF
--- a/.github/actions/archive-artifacts/action.yaml
+++ b/.github/actions/archive-artifacts/action.yaml
@@ -14,5 +14,3 @@ runs:
         kubectl get events -A -o yaml > /tmp/artifacts/data/kind-logs/all-events.log;
         kind export logs /tmp/artifacts/data/kind-logs/kind-export;
         tar zcvf /tmp/artifacts/${{ github.sha }}-${STAGE}-logs-volumes.tgz /tmp/artifacts/data/kind-logs;
-      env:
-         STAGE: end2end-http

--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -382,6 +382,8 @@ jobs:
         uses: ./.github/actions/debug-wait
       - name: Archive artifact logs and data
         uses: ./.github/actions/archive-artifacts
+        env:
+          STAGE: end2end-http
         if: always()
       - name: Clean Up
         run: kind delete cluster
@@ -445,6 +447,8 @@ jobs:
         uses: ./.github/actions/debug-wait
       - name: Archive artifact logs and data
         uses: ./.github/actions/archive-artifacts
+        env:
+          STAGE: end2end-https
         if: always()
       - name: Clean Up
         run: kind delete cluster
@@ -501,6 +505,8 @@ jobs:
         uses: ./.github/actions/debug-wait
       - name: Archive artifact logs and data
         uses: ./.github/actions/archive-artifacts
+        env:
+          STAGE: end2end-sharded
         if: always()
       - name: Clean Up
         run: kind delete cluster
@@ -559,6 +565,8 @@ jobs:
         uses: ./.github/actions/debug-wait
       - name: Archive artifact logs and data
         uses: ./.github/actions/archive-artifacts
+        env:
+          STAGE: ctst-end2end-sharded
         if: always()
       - name: Clean Up
         run: kind delete cluster


### PR DESCRIPTION
Zenko CI end2end tests log filename are hardcoded for all steps which cause all log are overwrited by the last one