### PR TITLE
Enable OOB tests

### DIFF
--- a/.github/scripts/end2end/common.sh
+++ b/.github/scripts/end2end/common.sh
@@ -61,3 +61,35 @@ wait_for_all_pods_behind_services() {
         done
     done
 }
+
+# wait for consumer group to be in a stable state (no rebance + at least one consumer connected)
+wait_for_consumer_group() {
+    # Getting the name of the first kafka pod
+    kafka_pod=$(kubectl get pods -l brokerId=0,kafka_cr=end2end-base-queue,app=kafka -o jsonpath='{.items[0].metadata.name}')
+    consumer_group=$1
+    timeout_s=$2
+    interval_s=${3:-5}
+    kubectl exec -it $kafka_pod -- bash -c '
+export KAFKA_OPTS=
+consumer_group=$1
+timeout_s=$2
+start_time=$(date +%s)
+while true; do
+    # The state becomes "Stable" when no rebalance is happening and at least one consumer is connected
+    state=$(kafka-consumer-groups.sh --bootstrap-server localhost:9092 --describe --group $consumer_group --state | awk '"'"'NF>1 && $(NF-1) != "STATE" {print (NF>1?$(NF-1):"None")} {next}'"'"')
+    if [ "$state" == "Stable" ]; then
+        echo "Consumer group $consumer_group is now consuming."
+        exit 0
+    fi
+    # Check if we have reached the timeout
+    current_time=$(date +%s)
+    elapsed_time=$((current_time - start_time))
+    if [ "$elapsed_time" -ge "$timeout_s" ]; then
+        echo "Error: Timed out waiting for consumer group $consumer_group to start consuming."
+        exit 1
+    fi
+    # Sleep for 1 second before checking again
+    sleep 1
+done
+' -- "$consumer_group" "$timeout_s" "$interval_s"
+}

