### PR TITLE
Improvement/zenko 4514 service users iam policies ctst tests

### DIFF
--- a/.github/scripts/end2end/run-e2e-ctst.sh
+++ b/.github/scripts/end2end/run-e2e-ctst.sh
@@ -16,6 +16,7 @@ ADMIN_SECRET_ACCESS_KEY=$(kubectl get secret end2end-management-vault-admin-cred
 STORAGE_MANAGER_USER_NAME="ctst_storage_manager"
 STORAGE_ACCOUNT_OWNER_USER_NAME="ctst_storage_account_owner"
 DATA_CONSUMER_USER_NAME="ctst_data_consumer"
+VAULT_AUTH_HOST="${ZENKO_NAME}-connector-vault-auth-api.default.svc.cluster.local"
 ZENKO_PORT="80"
 KEYCLOAK_TEST_PASSWORD=${OIDC_PASSWORD}
 KEYCLOAK_TEST_HOST=${OIDC_HOST}
@@ -24,13 +25,20 @@ KEYCLOAK_TEST_REALM_NAME=${OIDC_REALM}
 KEYCLOAK_TEST_CLIENT_ID=${OIDC_CLIENT_ID}
 KEYCLOAK_TEST_GRANT_TYPE="password"
 
+# get Zenko service users credentials
+BACKBEAT_LCBP_1_CREDS=$(kubectl get secret -l app.kubernetes.io/name=backbeat-lcbp-user-creds,app.kubernetes.io/instance=end2end -o jsonpath='{.items[0].data.backbeat-lifecycle-bp-1\.json}' | base64 -d)
+BACKBEAT_LCC_1_CREDS=$(kubectl get secret -l app.kubernetes.io/name=backbeat-lcc-user-creds,app.kubernetes.io/instance=end2end -o jsonpath='{.items[0].data.backbeat-lifecycle-conductor-1\.json}' | base64 -d)
+BACKBEAT_LCOP_1_CREDS=$(kubectl get secret -l app.kubernetes.io/name=backbeat-lcop-user-creds,app.kubernetes.io/instance=end2end -o jsonpath='{.items[0].data.backbeat-lifecycle-op-1\.json}' | base64 -d)
+BACKBEAT_QP_1_CREDS=$(kubectl get secret -l app.kubernetes.io/name=backbeat-qp-user-creds,app.kubernetes.io/instance=end2end -o jsonpath='{.items[0].data.backbeat-qp-1\.json}' | base64 -d)
+SERVICE_USERS_CREDENTIALS=$(echo '{"backbeat-lifecycle-bp-1":'${BACKBEAT_LCBP_1_CREDS}',"backbeat-lifecycle-conductor-1":'${BACKBEAT_LCC_1_CREDS}',"backbeat-lifecycle-op-1":'${BACKBEAT_LCOP_1_CREDS}',"backbeat-qp-1":'${BACKBEAT_QP_1_CREDS}'}' | jq -R)
+
 # Extracting kafka host from bacbeat's config
 KAFKA_HOST_PORT=$(kubectl get secret -l app.kubernetes.io/name=backbeat-config,app.kubernetes.io/instance=end2end \
     -o jsonpath='{.items[0].data.config\.json}' | base64 -di | jq .kafka.hosts)
 KAFKA_HOST_PORT=${KAFKA_HOST_PORT:1:-1}
 
 # Setting CTST world params
-WORLD_PARAMETERS='{"subdomain":"'${SUBDOMAIN}'","ssl":false,"port":"'${ZENKO_PORT}'","AccountName":"'${ZENKO_ACCOUNT_NAME}'","AdminAccessKey":"'${ADMIN_ACCESS_KEY_ID}'","AdminSecretKey":"'${ADMIN_SECRET_ACCESS_KEY}'","NotificationDestination":"'${NOTIF_DEST_NAME}'","NotificationDestinationTopic":"'${NOTIF_DEST_TOPIC}'","NotificationDestinationAlt":"'${NOTIF_ALT_DEST_NAME}'","NotificationDestinationTopicAlt":"'${NOTIF_ALT_DEST_TOPIC}'","KafkaHosts":"'${KAFKA_HOST_PORT}'","KeycloakPassword":"'${KEYCLOAK_TEST_PASSWORD}'","KeycloakHost":"'${KEYCLOAK_TEST_HOST}'","KeycloakPort":"'${KEYCLOAK_TEST_PORT}'","keycloakRealm":"'${KEYCLOAK_TEST_REALM_NAME}'","keycloakClientId":"'${KEYCLOAK_TEST_CLIENT_ID}'","keycloakGrantType":"'${KEYCLOAK_TEST_GRANT_TYPE}'","StorageManagerUsername":"'${STORAGE_MANAGER_USER_NAME}'","StorageAccountOwnerUsername":"'${STORAGE_ACCOUNT_OWNER_USER_NAME}'","DataConsumerUsername":"'${DATA_CONSUMER_USER_NAME}'"}'
+WORLD_PARAMETERS='{"subdomain":"'${SUBDOMAIN}'","ssl":false,"port":"'${ZENKO_PORT}'","AccountName":"'${ZENKO_ACCOUNT_NAME}'","AdminAccessKey":"'${ADMIN_ACCESS_KEY_ID}'","AdminSecretKey":"'${ADMIN_SECRET_ACCESS_KEY}'","VaultAuthHost":"'${VAULT_AUTH_HOST}'","NotificationDestination":"'${NOTIF_DEST_NAME}'","NotificationDestinationTopic":"'${NOTIF_DEST_TOPIC}'","NotificationDestinationAlt":"'${NOTIF_ALT_DEST_NAME}'","NotificationDestinationTopicAlt":"'${NOTIF_ALT_DEST_TOPIC}'","KafkaHosts":"'${KAFKA_HOST_PORT}'","KeycloakPassword":"'${KEYCLOAK_TEST_PASSWORD}'","KeycloakHost":"'${KEYCLOAK_TEST_HOST}'","KeycloakPort":"'${KEYCLOAK_TEST_PORT}'","keycloakRealm":"'${KEYCLOAK_TEST_REALM_NAME}'","keycloakClientId":"'${KEYCLOAK_TEST_CLIENT_ID}'","keycloakGrantType":"'${KEYCLOAK_TEST_GRANT_TYPE}'","StorageManagerUsername":"'${STORAGE_MANAGER_USER_NAME}'","StorageAccountOwnerUsername":"'${STORAGE_ACCOUNT_OWNER_USER_NAME}'","DataConsumerUsername":"'${DATA_CONSUMER_USER_NAME}'","ServiceUsersCredentials":'${SERVICE_USERS_CREDENTIALS}'}'
 
 E2E_IMAGE=$E2E_CTST_IMAGE_NAME:$E2E_IMAGE_TAG
 POD_NAME="${ZENKO_NAME}-ctst-tests"
@@ -53,4 +61,5 @@ kubectl run $POD_NAME \
         --attach=True \
         --image-pull-policy=Always \
         --env=TARGET_VERSION=$VERSION  \
+        --env=VERBOSE=1 \
         -- ./run "$COMMAND" $WORLD_PARAMETERS "--parallel $PARALLEL_RUNS --retry $RETRIES --retry-tag-filter @Flaky"

--- a/.github/scripts/end2end/run-e2e-ctst.sh
+++ b/.github/scripts/end2end/run-e2e-ctst.sh
@@ -30,7 +30,9 @@ BACKBEAT_LCBP_1_CREDS=$(kubectl get secret -l app.kubernetes.io/name=backbeat-lc
 BACKBEAT_LCC_1_CREDS=$(kubectl get secret -l app.kubernetes.io/name=backbeat-lcc-user-creds,app.kubernetes.io/instance=end2end -o jsonpath='{.items[0].data.backbeat-lifecycle-conductor-1\.json}' | base64 -d)
 BACKBEAT_LCOP_1_CREDS=$(kubectl get secret -l app.kubernetes.io/name=backbeat-lcop-user-creds,app.kubernetes.io/instance=end2end -o jsonpath='{.items[0].data.backbeat-lifecycle-op-1\.json}' | base64 -d)
 BACKBEAT_QP_1_CREDS=$(kubectl get secret -l app.kubernetes.io/name=backbeat-qp-user-creds,app.kubernetes.io/instance=end2end -o jsonpath='{.items[0].data.backbeat-qp-1\.json}' | base64 -d)
-SERVICE_USERS_CREDENTIALS=$(echo '{"backbeat-lifecycle-bp-1":'${BACKBEAT_LCBP_1_CREDS}',"backbeat-lifecycle-conductor-1":'${BACKBEAT_LCC_1_CREDS}',"backbeat-lifecycle-op-1":'${BACKBEAT_LCOP_1_CREDS}',"backbeat-qp-1":'${BACKBEAT_QP_1_CREDS}'}' | jq -R)
+SORBET_FWD_2_ACCESSKEY=$(kubectl get secret -l app.kubernetes.io/name=sorbet-fwd-creds,app.kubernetes.io/instance=end2end -o jsonpath='{.items[0].data.accessKey}' | base64 -d)
+SORBET_FWD_2_SECRETKEY=$(kubectl get secret -l app.kubernetes.io/name=sorbet-fwd-creds,app.kubernetes.io/instance=end2end -o jsonpath='{.items[0].data.secretKey}' | base64 -d)
+SERVICE_USERS_CREDENTIALS=$(echo '{"backbeat-lifecycle-bp-1":'${BACKBEAT_LCBP_1_CREDS}',"backbeat-lifecycle-conductor-1":'${BACKBEAT_LCC_1_CREDS}',"backbeat-lifecycle-op-1":'${BACKBEAT_LCOP_1_CREDS}',"backbeat-qp-1":'${BACKBEAT_QP_1_CREDS}',"sorbet-fwd-2":{"accessKey":"'${SORBET_FWD_2_ACCESSKEY}'","secretKey":"'${SORBET_FWD_2_SECRETKEY}'"}}' | jq -R)
 
 # Extracting kafka host from bacbeat's config
 KAFKA_HOST_PORT=$(kubectl get secret -l app.kubernetes.io/name=backbeat-config,app.kubernetes.io/instance=end2end \

--- a/tests/ctst/Dockerfile
+++ b/tests/ctst/Dockerfile
@@ -1,5 +1,5 @@
 ARG CTST_TAG
-FROM registry.scality.com/cli-testing-dev/cli-testing:$CTST_TAG
+FROM registry.scality.com/cli-testing/cli-testing:$CTST_TAG
 
 COPY package.json /tmp/package.json
 COPY ./features /ctst/features

--- a/tests/ctst/Dockerfile
+++ b/tests/ctst/Dockerfile
@@ -1,5 +1,5 @@
 ARG CTST_TAG
-FROM registry.scality.com/cli-testing/cli-testing:$CTST_TAG
+FROM registry.scality.com/cli-testing-dev/cli-testing:$CTST_TAG
 
 COPY package.json /tmp/package.json
 COPY ./features /ctst/features

--- a/tests/ctst/common/hooks.ts
+++ b/tests/ctst/common/hooks.ts
@@ -31,4 +31,9 @@ Given('a {string} AssumeRole user', async function (crossAccount: string) {
     this.saved.type = EntityType.ASSUME_ROLE_USER;
 });
 
+Given('a service user {string}', async function (serviceUserName: string) {
+    await this.prepareServiceUser(serviceUserName);
+    this.saved.type = EntityType.ASSUME_ROLE_USER;
+});
+
 export default worlds;

--- a/tests/ctst/common/hooks.ts
+++ b/tests/ctst/common/hooks.ts
@@ -31,8 +31,8 @@ Given('a {string} AssumeRole user', async function (crossAccount: string) {
     this.saved.type = EntityType.ASSUME_ROLE_USER;
 });
 
-Given('a service user {string}', async function (serviceUserName: string) {
-    await this.prepareServiceUser(serviceUserName);
+Given('a service user {string} assuming role {string}', async function (serviceUserName: string, roleName: string) {
+    await this.prepareServiceUser(serviceUserName, roleName);
     this.saved.type = EntityType.ASSUME_ROLE_USER;
 });
 

--- a/tests/ctst/features/iam-policies/backbeatServiceUser.feature
+++ b/tests/ctst/features/iam-policies/backbeatServiceUser.feature
@@ -44,3 +44,17 @@ Feature: IAM Policies for Backbeat Service Users
     Examples:
       | action                          | withVersioning | objectExists   | serviceUserName         | expectedError                |
       | GetBucketLifecycleConfiguration | with           | does not exist | backbeat-lifecycle-bp-1 | NoSuchLifecycleConfiguration |
+
+  @2.6.0
+  @PreMerge
+  @Flaky
+  @IamPoliciesBackbeatServiceUser
+  Scenario Outline: Backbeat Service Users are authorized to perform the actions
+    Given a service user "<serviceUserName>"
+    When the user tries to perform vault auth "<action>"
+    Then the user should be able to perform successfully the "<action>" action
+
+    Examples:
+      | action         | serviceUserName                |
+      | GetAccountInfo | backbeat-qp-1                  |
+      | GetAccountInfo | backbeat-lifecycle-conductor-1 |

--- a/tests/ctst/features/iam-policies/backbeatServiceUser.feature
+++ b/tests/ctst/features/iam-policies/backbeatServiceUser.feature
@@ -1,0 +1,46 @@
+Feature: IAM Policies for Backbeat Service Users
+  As a backbeat service user, 
+  I want to have specific permissions to perform S3 actions for data replication and expiration 
+  So that I can effectively manage data within the system.
+
+
+  @2.6.0
+  @PreMerge
+  @Flaky
+  @IamPoliciesBackbeatServiceUser
+  Scenario Outline: Backbeat Service Users are authorized to perform the actions and get success response
+    Given an existing bucket "" "<withVersioning>" versioning, "without" ObjectLock "" retention mode
+    And an object "" that "<objectExists>"
+    And a service user "<serviceUserName>"
+    When the user tries to perform "<action>" on the bucket
+    Then the user should be able to perform successfully the "<action>" action
+
+    Examples:
+      | action                          | withVersioning | objectExists   | serviceUserName         |
+      | GetBucketVersioning             | with           | does not exist | backbeat-lifecycle-bp-1 |
+      | ListObjects                     | with           | exists         | backbeat-lifecycle-bp-1 |
+      | ListMultipartUploads            | with           | exists         | backbeat-lifecycle-bp-1 |
+      | GetObjectTagging                | without        | exists         | backbeat-lifecycle-bp-1 |
+      | GetObjectTagging                | with           | exists         | backbeat-lifecycle-bp-1 |
+      | GetObject                       | without        | exists         | backbeat-lifecycle-bp-1 |
+      | GetObject                       | with           | exists         | backbeat-lifecycle-bp-1 |
+      | GetObject                       | without        | exists         | backbeat-lifecycle-op-1 |
+      | GetObject                       | with           | exists         | backbeat-lifecycle-op-1 |
+      | DeleteObject                    | without        | exists         | backbeat-lifecycle-op-1 |
+      | DeleteObject                    | with           | exists         | backbeat-lifecycle-op-1 |
+      | AbortMultipartUpload            | with           | exits          | backbeat-lifecycle-op-1 |
+
+  @2.6.0
+  @PreMerge
+  @Flaky
+  @IamPoliciesBackbeatServiceUser
+  Scenario Outline: Backbeat Service Users are authorized to perform the actions and get expected error response
+    Given an existing bucket "" "<withVersioning>" versioning, "without" ObjectLock "" retention mode
+    And an object "" that "<objectExists>"
+    And a service user "<serviceUserName>"
+    When the user tries to perform "<action>" on the bucket
+    Then the user should receive "<expectedError>" error
+
+    Examples:
+      | action                          | withVersioning | objectExists   | serviceUserName         | expectedError                |
+      | GetBucketLifecycleConfiguration | with           | does not exist | backbeat-lifecycle-bp-1 | NoSuchLifecycleConfiguration |

--- a/tests/ctst/features/iam-policies/backbeatServiceUser.feature
+++ b/tests/ctst/features/iam-policies/backbeatServiceUser.feature
@@ -6,55 +6,58 @@ Feature: IAM Policies for Backbeat Service Users
 
   @2.6.0
   @PreMerge
-  @Flaky
   @IamPoliciesBackbeatServiceUser
   Scenario Outline: Backbeat Service Users are authorized to perform the actions and get success response
     Given an existing bucket "" "<withVersioning>" versioning, "without" ObjectLock "" retention mode
     And an object "" that "<objectExists>"
-    And a service user "<serviceUserName>"
+    And a service user "<serviceUserName>" assuming role "<roleName>"
     When the user tries to perform "<action>" on the bucket
     Then the user should be able to perform successfully the "<action>" action
 
     Examples:
-      | action                          | withVersioning | objectExists   | serviceUserName         |
-      | GetBucketVersioning             | with           | does not exist | backbeat-lifecycle-bp-1 |
-      | ListObjects                     | with           | exists         | backbeat-lifecycle-bp-1 |
-      | ListMultipartUploads            | with           | exists         | backbeat-lifecycle-bp-1 |
-      | GetObjectTagging                | without        | exists         | backbeat-lifecycle-bp-1 |
-      | GetObjectTagging                | with           | exists         | backbeat-lifecycle-bp-1 |
-      | GetObject                       | without        | exists         | backbeat-lifecycle-bp-1 |
-      | GetObject                       | with           | exists         | backbeat-lifecycle-bp-1 |
-      | GetObject                       | without        | exists         | backbeat-lifecycle-op-1 |
-      | GetObject                       | with           | exists         | backbeat-lifecycle-op-1 |
-      | DeleteObject                    | without        | exists         | backbeat-lifecycle-op-1 |
-      | DeleteObject                    | with           | exists         | backbeat-lifecycle-op-1 |
-      | AbortMultipartUpload            | with           | exits          | backbeat-lifecycle-op-1 |
+      | action               | withVersioning | objectExists   | serviceUserName         | roleName                    |
+      | GetBucketVersioning  | with           | does not exist | backbeat-lifecycle-bp-1 | backbeat-lifecycle-bp-1     |
+      | ListObjects          | with           | exists         | backbeat-lifecycle-bp-1 | backbeat-lifecycle-bp-1     |
+      | ListMultipartUploads | with           | exists         | backbeat-lifecycle-bp-1 | backbeat-lifecycle-bp-1     |
+      | GetObjectTagging     | without        | exists         | backbeat-lifecycle-bp-1 | backbeat-lifecycle-bp-1     |
+      | GetObjectTagging     | with           | exists         | backbeat-lifecycle-bp-1 | backbeat-lifecycle-bp-1     |
+      | GetObject            | without        | exists         | backbeat-lifecycle-bp-1 | backbeat-lifecycle-bp-1     |
+      | GetObject            | with           | exists         | backbeat-lifecycle-bp-1 | backbeat-lifecycle-bp-1     |
+      | GetObject            | without        | exists         | backbeat-lifecycle-op-1 | backbeat-lifecycle-op-1     |
+      | GetObject            | with           | exists         | backbeat-lifecycle-op-1 | backbeat-lifecycle-op-1     |
+      | DeleteObject         | without        | exists         | backbeat-lifecycle-op-1 | backbeat-lifecycle-op-1     |
+      | DeleteObject         | with           | exists         | backbeat-lifecycle-op-1 | backbeat-lifecycle-op-1     |
+      | AbortMultipartUpload | with           | exits          | backbeat-lifecycle-op-1 | backbeat-lifecycle-op-1     |
+      | GetObject            | without        | exists         | sorbet-fwd-2            | cold-storage-archive-role-2 |
+      | GetObject            | with           | exists         | sorbet-fwd-2            | cold-storage-archive-role-2 |
+      | PutObject            | with           | exists         | sorbet-fwd-2            | cold-storage-restore-role-2 |
+      | GetObject            | without        | exists         | sorbet-fwd-2            | cold-storage-restore-role-2 |
+      | GetObject            | with           | exists         | sorbet-fwd-2            | cold-storage-restore-role-2 |
 
   @2.6.0
   @PreMerge
-  @Flaky
   @IamPoliciesBackbeatServiceUser
   Scenario Outline: Backbeat Service Users are authorized to perform the actions and get expected error response
     Given an existing bucket "" "<withVersioning>" versioning, "without" ObjectLock "" retention mode
     And an object "" that "<objectExists>"
-    And a service user "<serviceUserName>"
+    And a service user "<serviceUserName>" assuming role "<roleName>"
     When the user tries to perform "<action>" on the bucket
     Then the user should receive "<expectedError>" error
 
     Examples:
-      | action                          | withVersioning | objectExists   | serviceUserName         | expectedError                |
-      | GetBucketLifecycleConfiguration | with           | does not exist | backbeat-lifecycle-bp-1 | NoSuchLifecycleConfiguration |
+      | action                          | withVersioning | objectExists   | serviceUserName         | roleName                | expectedError                |
+      | GetBucketLifecycleConfiguration | with           | does not exist | backbeat-lifecycle-bp-1 | backbeat-lifecycle-bp-1 | NoSuchLifecycleConfiguration |
 
   @2.6.0
   @PreMerge
   @Flaky
   @IamPoliciesBackbeatServiceUser
   Scenario Outline: Backbeat Service Users are authorized to perform the actions
-    Given a service user "<serviceUserName>"
+    Given a service user "<serviceUserName>" assuming role "<roleName>"
     When the user tries to perform vault auth "<action>"
     Then the user should be able to perform successfully the "<action>" action
 
     Examples:
-      | action         | serviceUserName                |
-      | GetAccountInfo | backbeat-qp-1                  |
-      | GetAccountInfo | backbeat-lifecycle-conductor-1 |
+      | action         | serviceUserName                | roleName                       |
+      | GetAccountInfo | backbeat-qp-1                  | backbeat-qp-1                  |
+      | GetAccountInfo | backbeat-lifecycle-conductor-1 | backbeat-lifecycle-conductor-1 |

--- a/tests/ctst/features/iam-policies/backbeatServiceUser.feature
+++ b/tests/ctst/features/iam-policies/backbeatServiceUser.feature
@@ -30,7 +30,6 @@ Feature: IAM Policies for Backbeat Service Users
       | AbortMultipartUpload | with           | exits          | backbeat-lifecycle-op-1 | backbeat-lifecycle-op-1     |
       | GetObject            | without        | exists         | sorbet-fwd-2            | cold-storage-archive-role-2 |
       | GetObject            | with           | exists         | sorbet-fwd-2            | cold-storage-archive-role-2 |
-      | PutObject            | with           | exists         | sorbet-fwd-2            | cold-storage-restore-role-2 |
       | GetObject            | without        | exists         | sorbet-fwd-2            | cold-storage-restore-role-2 |
       | GetObject            | with           | exists         | sorbet-fwd-2            | cold-storage-restore-role-2 |
 
@@ -45,8 +44,9 @@ Feature: IAM Policies for Backbeat Service Users
     Then the user should receive "<expectedError>" error
 
     Examples:
-      | action                          | withVersioning | objectExists   | serviceUserName         | roleName                | expectedError                |
-      | GetBucketLifecycleConfiguration | with           | does not exist | backbeat-lifecycle-bp-1 | backbeat-lifecycle-bp-1 | NoSuchLifecycleConfiguration |
+      | action                          | withVersioning | objectExists   | serviceUserName         | roleName                    | expectedError                |
+      | GetBucketLifecycleConfiguration | with           | does not exist | backbeat-lifecycle-bp-1 | backbeat-lifecycle-bp-1     | NoSuchLifecycleConfiguration |
+      | PutObjectVersion                | with           | exists         | sorbet-fwd-2            | cold-storage-restore-role-2 | InvalidObjectState           |
 
   @2.6.0
   @PreMerge

--- a/tests/ctst/package.json
+++ b/tests/ctst/package.json
@@ -14,6 +14,6 @@
     "prometheus-query": "^3.2.0"
   },
   "devDependencies": {
-    "cli-testing": "github:scality/cli-testing.git#0.2.3"
+    "cli-testing": "github:scality/cli-testing.git#bf606f7a3c7bae0e8897d3d218e7fab50e357027"
   }
 }

--- a/tests/ctst/package.json
+++ b/tests/ctst/package.json
@@ -14,6 +14,6 @@
     "prometheus-query": "^3.2.0"
   },
   "devDependencies": {
-    "cli-testing": "github:scality/cli-testing.git#bf606f7a3c7bae0e8897d3d218e7fab50e357027"
+    "cli-testing": "github:scality/cli-testing.git#0.2.4"
   }
 }

--- a/tests/ctst/steps/iam-policies/common.ts
+++ b/tests/ctst/steps/iam-policies/common.ts
@@ -19,6 +19,10 @@ When('the user tries to perform {string} on the bucket', async function (action:
             this.result = await this.metadataSearchResponseCode(userCredentials, this.saved.bucketName);
             break;
         }
+        case 'PutObjectVersion': {
+            this.result = await this.putObjectVersionResponseCode(userCredentials, this.saved.bucketName, this.saved.objectName);
+            break;
+        }
         default: {
             this.resetCommand();
             this.saved.ifS3Standard = true;

--- a/tests/ctst/world/Zenko.ts
+++ b/tests/ctst/world/Zenko.ts
@@ -394,19 +394,20 @@ export default class Zenko extends World {
 
     /**
      * Creates an assumed role session as service user with a duration of 12 hours.
-     * @Param {string} serviceUserName - The name of the service user to be used, the same as role name to assume.
+     * @Param {string} serviceUserName - The name of the service user to be used,
+     * @Param {string} roleName - the role name to assume.
      * @returns {undefined}
      */
-    async prepareServiceUser(serviceUserName: string) {
+    async prepareServiceUser(serviceUserName: string, roleName: string) {
         this.resetGlobalType();
 
-        let roleArnToAssume: string | null = '';
+        let roleArnToAssume: string | null = null;
         // Getting the role to assume
-        this.addCommandParameter({ roleName: serviceUserName });
+        this.addCommandParameter({ roleName: roleName });
         roleArnToAssume = extractPropertyFromResults(await IAM.getRole(this.getCommandParameters()), 'Role', 'Arn');
         if (!roleArnToAssume) {
             // if role to assume does not exist in the account, then it should be in the internal services account
-            roleArnToAssume = `arn:aws:iam::${Constants.INTERNAL_SERVICES_ACCOUNT_ID}:role/scality-internal/${serviceUserName}`;
+            roleArnToAssume = `arn:aws:iam::${Constants.INTERNAL_SERVICES_ACCOUNT_ID}:role/scality-internal/${roleName}`;
         }
 
         // assign the credentials of the service user to the IAM session

--- a/tests/ctst/yarn.lock
+++ b/tests/ctst/yarn.lock
@@ -1492,9 +1492,9 @@ cli-table3@^0.6.0:
   optionalDependencies:
     "@colors/colors" "1.5.0"
 
-"cli-testing@github:scality/cli-testing.git#449ae371265505b55e3f2894a8195e24d38708a2":
-  version "0.2.1"
-  resolved "git+ssh://git@github.com/scality/cli-testing.git#449ae371265505b55e3f2894a8195e24d38708a2"
+"cli-testing@github:scality/cli-testing.git#bf606f7a3c7bae0e8897d3d218e7fab50e357027":
+  version "0.2.3"
+  resolved "git+ssh://git@github.com/scality/cli-testing.git#bf606f7a3c7bae0e8897d3d218e7fab50e357027"
   dependencies:
     "@cucumber/cucumber" "7.3.1"
     "@cucumber/pretty-formatter" "^1.0.0-alpha.1"

--- a/tests/ctst/yarn.lock
+++ b/tests/ctst/yarn.lock
@@ -1492,9 +1492,9 @@ cli-table3@^0.6.0:
   optionalDependencies:
     "@colors/colors" "1.5.0"
 
-"cli-testing@github:scality/cli-testing.git#bf606f7a3c7bae0e8897d3d218e7fab50e357027":
-  version "0.2.3"
-  resolved "git+ssh://git@github.com/scality/cli-testing.git#bf606f7a3c7bae0e8897d3d218e7fab50e357027"
+"cli-testing@github:scality/cli-testing.git#0.2.4":
+  version "0.2.4"
+  resolved "git+ssh://git@github.com/scality/cli-testing.git#6b6ef2b71e4ac7652292921f982f927889219074"
   dependencies:
     "@cucumber/cucumber" "7.3.1"
     "@cucumber/pretty-formatter" "^1.0.0-alpha.1"


### PR DESCRIPTION
tested the following service users are authorized to perform the actions that are defined in the policy of the role that they are assuming
- backbeat-lifecycle-bp-1
  - s3:GetBucketVersioning
  - s3:ListObjects
  - s3:ListMultipartUploads
  - s3:GetObjectTagging
  - s3:GetObject
  - s3:GetBucketLifecycleConfiguration
- backbeat-lifecycle-op-1
  - s3:GetObject
  - s3:DeleteObject
  - s3:AbortMultipartUpload
- sorbet-fwd-2 service user assuming cold-storage-archive-role-2
  - s3:GetObject
- sorbet-fwd-2 service user assuming cold-storage-restore-role-2
  - s3:GetObject
  - s3:PutObjectVersion
- backbeat-qp-1
  - vaultadmin:GetAccountInfo
- backbeat-lifecycle-conductor-1
  - vaultadmin:GetAccountInfo


some service users also have a `s3:ReplicateObject` permission, but this can only be tested by launching a lifecycle replication workflow and then check replicated result, this has already been done in Zenko backbeat end2end tests
