### PR TITLE
Bump dependencies

### DIFF
--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -6,7 +6,7 @@ backbeat:
   dashboard: backbeat-dashboards
   image: backbeat
   policy: backbeat-policies
-  tag: 8.6.8
+  tag: 8.6.9
   envsubst: BACKBEAT_TAG
 busybox:
   image: busybox
@@ -16,7 +16,7 @@ cloudserver:
   sourceRegistry: registry.scality.com/cloudserver
   dashboard: cloudserver-dashboards
   image: cloudserver
-  tag: 8.7.11
+  tag: 8.7.12
   envsubst: CLOUDSERVER_TAG
 jmx-javaagent:
   sourceRegistry: banzaicloud


### PR DESCRIPTION
- Cloudserver → 8.7.12
- Backbeat → 8.6.9

 Issue: ZENKO-4408