### PR TITLE
ZENKO-4656: bump zenko-ui deps to 1.6.17

### DIFF
--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -100,7 +100,7 @@ zenko-operator:
 zenko-ui:
   sourceRegistry: registry.scality.com/zenko-ui
   image: zenko-ui
-  tag: 1.6.16
+  tag: 1.6.17
   envsubst: ZENKO_UI_TAG
 zookeeper:
   sourceRegistry: pravega


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
bump zenko-ui deps to 1.6.17

**Which issue does this PR fix?**

fixes #<ISSUE>

**Special notes for your reviewers**:
