### PR TITLE
Do not store kafka log files in container

### DIFF
--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -260,6 +260,7 @@ jobs:
           KAFKA_CONNECT_TAG=$(yq eval '.kafka-connect.tag' deps.yaml)
           JMX_JAVAAGENT_IMAGE=$(get_image_from_deps jmx-javaagent)
           JMX_JAVAAGENT_TAG=$(yq eval '.jmx-javaagent.tag' deps.yaml)
+          MONGODB_CONNECTOR_TAG=$(yq eval '.mongodb-connector.tag' deps.yaml)
           EOF
 
       - name: Check kafka & kafka-connect versions match
@@ -288,6 +289,7 @@ jobs:
             JMX_JAVAAGENT_TAG=${{ env.JMX_JAVAAGENT_TAG }}
             KAFKA_IMAGE=${{ env.KAFKA_IMAGE }}
             KAFKA_TAG=${{ env.KAFKA_TAG }}
+            MONGODB_CONNECTOR_TAG=${{ env.MONGODB_CONNECTOR_TAG }}
           tags: "${{ env.KAFKA_CONNECT_IMAGE }}:${{ env.KAFKA_CONNECT_TAG }}"
           cache-from: type=gha,scope=$GITHUB_REF_NAME-kafka-connect
           cache-to: type=gha,mode=max,scope=$GITHUB_REF_NAME-kafka-connect

--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -265,7 +265,7 @@ jobs:
 
       - name: Check kafka & kafka-connect versions match
         run: |-
-          [ "${{ env.KAFKA_TAG }}" = "${{ env.KAFKA_CONNECT_TAG }}" ]
+          [ "${{ env.KAFKA_TAG }}-${{ env.MONGODB_CONNECTOR_TAG }}" = "${{ env.KAFKA_CONNECT_TAG }}" ]
 
       - name: Build and push kafka
         uses: docker/build-push-action@v4

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -31,7 +31,7 @@ kafka:
 kafka-connect:
   sourceRegistry: registry.scality.com/zenko
   image: kafka-connect
-  tag: 2.13-3.1.2
+  tag: 2.13-3.1.2-1.10.1
   envsubst: KAFKA_CONNECT_TAG
 mongodb-connector:
   tag: 1.10.1

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -33,6 +33,9 @@ kafka-connect:
   image: kafka-connect
   tag: 2.13-3.1.2
   envsubst: KAFKA_CONNECT_TAG
+mongodb-connector:
+  tag: 1.10.0
+  envsubst: MONGODB_CONNECTOR_TAG
 kafka-cruise-control:
   sourceRegistry: ghcr.io/banzaicloud
   image: cruise-control

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -34,7 +34,7 @@ kafka-connect:
   tag: 2.13-3.1.2
   envsubst: KAFKA_CONNECT_TAG
 mongodb-connector:
-  tag: 1.10.0
+  tag: 1.10.1
   envsubst: MONGODB_CONNECTOR_TAG
 kafka-cruise-control:
   sourceRegistry: ghcr.io/banzaicloud

--- a/solution/kafka-connect/Dockerfile
+++ b/solution/kafka-connect/Dockerfile
@@ -24,6 +24,8 @@ ARG JMX_JAVAAGENT_TAG
 COPY kafka-connect.yaml /etc/jmx-exporter/config.yaml
 COPY --from=jmx-exporter /opt/jmx_exporter/jmx_prometheus_javaagent-${JMX_JAVAAGENT_TAG}.jar \
      /opt/jmx-exporter/jmx_prometheus.jar
+
+COPY connect-log4j.properties ${KAFKA_HOME}/config/
 ENV KAFKA_OPTS=-javaagent:/opt/jmx-exporter/jmx_prometheus.jar=9020:/etc/jmx-exporter/config.yaml
 
 # mongodb ingestor

--- a/solution/kafka-connect/Dockerfile
+++ b/solution/kafka-connect/Dockerfile
@@ -12,10 +12,10 @@ FROM ${JMX_JAVAAGENT_IMAGE}:${JMX_JAVAAGENT_TAG} AS jmx-exporter
 FROM library/alpine:3.15 AS mongodb-connector
 RUN apk update && apk upgrade && apk add --no-cache curl zip
 
