### PR TITLE
Migrate to ghcr

### DIFF
--- a/.github/actions/deploy/action.yaml
+++ b/.github/actions/deploy/action.yaml
@@ -20,7 +20,7 @@ runs:
       run: bash create-pull-image-secret.sh
       working-directory: ./.github/scripts/end2end
     - name: Cache Helm repositories and charts
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cache/helm

--- a/.github/actions/install-doc-dependencies/action.yaml
+++ b/.github/actions/install-doc-dependencies/action.yaml
@@ -6,7 +6,7 @@ runs:
   steps:
     - name: Cache deb packages
       id: cache-deb
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/deb_cache
         key: ${{ runner.os }}-deb-${{ hashFiles('.github/actions/install-doc-dependencies/action.yaml') }}

--- a/.github/actions/install-end2end-dependencies/action.yaml
+++ b/.github/actions/install-end2end-dependencies/action.yaml
@@ -6,7 +6,7 @@ runs:
   steps:
     - name: Cache deb packages
       id: cache-deb
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/deb_cache
         key: ${{ runner.os }}-deb-${{ hashFiles('.github/actions/install-end2end-dependencies/action.yaml') }}
@@ -14,7 +14,7 @@ runs:
           ${{ runner.os }}-deb-
     - name: Cache binaries
       id: cache-binaries
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: /usr/local/bin
         key: ${{ runner.os }}-binaries-${{ hashFiles('.github/actions/install-end2end-dependencies/action.yaml') }}
@@ -77,6 +77,6 @@ runs:
           sudo curl -sSL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${{ env.KUSTOMIZE_VERSION }}/kustomize_${{ env.KUSTOMIZE_VERSION }}_linux_amd64.tar.gz | sudo tar -xvz
           sudo install kustomize /usr/local/bin
     - name: Kubectl tool installer
-      uses: Azure/setup-kubectl@v3
+      uses: Azure/setup-kubectl@v4
       with:
         version: 'v${{ env.KUBECTL_VERSION }}'

--- a/.github/scripts/end2end/configure-e2e.sh
+++ b/.github/scripts/end2end/configure-e2e.sh
@@ -5,7 +5,7 @@ set -exu
 . "$(dirname $0)/common.sh"
 
 ZENKO_NAME=${1:-end2end}
-E2E_IMAGE=${2:-registry.scality.com/zenko/zenko-e2e:latest}
+E2E_IMAGE=${2:-ghcr.io/scality/zenko/zenko-e2e:latest}
 NAMESPACE=${3:-default}
 
 SERVICE_ACCOUNT="${ZENKO_NAME}-config"

--- a/.github/scripts/end2end/deploy-shell-ui.sh
+++ b/.github/scripts/end2end/deploy-shell-ui.sh
@@ -4,7 +4,7 @@ set -exu
 
 NS=''
 
-SHELL_UI_IMAGE=${SHELL_UI_IMAGE:-registry.scality.com/playground/jbwatenberg/shell-ui:2.9-dev}
+SHELL_UI_IMAGE=${SHELL_UI_IMAGE:-ghcr.io/scality/metalk8s/shell-ui:v127.0.0}
 
 cat <<EOF | kubectl apply ${NS} -f -
 apiVersion: apps/v1

--- a/.github/scripts/end2end/run-e2e-test.sh
+++ b/.github/scripts/end2end/run-e2e-test.sh
@@ -7,7 +7,7 @@ DIR=$(dirname $0)
 . "$DIR/common.sh"
 
 ZENKO_NAME=${1:-end2end}
-E2E_IMAGE=${2:-registry.scality.com/zenko/zenko-e2e:latest}
+E2E_IMAGE=${2:-ghcr.io/scality/zenko/zenko-e2e:latest}
 STAGE=${3:-end2end}
 NAMESPACE=${4:-default}
 

