### PR TITLE
ZENKO-4728: Fix lifecycle transition tests, dates must be midnight.

### DIFF
--- a/tests/zenko_tests/node_tests/backbeat/tests/lifecycle/expiration.js
+++ b/tests/zenko_tests/node_tests/backbeat/tests/lifecycle/expiration.js
@@ -39,8 +39,6 @@ const getExpirationObject = (id, expiration, prefix, tag, enabled) => ({
     Expiration: expiration,
 });
 
-const oneDay = 1000 * 60 * 60 * 24;
-
 const expireDayRule = (prefix, tag, enabled) => getExpirationObject(
     'day expiration',
     { Days: 1 },
@@ -59,7 +57,7 @@ const longExpireDayRule = (prefix, tag, enabled) => getExpirationObject(
 
 const expireDateRule = (prefix, tag, enabled) => getExpirationObject(
     'date expiration',
-    { Date: new Date() },
+    { Date: new Date(new Date().setUTCHours(0, 0, 0, 0)) }, // today at midnight UTC
     prefix,
     tag,
     enabled,
@@ -67,7 +65,7 @@ const expireDateRule = (prefix, tag, enabled) => getExpirationObject(
 
 const longExpireDateRule = (prefix, tag, enabled) => getExpirationObject(
     'date expiration',
-    { Date: new Date(Date.now() + oneDay) },
+    { Date: new Date(new Date().setUTCHours(24, 0, 0, 0)) }, // tomorrow at midnight UTC
     prefix,
     tag,
     enabled,

--- a/tests/zenko_tests/node_tests/backbeat/tests/lifecycle/transition.js
+++ b/tests/zenko_tests/node_tests/backbeat/tests/lifecycle/transition.js
@@ -8,7 +8,7 @@ const LifecycleUtility = require('../../LifecycleUtility');
 function compareTransitionedData(sourceClient, destinationClient, versionId, cb) {
     return series([
         next => sourceClient.getObject(versionId, next),
-        next => sourceClient.putBucketLifecycleConfiguration(new Date(), next),
+        next => sourceClient.putBucketLifecycleConfiguration(new Date(new Date().setUTCHours(0, 0, 0, 0)), next),
         next => sourceClient.waitUntilTransitioned(versionId, next),
         next => destinationClient.getObjectDataFromLocation(next),
         next => sourceClient.getObject(versionId, next),
@@ -27,7 +27,7 @@ function compareTransitionedData(sourceClient, destinationClient, versionId, cb)
 function compareTransitionedColdData(sourceClient, versionId, cb) {
     return series([
         next => sourceClient.getObject(versionId, next),
-        next => sourceClient.putBucketLifecycleConfiguration(new Date(), next),
+        next => sourceClient.putBucketLifecycleConfiguration(new Date(new Date().setUTCHours(0, 0, 0, 0)), next),
         next => sourceClient.waitUntilTransitioned(versionId, next),
     ], cb);
 }


### PR DESCRIPTION
[S3C-8320](https://scality.atlassian.net/browse/S3C-8320) has changed the spec for lifecycle configuration dates, they must be set to midnight as per the AWS spec. 

This ticket is for aligning the tests with this new condition.

[S3C-8320]: https://scality.atlassian.net/browse/S3C-8320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