-ARG MONGODB_CONNECTOR_VERSION=1.10.0
+ARG MONGODB_CONNECTOR_TAG
 WORKDIR /tmp
-RUN curl -LO https://repo1.maven.org/maven2/org/mongodb/kafka/mongo-kafka-connect/${MONGODB_CONNECTOR_VERSION}/mongo-kafka-connect-${MONGODB_CONNECTOR_VERSION}-all.jar && \
-    mv /tmp/mongo-kafka-connect-${MONGODB_CONNECTOR_VERSION}-all.jar /tmp/mongo-kafka-connect.jar
+RUN curl -LO https://repo1.maven.org/maven2/org/mongodb/kafka/mongo-kafka-connect/${MONGODB_CONNECTOR_TAG}/mongo-kafka-connect-${MONGODB_CONNECTOR_TAG}-all.jar && \
+    mv /tmp/mongo-kafka-connect-${MONGODB_CONNECTOR_TAG}-all.jar /tmp/mongo-kafka-connect.jar
 
 # Use Kafka base image
 FROM ${KAFKA_IMAGE}:${KAFKA_TAG}

--- a/solution/kafka-connect/connect-log4j.properties
+++ b/solution/kafka-connect/connect-log4j.properties
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+ 
+log4j.rootLogger=INFO, stdout
+
+# Send the logs to the console.
+#
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+
+# Send the logs to a file, rolling the file at midnight local time. For example, the `File` option specifies the
+# location of the log files (e.g. ${kafka.logs.dir}/connect.log), and at midnight local time the file is closed
+# and copied in the same directory but with a filename that ends in the `DatePattern` option.
+#
+# log4j.appender.connectAppender=org.apache.log4j.DailyRollingFileAppender
+# log4j.appender.connectAppender.DatePattern='.'yyyy-MM-dd-HH
+# log4j.appender.connectAppender.File=${kafka.logs.dir}/connect.log
+# log4j.appender.connectAppender.layout=org.apache.log4j.PatternLayout
+
+# The `%X{connector.context}` parameter in the layout includes connector-specific and task-specific information
+# in the log messages, where appropriate. This makes it easier to identify those log messages that apply to a
+# specific connector.
+#
+connect.log.pattern=[%d] %p %X{connector.context}%m (%c:%L)%n
+
+log4j.appender.stdout.layout.ConversionPattern=${connect.log.pattern}
+# log4j.appender.connectAppender.layout.ConversionPattern=${connect.log.pattern}
+
+log4j.logger.org.apache.zookeeper=ERROR
+log4j.logger.org.reflections=ERROR

--- a/solution/kafka/Dockerfile
+++ b/solution/kafka/Dockerfile
@@ -36,6 +36,7 @@ ENV PATH=${PATH}:${KAFKA_HOME}/bin
 RUN mkdir ${KAFKA_HOME} && apt-get update && apt-get install curl -y && apt-get clean
 
 COPY --from=kafka_dist /var/tmp/kafka_$scala_version-$kafka_version ${KAFKA_HOME}
