### PR TITLE
Bump zkop 1.5.18

### DIFF
--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -228,7 +228,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Login to Registry
-        uses: docker/login-action@v1.10.0
+        uses: docker/login-action@v2
         with:
           username: "${{ secrets.REGISTRY_LOGIN }}"
           password: "${{ secrets.REGISTRY_PASSWORD }}"
@@ -294,7 +294,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to Registry
-        uses: docker/login-action@v1.10.0
+        uses: docker/login-action@v2
         with:
           username: "${{ secrets.REGISTRY_LOGIN }}"
           password: "${{ secrets.REGISTRY_PASSWORD }}"
@@ -325,7 +325,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to Registry
-        uses: docker/login-action@v1.10.0
+        uses: docker/login-action@v2
         with:
           username: "${{ secrets.REGISTRY_LOGIN }}"
           password: "${{ secrets.REGISTRY_PASSWORD }}"
@@ -358,7 +358,7 @@ jobs:
       - name: Wait for Docker daemon to be ready
         uses: ./.github/actions/wait-docker-ready
       - name: Login to Registry
-        uses: docker/login-action@v1.10.0
+        uses: docker/login-action@v2
         with:
           username: "${{ secrets.REGISTRY_LOGIN }}"
           password: "${{ secrets.REGISTRY_PASSWORD }}"
@@ -428,7 +428,7 @@ jobs:
       - name: Wait for Docker daemon to be ready
         uses: ./.github/actions/wait-docker-ready
       - name: Login to Registry
-        uses: docker/login-action@v1.10.0
+        uses: docker/login-action@v2
         with:
           username: "${{ secrets.REGISTRY_LOGIN }}"
           password: "${{ secrets.REGISTRY_PASSWORD }}"
@@ -489,7 +489,7 @@ jobs:
       - name: Wait for Docker daemon to be ready
         uses: ./.github/actions/wait-docker-ready
       - name: Login to Registry
-        uses: docker/login-action@v1.10.0
+        uses: docker/login-action@v2
         with:
           username: "${{ secrets.REGISTRY_LOGIN }}"
           password: "${{ secrets.REGISTRY_PASSWORD }}"
@@ -543,7 +543,7 @@ jobs:
       - name: Wait for Docker daemon to be ready
         uses: ./.github/actions/wait-docker-ready
       - name: Login to Registry
-        uses: docker/login-action@v1.10.0
+        uses: docker/login-action@v2
         with:
           username: "${{ secrets.REGISTRY_LOGIN }}"
           password: "${{ secrets.REGISTRY_PASSWORD }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,6 @@
 ---
 name: release
+run-name: Release ${{ inputs.tag }}
 
 on:
   workflow_dispatch:
@@ -20,10 +21,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      
+
       - name: Fetch tags
         run: git fetch --tags
-      
+
       - name: 'Check if tag was already created'
         shell: bash
         run: >

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -94,7 +94,7 @@ vault:
 zenko-operator:
   sourceRegistry: registry.scality.com/zenko-operator
   image: zenko-operator
-  tag: 1.5.13
+  tag: 1.5.18
   envsubst: ZENKO_OPERATOR_TAG
 zenko-ui:
   sourceRegistry: registry.scality.com/zenko-ui


### PR DESCRIPTION
Upgrade to zenko-operator 1.5.18. The features which should not be enabled have been feature-flagged in ZKOP, and are deactivated by default.

They are activated on 2.7 branch through [a change in `zenkoversion.yaml`](https://github.com/scality/Zenko/commit/bdec35ac3002508aea22c4ca9a002ac52971d071).

This should restore Zenko to working order on both 2.6 and 2.7 branches.

- Bump zenko-operator 1.5.18
- Include the version number in 'release' runs
- Upgrade docker-login action

Issue: ZENKO-4572
