### PR TITLE
Add CTST tests for keeping userMD and tags after a restore

### DIFF
--- a/tests/ctst/common/common.ts
+++ b/tests/ctst/common/common.ts
@@ -1,11 +1,35 @@
 import fs from 'fs';
-import path from 'path';
-import { Given, setDefaultTimeout } from '@cucumber/cucumber';
+import { tmpNameSync } from 'tmp';
+import { Given, setDefaultTimeout, Then } from '@cucumber/cucumber';
 import { Constants, S3, Utils } from 'cli-testing';
 import Zenko from 'world/Zenko';
-import { extractPropertyFromResults } from './utils';
+import { extractPropertyFromResults, safeJsonParse } from './utils';
+import assert from 'assert';
 
 setDefaultTimeout(Constants.DEFAULT_TIMEOUT);
+
+async function addMultipleObjects(this: Zenko, numberObjects: number,
+    objectName: string, sizeBytes: number, userMD?: string) {
+    for (let i = 1; i <= numberObjects; i++) {
+        this.addToSaved('objectName', `${objectName}-${i}` || Utils.randomString());
+        const objectPath = tmpNameSync({prefix: this.getSaved<string>('objectName')});
+        fs.writeFileSync(objectPath, Buffer.alloc(sizeBytes, this.getSaved<string>('objectName')));
+        this.resetCommand();
+        this.addCommandParameter({ key: this.getSaved<string>('objectName') });
+        this.addCommandParameter({ bucket: this.getSaved<string>('bucketName') });
+        this.addCommandParameter({ body: objectPath });
+        if (userMD) {
+            this.addCommandParameter({ metadata: JSON.stringify(userMD) });
+        }
+        this.addToSaved('versionId', extractPropertyFromResults(
+            await S3.putObject(this.getCommandParameters()), 'VersionId')
+        );
+        fs.rmSync(objectPath);
+        const createdObjects = this.getSaved<Map<string, string>>('createdObjects') || new Map<string, string>();
+        createdObjects.set(this.getSaved<string>('objectName'), this.getSaved<string>('versionId'));
+        this.addToSaved('createdObjects', createdObjects);
+    }
+}
 
 Given('a {string} bucket', async function (this: Zenko, versioning: string) {
     this.resetCommand();
@@ -71,20 +95,55 @@ Given('an object {string} that {string}',
 
 Given('{int} objects {string} of size {int} bytes',
     async function (this: Zenko, numberObjects: number, objectName: string, sizeBytes: number) {
-        for (let i = 1; i <= numberObjects; i++) { 
-            this.addToSaved('objectName', `${objectName}-${i}` || Utils.randomString());
-            const objectPath = path.join(__dirname, this.getSaved<string>('objectName'));
-            fs.writeFileSync(objectPath, Buffer.alloc(sizeBytes, this.getSaved<string>('objectName')));
-            this.resetCommand();
-            this.addCommandParameter({ key: this.getSaved<string>('objectName') });
-            this.addCommandParameter({ bucket: this.getSaved<string>('bucketName') });
-            this.addCommandParameter({ body: objectPath });
-            this.addToSaved('versionId', extractPropertyFromResults(
-                await S3.putObject(this.getCommandParameters()), 'VersionId'
-            ));
-            fs.rmSync(objectPath);
-            const createdObjects = this.getSaved<Map<string, string>>('createdObjects') || new Map<string, string>();
-            createdObjects.set(this.getSaved<string>('objectName'), this.getSaved<string>('versionId'));
-            this.addToSaved('createdObjects', createdObjects);
+        await addMultipleObjects.call(this, numberObjects, objectName, sizeBytes);
+    });
+
+Given('{int} objects {string} of size {int} bytes with user metadata {string}',
+    async function (this: Zenko, numberObjects: number, objectName: string, sizeBytes: number, userMD: string) {
+        await addMultipleObjects.call(this, numberObjects, objectName, sizeBytes, userMD);
+    });
+
+Given('a tag on object {string} with key {string} and value {string}',
+    async function (this: Zenko, objectName: string, tagKey: string, tagValue: string) {
+        this.resetCommand();
+        this.addCommandParameter({ bucket: this.getSaved<string>('bucketName') });
+        this.addCommandParameter({ key: objectName });
+        this.addCommandParameter({ tagging: `"TagSet=[{Key='${tagKey}',Value='${tagValue}'}]"` });
+        await S3.putObjectTagging(this.getCommandParameters());
+    });
+
+Then('object {string} should have the tag {string} with value {string}',
+    async function (this: Zenko, objectName: string, tagKey: string, tagValue: string) {
+        this.resetCommand();
+        this.addCommandParameter({ bucket: this.getSaved<string>('bucketName') });
+        this.addCommandParameter({ key: objectName });
+        const versionId = this.getSaved<Map<string, string>>('createdObjects')?.get(objectName);
+        if (versionId) {
+            this.addCommandParameter({ versionId });
         }
+        await S3.getObjectTagging(this.getCommandParameters()).then(res => {
+            const parsed = safeJsonParse(res.stdout);
+            const head = parsed.result as { TagSet: [{Key: string, Value: string}] | undefined };
+            assert(head.TagSet?.some(tag => tag.Key === tagKey && tag.Value === tagValue));
+        });
+    });
+
+Then('object {string} should have the user metadata with key {string} and value {string}',
+    async function (this: Zenko, objectName: string, userMDKey: string, userMDValue: string) {
+        this.resetCommand();
+        this.addCommandParameter({ bucket: this.getSaved<string>('bucketName') });
+        this.addCommandParameter({ key: objectName });
+        const versionId = this.getSaved<Map<string, string>>('createdObjects')?.get(objectName);
+        if (versionId) {
+            this.addCommandParameter({ versionId });
+        }
+        const res = await S3.headObject(this.getCommandParameters());
+        assert.ifError(res.stderr);
+        assert(res.stdout);
+        const parsed = safeJsonParse(res.stdout);
+        assert(parsed.ok);
+        const head = parsed.result as { Metadata: {[key: string]: string} | undefined };
+        assert(head.Metadata);
+        assert(head.Metadata[userMDKey]);
+        assert(head.Metadata[userMDKey] === userMDValue);
     });

--- a/tests/ctst/features/azureArchive.feature
+++ b/tests/ctst/features/azureArchive.feature
@@ -100,7 +100,10 @@ Feature: Azure Archive
     Scenario Outline: Restore objects from tar
     Given a "<versioningConfiguration>" bucket
     And a transition workflow to "e2e-azure-archive" location
-    And <objectCount> objects "obj" of size <objectSize> bytes
+    And <objectCount> objects "obj" of size <objectSize> bytes with user metadata "x-amz-meta-123=456"
+    And object "obj-2" should have the user metadata with key "x-amz-meta-123" and value "456"
+    And a tag on object "obj-1" with key "tag1" and value "value1"
+    And a tag on object "obj-2" with key "tag2" and value "value2"
     Then object "obj-1" should be "transitioning" and have the storage class "e2e-azure-archive"
     And object "obj-2" should be "transitioning" and have the storage class "e2e-azure-archive"
     And manifest containing object "obj-1" should "contain" object "obj-2"
@@ -110,10 +113,14 @@ Feature: Azure Archive
     Then object "obj-1" should be "restored" and have the storage class "e2e-azure-archive"
     And object "obj-1" should expire in <restoreDays> days
     And object "obj-1" should have the same data
+    And object "obj-1" should have the tag "tag1" with value "value1"
+    And object "obj-1" should have the user metadata with key "x-amz-meta-123" and value "456"
     When i restore object "obj-2" for <restoreDays> days
     Then object "obj-2" should be "restored" and have the storage class "e2e-azure-archive"
     And object "obj-2" should expire in <restoreDays> days
     And object "obj-2" should have the same data
+    And object "obj-2" should have the tag "tag2" with value "value2"
+    And object "obj-2" should have the user metadata with key "x-amz-meta-123" and value "456"
 
     Examples:
         | versioningConfiguration | objectCount | objectSize | restoreDays |

--- a/tests/ctst/package.json
+++ b/tests/ctst/package.json
@@ -9,11 +9,13 @@
   "private": true,
   "dependencies": {
     "@types/qs": "^6.9.7",
+    "@types/tmp": "^0.2.1",
     "assert": "^2.0.0",
     "aws4-axios": "^2.4.9",
     "node-gyp": "^9.3.1",
     "prometheus-query": "^3.2.0",
-    "qs": "^6.11.1"
+    "qs": "^6.11.1",
+    "tmp": "^0.2.1"
   },
   "devDependencies": {
     "cli-testing": "github:scality/cli-testing.git#0.2.15",

--- a/tests/ctst/yarn.lock
+++ b/tests/ctst/yarn.lock
@@ -1692,6 +1692,11 @@
     "@types/node" "*"
     minipass "^4.0.0"
 
+"@types/tmp@^0.2.1":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.2.3.tgz#908bfb113419fd6a42273674c00994d40902c165"
+  integrity sha512-dDZH/tXzwjutnuk4UacGgFRwV+JSLaXL1ikvidfJprkb7L9Nx1njcRHHmi3Dsvt7pgqqTEeucQuOrWHPFgzVHA==
+
 "@types/tunnel@^0.0.3":
   version "0.0.3"
   resolved "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.3.tgz"


### PR DESCRIPTION
Will need to release Cloudserver when [this pr](https://github.com/scality/cloudserver/pull/5215) is merged and bump the right version, currently using a custom version for testing purpose

Issue: ZENKO-4618