### PR TITLE
gha: use app tokens to access private repos

### DIFF
--- a/.github/actions/deploy/action.yaml
+++ b/.github/actions/deploy/action.yaml
@@ -66,7 +66,7 @@ runs:
         cd ./.github/scripts/end2end
         git init operator
         cd operator
-        git fetch --depth 1 --no-tags https://${GIT_ACCESS_TOKEN}@github.com/scality/zenko-operator.git ${OPERATOR_IMAGE_TAG}
+        git fetch --depth 1 --no-tags https://git:${GIT_ACCESS_TOKEN}@github.com/scality/zenko-operator.git ${OPERATOR_IMAGE_TAG}
         git checkout FETCH_HEAD
         tilt ci
       env:

--- a/.github/scripts/end2end/deploy-metadata.sh
+++ b/.github/scripts/end2end/deploy-metadata.sh
@@ -10,7 +10,7 @@ kubectl create namespace metadata
 # clone the metadata repository
 git init metadata
 cd metadata
-git fetch --depth 1 --no-tags https://${GIT_ACCESS_TOKEN}@github.com/scality/metadata.git
+git fetch --depth 1 --no-tags https://git:${GIT_ACCESS_TOKEN}@github.com/scality/metadata.git
 git checkout FETCH_HEAD
 
 # install metadata chart in a separate namespace

