### PR TITLE
Render more mongodb shard templates

### DIFF
--- a/solution-base/build.sh
+++ b/solution-base/build.sh
@@ -37,6 +37,14 @@ MONGODB_SINGLE_NODE_PATH=${ISO_ROOT}/deploy/mongodb-1-node.yaml
 MONGODB_THREE_NODE_PATH=${ISO_ROOT}/deploy/mongodb-3-nodes.yaml
 MONGODB_SHARDED_SINGLE_NODE_PATH=${ISO_ROOT}/deploy/mongodb-sharded-1-node.yaml
 MONGODB_SHARDED_THREE_NODE_PATH=${ISO_ROOT}/deploy/mongodb-sharded-3-nodes.yaml
+MONGODB_SHARDED_THREE_NODE_THREE_SHARDS_PATH=${ISO_ROOT}/deploy/mongodb-sharded-3-nodes-3-shards.yaml
+MONGODB_SHARDED_SIX_NODE_PATH=${ISO_ROOT}/deploy/mongodb-sharded-6-nodes.yaml
+MONGODB_SHARDED_SIX_NODE_THREE_SHARDS_PATH=${ISO_ROOT}/deploy/mongodb-sharded-6-nodes-3-shards.yaml
+MONGODB_SHARDED_SIX_NODE_SIX_SHARDS_PATH=${ISO_ROOT}/deploy/mongodb-sharded-6-nodes-6-shards.yaml
+MONGODB_SHARDED_NINE_NODE_PATH=${ISO_ROOT}/deploy/mongodb-sharded-9-nodes.yaml
+MONGODB_SHARDED_NINE_NODE_THREE_SHARDS_PATH=${ISO_ROOT}/deploy/mongodb-sharded-9-nodes-3-shards.yaml
+MONGODB_SHARDED_NINE_NODE_SIX_SHARDS_PATH=${ISO_ROOT}/deploy/mongodb-sharded-9-nodes-6-shards.yaml
+MONGODB_SHARDED_NINE_NODE_NINE_SHARDS_PATH=${ISO_ROOT}/deploy/mongodb-sharded-9-nodes-9-shards.yaml
 
 SOLUTION_ENV='SOLUTION_ENV'
 
@@ -201,7 +209,15 @@ function render_mongodb_sharded_yamls()
 function mongodb_sharded_yamls()
 {
     render_mongodb_sharded_yamls "${MONGODB_SHARDED_SINGLE_NODE_PATH}" 1 1
-    render_mongodb_sharded_yamls "${MONGODB_SHARDED_THREE_NODE_PATH}" 1 3 
+    render_mongodb_sharded_yamls "${MONGODB_SHARDED_THREE_NODE_PATH}" 1 3
+    render_mongodb_sharded_yamls "${MONGODB_SHARDED_THREE_NODE_THREE_SHARDS_PATH}" 3 3
+    render_mongodb_sharded_yamls "${MONGODB_SHARDED_SIX_NODE_PATH}" 1 6
+    render_mongodb_sharded_yamls "${MONGODB_SHARDED_SIX_NODE_THREE_SHARDS_PATH}" 3 6
+    render_mongodb_sharded_yamls "${MONGODB_SHARDED_SIX_NODE_SIX_SHARDS_PATH}" 6 6
+    render_mongodb_sharded_yamls "${MONGODB_SHARDED_NINE_NODE_PATH}" 1 9
+    render_mongodb_sharded_yamls "${MONGODB_SHARDED_NINE_NODE_THREE_SHARDS_PATH}" 3 9
+    render_mongodb_sharded_yamls "${MONGODB_SHARDED_NINE_NODE_SIX_SHARDS_PATH}" 6 9
+    render_mongodb_sharded_yamls "${MONGODB_SHARDED_NINE_NODE_NINE_SHARDS_PATH}" 9 9
 }
 
 function gen_manifest_yaml()

--- a/solution-base/mongodb/charts/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
+++ b/solution-base/mongodb/charts/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
@@ -375,7 +375,11 @@ spec:
         {{- end }}
         {{- if $.Values.shardsvr.persistence.selector }}
         selector:
-{{ toYaml $.Values.shardsvr.persistence.selector | indent 10 }}
+          matchLabels:
+            {{- if gt $.Values.shards 1 }}
+            shard: {{ $i | quote }}
+            {{- end }}
+{{ toYaml $.Values.shardsvr.persistence.selector.matchLabels | indent 12 }}
         {{- end }}
         resources:
           requests:

--- a/solution-base/mongodb/patches/mongodb-sharded-add-pv-selector.patch
+++ b/solution-base/mongodb/patches/mongodb-sharded-add-pv-selector.patch
@@ -1,29 +1,18 @@
-diff --git a/solution-base/mongodb/charts/mongodb-sharded/templates/config-server/config-server-statefulset.yaml b/solution-base/mongodb/charts/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
-index 6bd5b6cc..02fa0f39 100644
---- a/solution-base/mongodb/charts/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
-+++ b/solution-base/mongodb/charts/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
-@@ -366,6 +366,10 @@ spec:
-         {{- range .Values.configsvr.persistence.accessModes }}
-           - {{ . | quote }}
-         {{- end }}
-+        {{- if .Values.configsvr.persistence.selector }}
-+        selector:
-+{{ toYaml .Values.configsvr.persistence.selector | indent 10 }}
-+        {{- end }}
-         resources:
-           requests:
-             storage: {{ .Values.configsvr.persistence.size | quote }}
 diff --git a/solution-base/mongodb/charts/mongodb-sharded/templates/shard/shard-data-statefulset.yaml b/solution-base/mongodb/charts/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
-index 2dc362b4..6e29ad65 100644
+index c24aaf5d..5c448f35 100644
 --- a/solution-base/mongodb/charts/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
 +++ b/solution-base/mongodb/charts/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
-@@ -373,6 +373,10 @@ spec:
+@@ -372,6 +373,14 @@ spec:
          {{- range $.Values.shardsvr.persistence.accessModes }}
            - {{ . | quote }}
          {{- end }}
 +        {{- if $.Values.shardsvr.persistence.selector }}
 +        selector:
-+{{ toYaml $.Values.shardsvr.persistence.selector | indent 10 }}
++          matchLabels:
++            {{- if gt $.Values.shards 1 }}
++            shard: {{ $i | quote }}
++            {{- end }}
++{{ toYaml $.Values.shardsvr.persistence.selector.matchLabels | indent 12 }}
 +        {{- end }}
          resources:
            requests:


### PR DESCRIPTION
Render more mongodb shard templates.

Note that 1-shard template does not currently use a volume selector to stay compatible with existing deployments.