+COPY log4j.properties ${KAFKA_HOME}/config/
 
 RUN chmod a+x ${KAFKA_HOME}/bin/*.sh
 

--- a/solution/kafka/Dockerfile
+++ b/solution/kafka/Dockerfile
@@ -29,7 +29,8 @@ ARG kafka_version=3.1.0
 
 ENV KAFKA_VERSION=$kafka_version \
     SCALA_VERSION=$scala_version \
-    KAFKA_HOME=/opt/kafka
+    KAFKA_HOME=/opt/kafka \
+    KAFKA_GC_LOG_OPTS=-Dnogclog
 
 ENV PATH=${PATH}:${KAFKA_HOME}/bin
 

--- a/solution/kafka/log4j.properties
+++ b/solution/kafka/log4j.properties
@@ -1,0 +1,91 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Unspecified loggers and loggers with additivity=true output to server.log and stdout
+# Note that INFO only applies to unspecified loggers, the log level of the child logger is used otherwise
+log4j.rootLogger=INFO, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+# log4j.appender.kafkaAppender=org.apache.log4j.DailyRollingFileAppender
+# log4j.appender.kafkaAppender.DatePattern='.'yyyy-MM-dd-HH
+# log4j.appender.kafkaAppender.File=${kafka.logs.dir}/server.log
+# log4j.appender.kafkaAppender.layout=org.apache.log4j.PatternLayout
+# log4j.appender.kafkaAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+# log4j.appender.stateChangeAppender=org.apache.log4j.DailyRollingFileAppender
+# log4j.appender.stateChangeAppender.DatePattern='.'yyyy-MM-dd-HH
+# log4j.appender.stateChangeAppender.File=${kafka.logs.dir}/state-change.log
+# log4j.appender.stateChangeAppender.layout=org.apache.log4j.PatternLayout
+# log4j.appender.stateChangeAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+# log4j.appender.requestAppender=org.apache.log4j.DailyRollingFileAppender
+# log4j.appender.requestAppender.DatePattern='.'yyyy-MM-dd-HH
+# log4j.appender.requestAppender.File=${kafka.logs.dir}/kafka-request.log
+# log4j.appender.requestAppender.layout=org.apache.log4j.PatternLayout
+# log4j.appender.requestAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+# log4j.appender.cleanerAppender=org.apache.log4j.DailyRollingFileAppender
+# log4j.appender.cleanerAppender.DatePattern='.'yyyy-MM-dd-HH
+# log4j.appender.cleanerAppender.File=${kafka.logs.dir}/log-cleaner.log
+# log4j.appender.cleanerAppender.layout=org.apache.log4j.PatternLayout
+# log4j.appender.cleanerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+# log4j.appender.controllerAppender=org.apache.log4j.DailyRollingFileAppender
+# log4j.appender.controllerAppender.DatePattern='.'yyyy-MM-dd-HH
+# log4j.appender.controllerAppender.File=${kafka.logs.dir}/controller.log
+# log4j.appender.controllerAppender.layout=org.apache.log4j.PatternLayout
+# log4j.appender.controllerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+# log4j.appender.authorizerAppender=org.apache.log4j.DailyRollingFileAppender
+# log4j.appender.authorizerAppender.DatePattern='.'yyyy-MM-dd-HH
+# log4j.appender.authorizerAppender.File=${kafka.logs.dir}/kafka-authorizer.log
+# log4j.appender.authorizerAppender.layout=org.apache.log4j.PatternLayout
+# log4j.appender.authorizerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+# Change the line below to adjust ZK client logging
+log4j.logger.org.apache.zookeeper=INFO
+
+# Change the two lines below to adjust the general broker logging level (output to server.log and stdout)
+log4j.logger.kafka=INFO
+log4j.logger.org.apache.kafka=INFO
+
+# Change to DEBUG or TRACE to enable request logging
+log4j.logger.kafka.request.logger=WARN, stdout
+log4j.additivity.kafka.request.logger=false
+
+# Uncomment the lines below and change log4j.logger.kafka.network.RequestChannel$ to TRACE for additional output
+# related to the handling of requests
+#log4j.logger.kafka.network.Processor=TRACE, requestAppender
+#log4j.logger.kafka.server.KafkaApis=TRACE, requestAppender
+#log4j.additivity.kafka.server.KafkaApis=false
+log4j.logger.kafka.network.RequestChannel$=WARN, stdout
+log4j.additivity.kafka.network.RequestChannel$=false
+
+log4j.logger.kafka.controller=TRACE, stdout
+log4j.additivity.kafka.controller=false
+
+log4j.logger.kafka.log.LogCleaner=INFO, stdout
+log4j.additivity.kafka.log.LogCleaner=false
+
+log4j.logger.state.change.logger=INFO, stdout
+log4j.additivity.state.change.logger=false
+
+# Access denials are logged at INFO level, change to DEBUG to also log allowed accesses
+log4j.logger.kafka.authorizer.logger=INFO, stdout
+log4j.additivity.kafka.authorizer.logger=false
+


### PR DESCRIPTION
By default, the kafka image is setup to store logs in rotated files in /opt/kafka/logs.
Since we are using kubernetes and do not have a log volume, this is not really relevant;
and can occasionally crash the whole system if kafka (or kafka-connect) starts logging
errors repeatedly.

- Remove in-container file logging from kafka
- Move MONGODB connection versoin to deps.yaml
- Upgrade mongodb connector to 1.10.1
- Add mongodb connector tag to kafka-connect image
- Disable kafka's GC log

Issue: ZENKO-4640