--- a/.github/workflows/alerts.yaml
+++ b/.github/workflows/alerts.yaml
@@ -15,6 +15,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Get token to access private repositories
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.ACTIONS_APP_ID }}
+          private-key: ${{ secrets.ACTIONS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: action-prom-render-test
+
       - name: Render and test mongodb alerts 
         uses: scality/action-prom-render-test@1.0.3
         with:
@@ -25,7 +34,7 @@ jobs:
             service=data-db-mongodb-sharded
             pvc=datadir-mongodb
             replicas=3
-          github_token: ${{ secrets.GIT_ACCESS_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
 
       - name: Render and test kafka alerts 
         uses: scality/action-prom-render-test@1.0.3
@@ -40,7 +49,7 @@ jobs:
             replicas=3
             maxConsumerLagMessagesWarningThreshold=1000
             maxConsumerLagSecondsWarningThreshold=300
-          github_token: ${{ secrets.GIT_ACCESS_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
 
       - name: Render and test redis alerts 
         uses: scality/action-prom-render-test@1.0.3
@@ -50,7 +59,7 @@ jobs:
           alert_inputs: |
             namespace=zenko
             service=artesca-data-base-cache-metrics
-          github_token: ${{ secrets.GIT_ACCESS_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
 
       - name: Render and test zookeeper alerts 
         uses: scality/action-prom-render-test@1.0.3
@@ -63,7 +72,7 @@ jobs:
             pvc=artesca-data-base-quorum
             replicas=3
             quorum=3
-          github_token: ${{ secrets.GIT_ACCESS_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
       
       - name: Render and test dr alerts
         uses: scality/action-prom-render-test@1.0.3
@@ -78,4 +87,4 @@ jobs:
             rto_alert_threshold=30
             mongo_jobs=zenko/data-db-mongodb-sharded-shard.*
             lifecycle_jobs=artesca-data-backbeat-lifecycle-.*-headless
-          github_token: ${{ secrets.GIT_ACCESS_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -250,10 +250,19 @@ jobs:
         with:
           username: "${{ secrets.DOCKERHUB_LOGIN }}"
           password: "${{ secrets.DOCKERHUB_PASSWORD }}"
+      - name: Get token to access ZKOP
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.ACTIONS_APP_ID }}
+          private-key: ${{ secrets.ACTIONS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            zenko-operator
       - name: Configure GIT
-        run: git config --global url."https://${GIT_ACCESS_TOKEN}@github.com/".insteadOf "https://github.com/"
+        run: git config --global url."https://git:${{ env.GIT_ACCESS_TOKEN }}@github.com/".insteadOf "https://github.com/"
         env:
-          GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
+          GIT_ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Build ISO
         run: PATH="/usr/local/bin:$PATH" bash -x ./build.sh
         working-directory: ./solution
@@ -362,14 +371,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GIT_ACCESS_TOKEN }}
+          persist-credentials: false # otherwise, the token is not passed to the next steps
+      - name: Get token to access private repositories
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.ACTIONS_APP_ID }}
+          private-key: ${{ secrets.ACTIONS_APP_PRIVATE_KEY }}
+          repositories: |
+            cli-testing
       - name: Configure GIT
         run: |
-          git config --global url.https://x-access-token:${{ secrets.GIT_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
-          git config --global url.https://x-access-token:${{ secrets.GIT_ACCESS_TOKEN }}@github.com/.insteadOf git@github.com:
-          git config --global url.https://x-access-token:${{ secrets.GIT_ACCESS_TOKEN }}@github.com/.insteadOf ssh://git@github.com/
+          git config --global url.https://x-access-token:${{ env.GIT_ACCESS_TOKEN }}@github.com/.insteadOf https://github.com/
+          git config --global url.https://x-access-token:${{ env.GIT_ACCESS_TOKEN }}@github.com/.insteadOf github.com:
+          git config --global url.https://x-access-token:${{ env.GIT_ACCESS_TOKEN }}@github.com/.insteadOf ssh://git@github.com/
         env:
-          GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
+          GIT_ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -432,10 +449,19 @@ jobs:
           username: "${{ github.repository_owner }}"
           password: "${{ github.token }}"
           registry: ghcr.io
+      - name: Get token to access private repositories
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.ACTIONS_APP_ID }}
+          private-key: ${{ secrets.ACTIONS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            zenko-operator
       - name: Deploy Zenko
         uses: ./.github/actions/deploy
         env:
-          GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
+          GIT_ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Run init CI test
         run: bash run-e2e-test.sh "end2end" ${E2E_IMAGE_NAME}:${E2E_IMAGE_TAG} "end2end" "default"
         working-directory: ./.github/scripts/end2end
@@ -465,8 +491,6 @@ jobs:
   end2end-pra:
     needs: [build-kafka, lint-and-build-ctst]
     runs-on: ubuntu-24.04-16core
-    env:
-      GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -480,8 +504,19 @@ jobs:
           username: "${{ github.repository_owner }}"
           password: "${{ github.token }}"
           registry: ghcr.io
+      - name: Get token to access private repositories
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.ACTIONS_APP_ID }}
+          private-key: ${{ secrets.ACTIONS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            zenko-operator
       - name: Deploy Zenko
         uses: ./.github/actions/deploy
+        env:
+          GIT_ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Prepare PRA environment
         run: bash prepare-pra.sh
         working-directory: ./.github/scripts/end2end
@@ -533,7 +568,6 @@ jobs:
       OIDC_ENDPOINT: 'https://keycloak.zenko.local'
       NAVBAR_ENDPOINT: 'https://shell-ui.zenko.local'
       ENABLE_KEYCLOAK_HTTPS: 'true'
-      GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -547,8 +581,19 @@ jobs:
           username: "${{ github.repository_owner }}"
           password: "${{ github.token }}"
           registry: ghcr.io
+      - name: Get token to access private repositories
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.ACTIONS_APP_ID }}
+          private-key: ${{ secrets.ACTIONS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            zenko-operator
       - name: Deploy Zenko
         uses: ./.github/actions/deploy
+        env:
+          GIT_ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Run init CI test
         run: bash run-e2e-test.sh "end2end" ${E2E_IMAGE_NAME}:${E2E_IMAGE_TAG} "end2end" "default"
         working-directory: ./.github/scripts/end2end
@@ -593,10 +638,20 @@ jobs:
           username: "${{ github.repository_owner }}"
           password: "${{ github.token }}"
           registry: ghcr.io
+      - name: Get token to access private repositories
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.ACTIONS_APP_ID }}
+          private-key: ${{ secrets.ACTIONS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            metadata
+            zenko-operator
       - name: Deploy Zenko
         uses: ./.github/actions/deploy
         env:
-          GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
+          GIT_ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           deploy_metadata: ${{ env.ENABLE_RING_TESTS }}
       - name: Run backbeat end to end tests
@@ -635,10 +690,19 @@ jobs:
           username: "${{ github.repository_owner }}"
           password: "${{ github.token }}"
           registry: ghcr.io
+      - name: Get token to access private repositories
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.ACTIONS_APP_ID }}
+          private-key: ${{ secrets.ACTIONS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            zenko-operator
       - name: Deploy Zenko
         uses: ./.github/actions/deploy
         env:
-          GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
+          GIT_ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}
           ZENKO_ENABLE_SOSAPI: true
           TIME_PROGRESSION_FACTOR: 86400
           TRANSITION_ONE_DAY_EARLIER: false


### PR DESCRIPTION
As documented in [1], use dynamically created app token instead of
relying on a global `GIT_ACCESS_TOKEN` secret.

This allows using temporary creds, and restricting them to specific
repositories.

[1] https://devdocs.scality.net/ci-engines/github-actions/permissions/

Issue: ZENKO-4994
