### PR TITLE
Bump misc deps

### DIFF
--- a/solution-base/deps.yaml
+++ b/solution-base/deps.yaml
@@ -9,7 +9,7 @@ mongodb-exporter:
   tag: 0.34.0-debian-11-r31
 mongodb-sharded:
   image: bitnami/mongodb-sharded
-  tag: 4.0.27-debian-9-r111
+  tag: 4.0.27-debian-9-r112
 mongodb-sharded-exporter:
   image: bitnami/mongodb-exporter
   tag: 0.34.0-debian-11-r31

--- a/solution-base/deps.yaml
+++ b/solution-base/deps.yaml
@@ -6,13 +6,13 @@ mongodb:
   tag: 4.0.27-debian-9-r118
 mongodb-exporter:
   image: bitnami/mongodb-exporter
-  tag: 0.34.0-debian-11-r24
+  tag: 0.34.0-debian-11-r31
 mongodb-sharded:
   image: bitnami/mongodb-sharded
   tag: 4.0.27-debian-9-r111
 mongodb-sharded-exporter:
   image: bitnami/mongodb-exporter
-  tag: 0.34.0-debian-11-r24
+  tag: 0.34.0-debian-11-r31
 mongodb-shell:
   image: bitnami/os-shell
   tag: 12-debian-12-r22

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -10,7 +10,7 @@ backbeat:
   envsubst: BACKBEAT_TAG
 busybox:
   image: busybox
-  tag: 1.33.0
+  tag: 1.36.1
   envsubst: BUSYBOX_TAG
 cloudserver:
   sourceRegistry: ghcr.io/scality

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -64,7 +64,7 @@ rclone:
   envsubst: RCLONE_TAG
 redis:
   image: redis
-  tag: 7.0.4
+  tag: 7.0.15
   envsubst: REDIS_TAG
 redis-kubedb:
   sourceRegistry: kubedb

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -121,5 +121,5 @@ zenko-ui:
 zookeeper:
   sourceRegistry: pravega
   image: zookeeper
-  tag: 0.2.14
+  tag: 0.2.15
   envsubst: ZOOKEEPER_TAG

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -37,10 +37,10 @@ kafka-cleaner:
 kafka-connect:
   sourceRegistry: ghcr.io/scality/zenko
   image: kafka-connect
-  tag: 2.13-3.1.2-1.10.1
+  tag: 2.13-3.1.2-1.13.0
   envsubst: KAFKA_CONNECT_TAG
 mongodb-connector:
-  tag: 1.10.1
+  tag: 1.13.0
   envsubst: MONGODB_CONNECTOR_TAG
 kafka-cruise-control:
   sourceRegistry: ghcr.io/banzaicloud

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -60,7 +60,7 @@ pensieve-api:
 rclone:
   sourceRegistry: rclone
   image: rclone
-  tag: 1.59.2
+  tag: 1.67.0
   envsubst: RCLONE_TAG
 redis:
   image: redis

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -74,7 +74,7 @@ redis-kubedb:
 redis_exporter:
   sourceRegistry: oliver006
   image: redis_exporter
-  tag: v1.43.1
+  tag: v1.61.0
   envsubst: REDIS_EXPORTER_TAG
 s3utils:
   sourceRegistry: ghcr.io/scality


### PR DESCRIPTION
- Bump mongodb-exporter:0.34.0-debian-11-r31 / 0.37.0-debian-11-r33
- Bump mongo-sharded: 4.0.27-debian-9-r112 / 5.0.24-debian-11-r20
- Bump rclone:1.67.0
- Bump redis:7.0.15
- Bump busybox:1.36.1
- Bump mongodb kafka connector:1.13.0
- Bump redis-exporter:1.61.0
- Bump zookeeper:3.7.1 (pravega 0.2.15)

Issue: ZENKO-4841