--- a/.github/scripts/end2end/vault-e2e-test.sh
+++ b/.github/scripts/end2end/vault-e2e-test.sh
@@ -25,8 +25,8 @@ REDIS_TEST_HOST="${ZENKO_RESOURCE}-base-cache"
 REDIS_TEST_PORT="6379"
 REDIS_TEST_PASSWORD=$(kubectl get secret $ZENKO_RESOURCE-base-cache-creds.v1 -n $NAMESPACE -o jsonpath='{.data.password}' | base64 -d)
 ZENKO_VERSION=$(kubectl get zenko $ZENKO_RESOURCE -n $NAMESPACE -o jsonpath='{.spec.version}')
-VAULT_TEST_TAG=$(kubectl get zenkoversion $ZENKO_VERSION  -n $NAMESPACE -o jsonpath='{.spec.versions.vault.tag}')
-VAULT_TEST_IMAGE="registry.scality.com/vault/vault-test"
+VAULT_TEST_TAG=$(kubectl get zenkoversion $ZENKO_VERSION  -n $NAMESPACE -o jsonpath='{.spec.versions.vault.tag}')-test
+VAULT_TEST_IMAGE="ghcr.io/scality/vault2"
 KEYCLOAK_TEST_USER="${OIDC_USERNAME}-norights"
 KEYCLOAK_TEST_PASSWORD=${OIDC_PASSWORD}
 KEYCLOAK_TEST_HOST=${OIDC_ENDPOINT}

--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -198,13 +198,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Login to Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: "${{ github.repository_owner }}"
           password: "${{ github.token }}"
           registry: ghcr.io
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: "${{ secrets.DOCKERHUB_LOGIN }}"
           password: "${{ secrets.DOCKERHUB_PASSWORD }}"
@@ -555,7 +555,7 @@ jobs:
       - name: Wait for Docker daemon to be ready
         uses: ./.github/actions/wait-docker-ready
       - name: Kubectl tool installer
-        uses: Azure/setup-kubectl@v3
+        uses: Azure/setup-kubectl@v4
       - name: Login to Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -25,7 +25,7 @@ env:
   OIDC_FIRST_NAME: 'hello'
   OIDC_LAST_NAME: 'world'
   SHELL_UI_NAME: "shell-ui"
-  SHELL_UI_IMAGE: "registry.scality.com/sf-eng/shell-ui:2.9-dev"
+  SHELL_UI_IMAGE: "ghcr.io/scality/metalk8s/shell-ui:v127.0.0"
   HTTP_PROXY: ""
   HTTPS_PROXY: ""
   BACKBEAT_BUCKET_CHECK_TIMEOUT_S: ""
@@ -559,9 +559,9 @@ jobs:
       - name: Login to Registry
         uses: docker/login-action@v3
         with:
-          username: "${{ secrets.REGISTRY_LOGIN }}"
-          password: "${{ secrets.REGISTRY_PASSWORD }}"
-          registry: registry.scality.com
+          username: "${{ github.repository_owner }}"
+          password: "${{ github.token }}"
+          registry: ghcr.io
       - name: Deploy Zenko
         uses: ./.github/actions/deploy
         env:

--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -31,8 +31,8 @@ env:
   BACKBEAT_BUCKET_CHECK_TIMEOUT_S: ""
   BACKBEAT_LCC_CRON_RULE: ""
   # e2e-env
-  E2E_IMAGE_NAME: registry.scality.com/zenko/zenko-e2e
-  E2E_CTST_IMAGE_NAME: registry.scality.com/zenko/zenko-e2e-ctst
+  E2E_IMAGE_NAME: ghcr.io/scality/zenko/zenko-e2e
+  E2E_CTST_IMAGE_NAME: ghcr.io/scality/zenko/zenko-e2e-ctst
   E2E_IMAGE_TAG: ${{ github.sha }}
   VAULT_TEST_IMAGE_NAME: ""
   VAULT_TEST_IMAGE_TAG: ""
@@ -200,20 +200,14 @@ jobs:
       - name: Login to Registry
         uses: docker/login-action@v2
         with:
