### PR TITLE
ZENKO-4561: update ctst tests

### DIFF
--- a/tests/ctst/common/hooks.ts
+++ b/tests/ctst/common/hooks.ts
@@ -31,7 +31,12 @@ Given('a {string} AssumeRole user', async function (crossAccount: string) {
     this.saved.type = EntityType.ASSUME_ROLE_USER;
 });
 
-Given('a service user {string} assuming role {string}', async function (serviceUserName: string, roleName: string) {
+Given('a service user {string} assuming the role {string} of an internal service account', async function (serviceUserName: string, roleName: string) {
+    await this.prepareServiceUser(serviceUserName, roleName, true);
+    this.saved.type = EntityType.ASSUME_ROLE_USER;
+});
+
+Given('a service user {string} assuming the role {string} of a user account', async function (serviceUserName: string, roleName: string) {
     await this.prepareServiceUser(serviceUserName, roleName);
     this.saved.type = EntityType.ASSUME_ROLE_USER;
 });

--- a/tests/ctst/features/iam-policies/backbeatServiceUser.feature
+++ b/tests/ctst/features/iam-policies/backbeatServiceUser.feature
@@ -10,7 +10,7 @@ Feature: IAM Policies for Backbeat Service Users
   Scenario Outline: Backbeat Service Users are authorized to perform the actions and get success response
     Given an existing bucket "" "<withVersioning>" versioning, "without" ObjectLock "" retention mode
     And an object "" that "<objectExists>"
-    And a service user "<serviceUserName>" assuming role "<roleName>"
+    And a service user "<serviceUserName>" assuming the role "<roleName>" of a user account
     When the user tries to perform "<action>" on the bucket
     Then the user should be able to perform successfully the "<action>" action
 
@@ -39,7 +39,7 @@ Feature: IAM Policies for Backbeat Service Users
   Scenario Outline: Backbeat Service Users are authorized to perform the actions and get expected error response
     Given an existing bucket "" "<withVersioning>" versioning, "without" ObjectLock "" retention mode
     And an object "" that "<objectExists>"
-    And a service user "<serviceUserName>" assuming role "<roleName>"
+    And a service user "<serviceUserName>" assuming the role "<roleName>" of a user account
     When the user tries to perform "<action>" on the bucket
     Then the user should receive "<expectedError>" error
 
@@ -53,11 +53,24 @@ Feature: IAM Policies for Backbeat Service Users
   @Flaky
   @IamPoliciesBackbeatServiceUser
   Scenario Outline: Backbeat Service Users are authorized to perform the actions
-    Given a service user "<serviceUserName>" assuming role "<roleName>"
+    Given a service user "<serviceUserName>" assuming the role "<roleName>" of an internal service account
     When the user tries to perform vault auth "<action>"
     Then the user should be able to perform successfully the "<action>" action
 
     Examples:
       | action         | serviceUserName                | roleName                       |
       | GetAccountInfo | backbeat-qp-1                  | backbeat-qp-1                  |
+      | GetAccountInfo | backbeat-lifecycle-conductor-1 | backbeat-lifecycle-conductor-1 |
+
+  @2.6.0
+  @PreMerge
+  @Flaky
+  @IamPoliciesBackbeatServiceUser
+  Scenario Outline: Backbeat Service Users are not authorized to perform the actions
+    Given a service user "<serviceUserName>" assuming the role "<roleName>" of a user account
+    When the user tries to perform vault auth "<action>"
+    Then the user should not be able to perform the "<action>" action
+
+    Examples:
+      | action         | serviceUserName                | roleName                       |
       | GetAccountInfo | backbeat-lifecycle-conductor-1 | backbeat-lifecycle-conductor-1 |

--- a/tests/ctst/steps/iam-policies/common.ts
+++ b/tests/ctst/steps/iam-policies/common.ts
@@ -95,6 +95,19 @@ Then('the user should be able to perform successfully the {string} action', func
     }
 });
 
+Then('the user should not be able to perform the {string} action', function (action : string) {
+    this.cleanupEntity();
+    switch (action) {
+        case 'GetAccountInfo': {
+            assert.strictEqual(this.result instanceof Error, true);
+            break;
+        }
+        default: {
+            assert.strictEqual(this.result?.err, null);
+        }
+    }
+});
+
 Then('the user should receive {string} error', function (error : string) {
     this.cleanupEntity();
     assert.strictEqual(this.result.err.includes(error), true);

--- a/tests/ctst/world/Zenko.ts
+++ b/tests/ctst/world/Zenko.ts
@@ -396,18 +396,27 @@ export default class Zenko extends World {
      * Creates an assumed role session as service user with a duration of 12 hours.
      * @Param {string} serviceUserName - The name of the service user to be used,
      * @Param {string} roleName - the role name to assume.
+     * @Param {string} internal - if true, target role is attached to an internal account
      * @returns {undefined}
      */
-    async prepareServiceUser(serviceUserName: string, roleName: string) {
+    async prepareServiceUser(serviceUserName: string, roleName: string, internal: boolean = false) {
         this.resetGlobalType();
 
         let roleArnToAssume: string | null = null;
         // Getting the role to assume
         this.addCommandParameter({ roleName: roleName });
-        roleArnToAssume = extractPropertyFromResults(await IAM.getRole(this.getCommandParameters()), 'Role', 'Arn');
-        if (!roleArnToAssume) {
-            // if role to assume does not exist in the account, then it should be in the internal services account
+        if (internal) {
             roleArnToAssume = `arn:aws:iam::${Constants.INTERNAL_SERVICES_ACCOUNT_ID}:role/scality-internal/${roleName}`;
+        } else {
+            const role = await IAM.getRole(this.getCommandParameters())
+            if (role.err) {
+                throw new Error(`Error occured when getting ${roleName} for user account`);
+            }
+
+            roleArnToAssume = extractPropertyFromResults(role, 'Role', 'Arn');
+            if (!roleArnToAssume) {
+                throw new Error(`Failed to extract role ARN for ${roleName}`);
+            }
         }
 
         // assign the credentials of the service user to the IAM session


### PR DESCRIPTION
Updates CTST assume role test setup:
* addresses issue in which the incorrect role is assumed.