### PR TITLE
Improvement/zenko 4713 tests on put obj no version

### DIFF
--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -16,7 +16,7 @@ cloudserver:
   sourceRegistry: ghcr.io/scality
   dashboard: cloudserver/cloudserver-dashboards
   image: cloudserver
-  tag: 8.8.25
+  tag: 8.8.28
   envsubst: CLOUDSERVER_TAG
 jmx-javaagent:
   sourceRegistry: banzaicloud

--- a/tests/ctst/features/dmf.feature
+++ b/tests/ctst/features/dmf.feature
@@ -73,3 +73,22 @@ Feature: DMF
     |           Non versioned |           2 |        100 |           1 |
     |               Versioned |           2 |        100 |           1 |
     |               Suspended |           2 |        100 |           1 |
+
+    @2.7.0
+    @PreMerge
+    @Dmf
+    @ColdStorage
+    Scenario Outline: Overwriting of a cold object
+    Given a "<versioningConfiguration>" bucket
+    And a transition workflow to "e2e-cold" location
+    And <objectCount> objects "obj" of size <objectSize> bytes
+    Then object "obj-1" should be "transitioned" and have the storage class "e2e-cold"
+    And dmf volume should contain <objectCount> objects
+    Given <objectCount> objects "obj" of size <objectSize> bytes
+    Then object "obj-1" should be "transitioned" and have the storage class "e2e-cold"
+    Then dmf volume should contain 1 objects
+
+    Examples:
+    | versioningConfiguration | objectCount | objectSize |
+    |           Non versioned |           1 |        100 |
+    |               Suspended |           1 |        100 |


### PR DESCRIPTION
This PR aims to add a test case on the dmfFeature , for the put of an existing object in the cold lolcation in the hot one , in the test we make sure that dmf deletes the already existing object in the cold storage , before the hot location object is transitioned thus avoiding the creation of orphans. 

Issue : ZENKO-4713