-          username: "${{ secrets.REGISTRY_LOGIN }}"
-          password: "${{ secrets.REGISTRY_PASSWORD }}"
-          registry: registry.scality.com
+          username: "${{ github.repository_owner }}"
+          password: "${{ github.token }}"
+          registry: ghcr.io
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: "${{ secrets.DOCKERHUB_LOGIN }}"
           password: "${{ secrets.DOCKERHUB_PASSWORD }}"
-      - name: Login to OCI Registry
-        uses: docker/login-action@v2
-        with:
-          username: "${{ secrets.SCALITY_OCI_RW_USER }}"
-          password: "${{ secrets.SCALITY_OCI_RW_PASSWORD }}"
-          registry: registry.scality.com
       - name: Configure GIT
         run: git config --global url."https://${GIT_ACCESS_TOKEN}@github.com/".insteadOf "https://github.com/"
         env:
@@ -253,9 +247,9 @@ jobs:
       - name: Login to Registry
         uses: docker/login-action@v3
         with:
-          username: "${{ secrets.REGISTRY_LOGIN }}"
-          password: "${{ secrets.REGISTRY_PASSWORD }}"
-          registry: registry.scality.com
+          username: "${{ github.repository_owner }}"
+          password: "${{ github.token }}"
+          registry: ghcr.io
 
       - name: Extract environment
         run: |-
@@ -321,9 +315,9 @@ jobs:
       - name: Login to Registry
         uses: docker/login-action@v3
         with:
-          username: "${{ secrets.REGISTRY_LOGIN }}"
-          password: "${{ secrets.REGISTRY_PASSWORD }}"
-          registry: registry.scality.com
+          username: "${{ github.repository_owner }}"
+          password: "${{ github.token }}"
+          registry: ghcr.io
       - name: Generate end2end config yaml
         run: |-
           cd tests/zenko_tests
@@ -339,8 +333,8 @@ jobs:
           push: true
           context: ./tests/zenko_tests
           tags: "${{ env.E2E_IMAGE_NAME }}:${{ env.E2E_IMAGE_TAG }}"
-          cache-from: type=gha,scope=$GITHUB_REF_NAME-test
-          cache-to: type=gha,mode=max,scope=$GITHUB_REF_NAME-test
+          cache-from: type=gha,scope=end2end-test
+          cache-to: type=gha,mode=max,scope=end2end-test
 
   lint-and-build-ctst:
     runs-on: ubuntu-20.04
@@ -372,9 +366,9 @@ jobs:
       - name: Login to Registry
         uses: docker/login-action@v3
         with:
-          username: "${{ secrets.REGISTRY_LOGIN }}"
-          password: "${{ secrets.REGISTRY_PASSWORD }}"
-          registry: registry.scality.com
+          username: "${{ github.repository_owner }}"
+          password: "${{ github.token }}"
+          registry: ghcr.io
       - name: Get CTST image tag
         shell: bash
         run: |-
@@ -386,8 +380,8 @@ jobs:
           context: ./tests/ctst
           build-args: CTST_TAG=${{ env.CTST_TAG }}
           tags: "${{ env.E2E_CTST_IMAGE_NAME }}:${{ env.E2E_IMAGE_TAG }}"
-          cache-from: type=gha,scope=$GITHUB_REF_NAME-ctst
-          cache-to: type=gha,mode=max,scope=$GITHUB_REF_NAME-ctst
+          cache-from: type=gha,scope=end2end-ctst
+          cache-to: type=gha,mode=max,scope=end2end-ctst
 
   end2end-http:
     needs: [build-kafka, build-test-image, check-dashboard-versions]
@@ -405,9 +399,9 @@ jobs:
       - name: Login to Registry
         uses: docker/login-action@v3
         with:
-          username: "${{ secrets.REGISTRY_LOGIN }}"
-          password: "${{ secrets.REGISTRY_PASSWORD }}"
-          registry: registry.scality.com
+          username: "${{ github.repository_owner }}"
+          password: "${{ github.token }}"
+          registry: ghcr.io
       - name: Deploy Zenko
         uses: ./.github/actions/deploy
         env:
