### PR TITLE
Bugfix/zenko 4624 fix invalid namespace in sharded tests

### DIFF
--- a/tests/zenko_tests/node_tests/backbeat/tests/lifecycle/expiration.js
+++ b/tests/zenko_tests/node_tests/backbeat/tests/lifecycle/expiration.js
@@ -5,7 +5,7 @@ const { scalityS3Client } = require('../../../s3SDK');
 const LifecycleUtlity = require('../../LifecycleUtility');
 
 const utils = new LifecycleUtlity(scalityS3Client);
-const getBucketName = prefix => `${prefix}${uuid.v4()}`;
+const getBucketName = prefix => `${prefix}${uuid.v4().slice(0, 5)}`;
 const getObjectKey = prefix => `${prefix}${uuid.v4()}`;
 const getObjectKeys = (prefix, count) => Array.from(Array(count)).map((_, n) => getObjectKey(`${prefix}${n}-`));
 

--- a/tests/zenko_tests/node_tests/backbeat/tests/lifecycle/transition.js
+++ b/tests/zenko_tests/node_tests/backbeat/tests/lifecycle/transition.js
@@ -90,7 +90,7 @@ const testsToRun = [{
 testsToRun.forEach(test => {
     // eslint-disable-next-line prefer-arrow-callback
     describe(`Lifecycle transition from ${test.from} to ${test.to}`, function () {
-        const srcBucket = `transition-bucket-${uuid()}`;
+        const srcBucket = `transition-bucket-${uuid().slice(0, 5)}`;
         const keyPrefix = uuid();
         const cloudServer = new LifecycleUtility(scalityS3Client)
             .setBucket(srcBucket)


### PR DESCRIPTION
Slice UUID size to have a smaller name for buckets, because db name + bucket name with a full uuid is too large for mongodb