--- a/.github/scripts/end2end/common.sh
+++ b/.github/scripts/end2end/common.sh
@@ -64,14 +64,15 @@ wait_for_all_pods_behind_services() {
 
 # wait for consumer group to be in a stable state (no rebance + at least one consumer connected)
 wait_for_consumer_group() {
+    namespace=$1
     # Getting the name of the first kafka pod
-    kafka_pod=$(kubectl get pods -l brokerId=0,kafka_cr=end2end-base-queue,app=kafka -o jsonpath='{.items[0].metadata.name}')
-    consumer_group=$1
+    kafka_pod=$(kubectl get pods -n $namespace -l brokerId=0,kafka_cr=end2end-base-queue,app=kafka -o jsonpath='{.items[0].metadata.name}')
+    consumer_group=$2
     # When a pod is restarted the previous consumer is kept in the group until the session timeout expires
-    expected_members=$2
-    timeout_s=$3
-    interval_s=${4:-5}
-    kubectl exec -it $kafka_pod -- bash -c '
+    expected_members=$3
+    timeout_s=$4
+    interval_s=${5:-5}
+    kubectl exec -it $kafka_pod -n $namespace -- bash -c '
 export KAFKA_OPTS=
 consumer_group=$1
 expected_members=$2

--- a/.github/scripts/end2end/common.sh
+++ b/.github/scripts/end2end/common.sh
@@ -67,17 +67,23 @@ wait_for_consumer_group() {
     # Getting the name of the first kafka pod
     kafka_pod=$(kubectl get pods -l brokerId=0,kafka_cr=end2end-base-queue,app=kafka -o jsonpath='{.items[0].metadata.name}')
     consumer_group=$1
-    timeout_s=$2
-    interval_s=${3:-5}
+    # When a pod is restarted the previous consumer is kept in the group until the session timeout expires
+    expected_members=$2
+    timeout_s=$3
+    interval_s=${4:-5}
     kubectl exec -it $kafka_pod -- bash -c '
 export KAFKA_OPTS=
 consumer_group=$1
-timeout_s=$2
+expected_members=$2
+timeout_s=$3
+interval_s=$4
 start_time=$(date +%s)
 while true; do
     # The state becomes "Stable" when no rebalance is happening and at least one consumer is connected
     state=$(kafka-consumer-groups.sh --bootstrap-server localhost:9092 --describe --group $consumer_group --state | awk '"'"'NF>1 && $(NF-1) != "STATE" {print (NF>1?$(NF-1):"None")} {next}'"'"')
-    if [ "$state" == "Stable" ]; then
+    members=$(kafka-consumer-groups.sh --bootstrap-server localhost:9092 --describe --group $consumer_group --state | awk '"'"'NF>1 && $NF != "#MEMBERS" {print (NF>1?$NF:"None")} {next}'"'"')
+    echo "Consumer group $consumer_group state: $state, members: $members"
+    if [ "$state" == "Stable" ] && [ "$members" -eq "$expected_members" ]; then
         echo "Consumer group $consumer_group is now consuming."
         exit 0
     fi
@@ -88,8 +94,7 @@ while true; do
         echo "Error: Timed out waiting for consumer group $consumer_group to start consuming."
         exit 1
     fi
-    # Sleep for 1 second before checking again
-    sleep 1
+    sleep $interval_s
 done
-' -- "$consumer_group" "$timeout_s" "$interval_s"
+' -- "$consumer_group" "$expected_members" "$timeout_s" "$interval_s"
 }

--- a/.github/scripts/end2end/configs/zenko.yaml
+++ b/.github/scripts/end2end/configs/zenko.yaml
@@ -34,7 +34,7 @@ spec:
     ingestionProcessor:
       concurrency: 2
     logging:
-      logLevel: trace
+      logLevel: debug
   mongodb:
     provider: External
     endpoints:

--- a/.github/scripts/end2end/configure-e2e.sh
+++ b/.github/scripts/end2end/configure-e2e.sh
@@ -110,6 +110,9 @@ sleep 10
 kubectl wait --for condition=DeploymentFailure=false --timeout 25m -n ${NAMESPACE} zenko/${ZENKO_NAME}
 kubectl wait --for condition=DeploymentInProgress=false --timeout 25m -n ${NAMESPACE} zenko/${ZENKO_NAME}
 
-# wait for ingestion processor to start consuming from Kafka
-ingestion_processor_replicas=$(kubectl -n $NAMESPACE get deploy/end2end-backbeat-ingestion-processor -o jsonpath='{.spec.replicas}')
-wait_for_consumer_group $NAMESPACE $UUID.backbeat-ingestion-group $ingestion_processor_replicas 300
+
+if [ $ENABLE_RING_TESTS = true ]; then
+  # wait for ingestion processor to start consuming from Kafka
+  ingestion_processor_replicas=$(kubectl -n $NAMESPACE get deploy/end2end-backbeat-ingestion-processor -o jsonpath='{.spec.replicas}')
+  wait_for_consumer_group $NAMESPACE $UUID.backbeat-ingestion-group $ingestion_processor_replicas 300
+fi

--- a/.github/scripts/end2end/configure-e2e.sh
+++ b/.github/scripts/end2end/configure-e2e.sh
@@ -109,3 +109,6 @@ sleep 10
 
 kubectl wait --for condition=DeploymentFailure=false --timeout 25m -n ${NAMESPACE} zenko/${ZENKO_NAME}
 kubectl wait --for condition=DeploymentInProgress=false --timeout 25m -n ${NAMESPACE} zenko/${ZENKO_NAME}
+
+# wait for ingestion processor to start consuming from Kafka
+wait_for_consumer_group $UUID.backbeat-ingestion-group 300

--- a/.github/scripts/end2end/configure-e2e.sh
+++ b/.github/scripts/end2end/configure-e2e.sh
@@ -111,4 +111,5 @@ kubectl wait --for condition=DeploymentFailure=false --timeout 25m -n ${NAMESPAC
 kubectl wait --for condition=DeploymentInProgress=false --timeout 25m -n ${NAMESPACE} zenko/${ZENKO_NAME}
 
 # wait for ingestion processor to start consuming from Kafka
-wait_for_consumer_group $NAMESPACE $UUID.backbeat-ingestion-group 1 300
+ingestion_processor_replicas=$(kubectl -n $NAMESPACE get deploy/end2end-backbeat-ingestion-processor -o jsonpath='{.spec.replicas}')
+wait_for_consumer_group $NAMESPACE $UUID.backbeat-ingestion-group $ingestion_processor_replicas 300

--- a/.github/scripts/end2end/configure-e2e.sh
+++ b/.github/scripts/end2end/configure-e2e.sh
@@ -111,4 +111,4 @@ kubectl wait --for condition=DeploymentFailure=false --timeout 25m -n ${NAMESPAC
 kubectl wait --for condition=DeploymentInProgress=false --timeout 25m -n ${NAMESPACE} zenko/${ZENKO_NAME}
 
 # wait for ingestion processor to start consuming from Kafka
-wait_for_consumer_group $UUID.backbeat-ingestion-group 300
+wait_for_consumer_group $UUID.backbeat-ingestion-group 1 300

--- a/.github/scripts/end2end/configure-e2e.sh
+++ b/.github/scripts/end2end/configure-e2e.sh
@@ -111,4 +111,4 @@ kubectl wait --for condition=DeploymentFailure=false --timeout 25m -n ${NAMESPAC
 kubectl wait --for condition=DeploymentInProgress=false --timeout 25m -n ${NAMESPACE} zenko/${ZENKO_NAME}
 
 # wait for ingestion processor to start consuming from Kafka
-wait_for_consumer_group $UUID.backbeat-ingestion-group 1 300
+wait_for_consumer_group $NAMESPACE $UUID.backbeat-ingestion-group 1 300

--- a/tests/zenko_tests/node_tests/backbeat/tests/ingestion/ingestionS3CPauseResume.js
+++ b/tests/zenko_tests/node_tests/backbeat/tests/ingestion/ingestionS3CPauseResume.js
@@ -93,7 +93,6 @@ describe('Ingestion pause resume', function () {
             'non-existent-location',
             (err, data) => {
                 assert.ifError(err);
-                assert.strictEqual(data.code, 404);
                 assert.strictEqual(data.RouteNotFound, true);
                 return done();
             },

--- a/tests/zenko_tests/node_tests/package.json
+++ b/tests/zenko_tests/node_tests/package.json
@@ -53,7 +53,7 @@
     "test_operator": "mocha --tags ${MOCHA_TAGS} --exit -t 10000 --reporter mocha-multi-reporters --reporter-options configFile=config.json ./init_test.js",
     "test_smoke": "mocha --tags ${MOCHA_TAGS} --exit -t 10000 --reporter mocha-multi-reporters --reporter-options configFile=config.json --recursive smoke_tests",
     "test_iam_policies": "mocha --tags ${MOCHA_TAGS} --exit -t 15000 --reporter mocha-multi-reporters --reporter-options configFile=config.json --recursive iam_policies",
-    "test_all_extensions": "run-p --aggregate-output test_aws_crr test_expiration test_transition",
+    "test_all_extensions": "run-p --aggregate-output test_aws_crr test_expiration test_transition test_ingestion_oob_s3c",
     "test_object_api": "mocha --tags ${MOCHA_TAGS} --exit -t 10000 --reporter mocha-multi-reporters --reporter-options configFile=config.json --recursive cloudserver/keyFormatVersion/tests",
     "lint": "eslint $(find . -name '*.js' -not -path '*/node_modules/*')"
   },

--- a/tests/zenko_tests/node_tests/package.json
+++ b/tests/zenko_tests/node_tests/package.json
@@ -46,7 +46,7 @@
     "test_expiration": "mocha --tags ${MOCHA_TAGS} --exit -t 900000 --reporter mocha-multi-reporters --reporter-options configFile=config.json backbeat/tests/lifecycle/expiration.js",
     "test_transition": "mocha --tags ${MOCHA_TAGS} --exit -t 900000 --reporter mocha-multi-reporters --reporter-options configFile=config.json backbeat/tests/lifecycle/transition.js",
     "test_lifecycle": "mocha --tags ${MOCHA_TAGS} --exit -t 1800000 --reporter mocha-multi-reporters --reporter-options configFile=config.json --recursive backbeat/tests/lifecycle",
-    "test_ingestion_oob_s3c": "mocha --tags ${MOCHA_TAGS} --exit -t 100000 --reporter mocha-multi-reporters --reporter-options configFile=config.json --recursive backbeat/tests/ingestion",
+    "test_ingestion_oob_s3c": "mocha --tags ${MOCHA_TAGS} --exit -t 180000 --reporter mocha-multi-reporters --reporter-options configFile=config.json --recursive backbeat/tests/ingestion",
     "test_location_quota": "mocha --tags ${MOCHA_TAGS} --exit -t 10000 --reporter mocha-multi-reporters --reporter-options configFile=config.json  --recursive cloudserver/locationQuota/tests",
     "test_bucket_get_v2": "mocha --tags ${MOCHA_TAGS} --exit -t 10000 --reporter mocha-multi-reporters --reporter-options configFile=config.json --recursive cloudserver/bucketGetV2/tests",
     "test_bucket_policy": "mocha --tags ${MOCHA_TAGS} --exit -t 10000 --reporter mocha-multi-reporters --reporter-options configFile=config.json --recursive cloudserver/bucketPolicy/tests",


### PR DESCRIPTION
- Enable OOB tests
- Increase the timeout of OOB tests as replication of operations between the repds can be slow when the CI vm is saturated (an operation is only visible in the raft log once it got replicated to the majority of the repds)
- Wait for the ingestion consumer group to be in a stable state before starting the tests. Zenko is reconciled just before launching the tests which causes the ingestion pods to restart and the consumer group to rebalance. The consumer group stays in the rebalance state for 30-ish seconds which is enough time for the tests to start. Not waiting for the state to be stable can cause the first messages pushed to the topic to be skipped (consumers start consuming late because of the rebalance) as the consumers are configured to start consuming from the latest offset if no offset was found (which is the case at startup).
- When we wait for the consumer group state to be stable we also check if we have the proper number of consumers connected to the consumer group. When the ingestion pods restart from the reconcile, the previous consumers are kept in the consumer group until their session times out. Not waiting for this can cause messages to be skipped as well, as the new consumer(s) only have some partitions assigned to them and not all, the rest are assigned to the "dead" consumer until future rebalance. At startup no offset is generally stored yet for the partitions assigned to the "dead" consumer, so when the rebalance occurs and the new consumer get assigned to them the new offset becomes the latest and previous messages are skipped.

Issue: ZENKO-4286