@@ -466,9 +460,9 @@ jobs:
       - name: Login to Registry
         uses: docker/login-action@v3
         with:
-          username: "${{ secrets.REGISTRY_LOGIN }}"
-          password: "${{ secrets.REGISTRY_PASSWORD }}"
-          registry: registry.scality.com
+          username: "${{ github.repository_owner }}"
+          password: "${{ github.token }}"
+          registry: ghcr.io
       - name: Deploy Zenko
         uses: ./.github/actions/deploy
       - name: Run init CI test
@@ -518,9 +512,9 @@ jobs:
       - name: Login to Registry
         uses: docker/login-action@v3
         with:
-          username: "${{ secrets.REGISTRY_LOGIN }}"
-          password: "${{ secrets.REGISTRY_PASSWORD }}"
-          registry: registry.scality.com
+          username: "${{ github.repository_owner }}"
+          password: "${{ github.token }}"
+          registry: ghcr.io
       - name: Deploy Zenko
         uses: ./.github/actions/deploy
         env:

--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -197,21 +197,23 @@ jobs:
             sudo PATH="/usr/local/go/bin:$PATH" DISABLE_DOCS=1 make install
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Wait for Docker daemon to be ready
-        uses: ./.github/actions/wait-docker-ready
-      - name: Docker login
-        run: |-
-          docker login --username "${REGISTRY_LOGIN}" --password "${REGISTRY_PASSWORD}" ${REGISTRY}
-          docker login --username "${DOCKERHUB_LOGIN}" --password "${DOCKERHUB_PASSWORD}"
-          docker login --username "${SCALITY_OCI_RW_USER}" --password "${SCALITY_OCI_RW_PASSWORD}" ${REGISTRY}
-        env:
-          REGISTRY_LOGIN: ${{ secrets.REGISTRY_LOGIN }}
-          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
-          DOCKERHUB_LOGIN: ${{ secrets.DOCKERHUB_LOGIN }}
-          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-          REGISTRY: "registry.scality.com"
-          SCALITY_OCI_RW_USER: ${{ secrets.SCALITY_OCI_RW_USER }}
-          SCALITY_OCI_RW_PASSWORD: ${{ secrets.SCALITY_OCI_RW_PASSWORD }}
+      - name: Login to Registry
+        uses: docker/login-action@v2
+        with:
+          username: "${{ secrets.REGISTRY_LOGIN }}"
+          password: "${{ secrets.REGISTRY_PASSWORD }}"
+          registry: registry.scality.com
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: "${{ secrets.DOCKERHUB_LOGIN }}"
+          password: "${{ secrets.DOCKERHUB_PASSWORD }}"
+      - name: Login to OCI Registry
+        uses: docker/login-action@v2
+        with:
+          username: "${{ secrets.SCALITY_OCI_RW_USER }}"
+          password: "${{ secrets.SCALITY_OCI_RW_PASSWORD }}"
+          registry: registry.scality.com
       - name: Configure GIT
         run: git config --global url."https://${GIT_ACCESS_TOKEN}@github.com/".insteadOf "https://github.com/"
         env:

--- a/solution/build.sh
+++ b/solution/build.sh
@@ -259,7 +259,7 @@ function build_registry_config()
         --mount type=bind,source=${ISO_ROOT}/images,destination=/var/lib/images \
         --mount type=bind,source=${ISO_ROOT},destination=/var/run \
         --rm \
-        registry.scality.com/static-container-registry/static-container-registry:1.0.0 \
+        ghcr.io/scality/static-container-registry:1.0.0 \
             python3 static_container_registry.py \
             --name-prefix '{{ repository }}' \
             --server-root '{{ registry_root }}' \

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -24,7 +24,7 @@ jmx-javaagent:
   tag: 0.14.0
   envsubst: JMX_JAVAAGENT_TAG
 kafka:
-  sourceRegistry: registry.scality.com/zenko
+  sourceRegistry: ghcr.io/scality/zenko
   image: kafka
   tag: 2.13-3.1.2
   envsubst: KAFKA_TAG
@@ -35,7 +35,7 @@ kafka-cleaner:
   tag: v1.0.2
   envsubst: KAFKA_CLEANER_TAG
 kafka-connect:
-  sourceRegistry: registry.scality.com/zenko
+  sourceRegistry: ghcr.io/scality/zenko
   image: kafka-connect
   tag: 2.13-3.1.2-1.10.1
   envsubst: KAFKA_CONNECT_TAG

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -108,7 +108,7 @@ zenko-operator:
   tag: 1.5.44
   envsubst: ZENKO_OPERATOR_TAG
 zenko-ui:
-  sourceRegistry: registry.scality.com/zenko-ui
+  sourceRegistry: ghcr.io/scality
   image: zenko-ui
   tag: 1.6.16
   envsubst: ZENKO_UI_TAG

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -77,8 +77,8 @@ redis_exporter:
   tag: v1.43.1
   envsubst: REDIS_EXPORTER_TAG
 s3utils:
-  sourceRegistry: registry.scality.com/s3utils
-  dashboard: s3utils-dashboards
+  sourceRegistry: ghcr.io/scality
+  dashboard: s3utils/s3utils-dashboards
   image: s3utils
   tag: 1.14.5
   envsubst: S3UTILS_TAG

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -103,7 +103,7 @@ vault:
   tag: 8.7.12
   envsubst: VAULT_TAG
 zenko-operator:
-  sourceRegistry: registry.scality.com/zenko-operator
+  sourceRegistry: ghcr.io/scality
   image: zenko-operator
   tag: 1.5.44
   envsubst: ZENKO_OPERATOR_TAG

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -2,10 +2,10 @@
 # to sort keys, use the following command
 # yq eval 'sortKeys(.)' -i deps.yaml
 backbeat:
-  sourceRegistry: registry.scality.com/backbeat
-  dashboard: backbeat-dashboards
+  sourceRegistry: ghcr.io/scality
+  dashboard: backbeat/backbeat-dashboards
   image: backbeat
-  policy: backbeat-policies
+  policy: backbeat/backbeat-policies
   tag: 8.6.41
   envsubst: BACKBEAT_TAG
 busybox:

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -91,7 +91,7 @@ sorbet:
   envsubst: SORBET_TAG
 # To be enabled back when utapi is used in Zenko 2.x
 # utapi:
-#   sourceRegistry: registry.scality.com/sf-eng
+#   sourceRegistry: ghcr.io/scality
 #   image: utapi
 #   tag: zenko-1.0.0
 #   envsubst: UTAPI_TAG

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -83,8 +83,8 @@ s3utils:
   tag: 1.14.5
   envsubst: S3UTILS_TAG
 sorbet:
-  sourceRegistry: registry.scality.com/sorbet
-  policy: sorbet-policies
+  sourceRegistry: ghcr.io/scality
+  policy: sorbet/sorbet-policies
   image: sorbet
   tag: v1.1.9
   envsubst: SORBET_TAG

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -53,7 +53,7 @@ kafka-lag-exporter:
   tag: 0.7.1
   envsubst: KAFKA_LAGEXPORTER_TAG
 pensieve-api:
-  sourceRegistry: registry.scality.com/pensieve-api
+  sourceRegistry: ghcr.io/scality
   image: pensieve-api
   tag: 1.4.10
   envsubst: PENSIEVE_API_TAG

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -96,10 +96,10 @@ sorbet:
 #   tag: zenko-1.0.0
 #   envsubst: UTAPI_TAG
 vault:
-  sourceRegistry: registry.scality.com/vault
-  dashboard: vault-dashboards
-  policy: vault-policies
-  image: vault
+  sourceRegistry: ghcr.io/scality
+  dashboard: vault2/vault-dashboards
+  policy: vault2/vault-policies
+  image: vault2
   tag: 8.7.12
   envsubst: VAULT_TAG
 zenko-operator:

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -13,8 +13,8 @@ busybox:
   tag: 1.33.0
   envsubst: BUSYBOX_TAG
 cloudserver:
