### PR TITLE
ZENKO-4636: fix e2e cold transition dmf tests

### DIFF
--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -6,7 +6,7 @@ backbeat:
   dashboard: backbeat-dashboards
   image: backbeat
   policy: backbeat-policies
-  tag: 8.6.25
+  tag: 8.6.26
   envsubst: BACKBEAT_TAG
 busybox:
   image: busybox
@@ -16,7 +16,7 @@ cloudserver:
   sourceRegistry: registry.scality.com/cloudserver
   dashboard: cloudserver-dashboards
   image: cloudserver
-  tag: 8.7.23
+  tag: 8.7.26
   envsubst: CLOUDSERVER_TAG
 jmx-javaagent:
   sourceRegistry: banzaicloud
@@ -95,7 +95,7 @@ vault:
 zenko-operator:
   sourceRegistry: registry.scality.com/zenko-operator
   image: zenko-operator
-  tag: 1.5.28
+  tag: 1.5.29
   envsubst: ZENKO_OPERATOR_TAG
 zenko-ui:
   sourceRegistry: registry.scality.com/zenko-ui

--- a/tests/zenko_tests/node_tests/backbeat/LifecycleUtility.js
+++ b/tests/zenko_tests/node_tests/backbeat/LifecycleUtility.js
@@ -402,7 +402,7 @@ class LifecycleUtility extends ReplicationUtility {
                 if (err) {
                     return next(err);
                 }
-                shouldContinue = data.StorageClass;
+                shouldContinue = data.Restore && data.Restore.includes('ongoing-request="false", expiry-date=');
                 if (shouldContinue) {
                     return setTimeout(next, 5000);
                 }

--- a/tests/zenko_tests/node_tests/backbeat/tests/lifecycle/transition.js
+++ b/tests/zenko_tests/node_tests/backbeat/tests/lifecycle/transition.js
@@ -87,8 +87,6 @@ const testsToRun = [{
     to: 'DMF',
 }];
 
-const skipIfDMF = to => (to === 'DMF' ? it.skip : it);
-
 testsToRun.forEach(test => {
     // eslint-disable-next-line prefer-arrow-callback
     describe(`Lifecycle transition from ${test.from} to ${test.to}`, function () {
@@ -131,7 +129,7 @@ testsToRun.forEach(test => {
         describe('without versioning', () => {
             beforeEach(done => cloudServer.createBucket(srcBucket, done));
 
-            skipIfDMF(test.to)('should transition a 0 byte object', done => {
+            it('should transition a 0 byte object', done => {
                 const key = `${prefix}nover-0-byte-object`;
                 cloudServer.setKey(key);
                 cloud.setKey(`${srcBucket}/${key}`);


### PR DESCRIPTION
Issue: ZENKO-4636

- Bump Cloudserver, Backbeat & ZKOP
- Adapt E2E restore tests to the new changes in Cloudserver (storage class no longer changing after a transitioned object is restored)