-  sourceRegistry: registry.scality.com/cloudserver
-  dashboard: cloudserver-dashboards
+  sourceRegistry: ghcr.io/scality
+  dashboard: cloudserver/cloudserver-dashboards
   image: cloudserver
   tag: 8.7.47
   envsubst: CLOUDSERVER_TAG

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -29,8 +29,8 @@ kafka:
   tag: 2.13-3.1.2
   envsubst: KAFKA_TAG
 kafka-cleaner:
-  sourceRegistry: registry.scality.com/kafka-cleaner
-  dashboard: kafka-cleaner-dashboards
+  sourceRegistry: ghcr.io/scality
+  dashboard: kafka-cleaner/kafka-cleaner-dashboards
   image: kafka-cleaner
   tag: v1.0.2
   envsubst: KAFKA_CLEANER_TAG

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -85,6 +85,7 @@ s3utils:
 sorbet:
   sourceRegistry: ghcr.io/scality
   policy: sorbet/sorbet-policies
+  dashboard: sorbet/sorbet-dashboards
   image: sorbet
   tag: v1.1.9
   envsubst: SORBET_TAG

--- a/tests/ctst/Dockerfile
+++ b/tests/ctst/Dockerfile
@@ -1,5 +1,5 @@
 ARG CTST_TAG
-FROM registry.scality.com/cli-testing/cli-testing:$CTST_TAG
+FROM ghcr.io/scality/cli-testing:$CTST_TAG
 
 COPY package.json /tmp/package.json
 COPY ./features /ctst/features

--- a/tests/ctst/README.md
+++ b/tests/ctst/README.md
@@ -20,10 +20,10 @@ folders. The image can be built and pushed with the following steps:
 cd ./tests/ctst/
 
 # Building the image
-docker build --build-arg CTST_TAG=0.2.0 . -t registry.scality.com/playground/<username>/custom-ctst:0.2.0
+docker build --build-arg CTST_TAG=0.2.0 . -t ghcr.io/scality/playground/<username>/custom-ctst:0.2.0
 
 # Pushing the custom image into a repository
-docker push registry.scality.com/playground/<username>/custom-ctst:0.2.0
+docker push ghcr.io/scality/playground/<username>/custom-ctst:0.2.0
 ```
 
 Running the tests can be done with the following steps:

--- a/tests/zenko_tests/README.md
+++ b/tests/zenko_tests/README.md
@@ -83,9 +83,9 @@ Then login from CLI, using your registry Username and the CLI secret you just ge
 
 
 ```shell
-$ docker login registry.scality.com
-User name: <Username on registry.scality.com>
-Password: <Generated CLI secret>
+$ docker login ghcr.io
+User name: <Username on github>
+Password: <Github personal access token>
 ```
 
 ***

--- a/tests/zenko_tests/README.md
+++ b/tests/zenko_tests/README.md
@@ -119,7 +119,7 @@ Edit file `/doc/examples/zenkoversion-1.2-dev.yaml` by changing the versions
 _For example:_
 ```diff
 vault:
-  image: registry.scality.com/vault/vault
+  image: ghcr.io/scality/vault2
 -      tag: '8.3.6'
 +      tag: '8.4.0'
   shell:


### PR DESCRIPTION
- Use backbeat from ghcr
- Use docker/login-action to setup registry
- Migrate to ghcr
- Upgrade actions
- Use cloudserver from ghcr
- Use ctst from ghcr
- Use kafka-cleaner from ghcr
- Use sorbet from ghcr
- Add sorbet dashboards
- Use shell-ui from ghcr
- Use pensieve-api from ghcr
- Use s3utils from ghcr
- Use static container registry from ghcr
- Use utapi from ghcr
- Use vault from ghcr
- Use zkop from ghcr
- Use zenko-ui from ghcr

Issue: ZENKO-4800
