### PR TITLE
Remove count-items monitoring work-around

### DIFF
--- a/.github/scripts/end2end/run-e2e-ctst.sh
+++ b/.github/scripts/end2end/run-e2e-ctst.sh
@@ -137,10 +137,6 @@ EOF
 kubectl set env deployment end2end-connector-cloudserver SCUBA_HEALTHCHECK_FREQUENCY=100
 kubectl rollout status deployment end2end-connector-cloudserver
 
-# disable moniroting of count-items
-kubectl set env cronjob end2end-ops-count-items PROMETHEUS_POLLING_ATTEMPTS=1
-kubectl set env cronjob end2end-ops-count-items PROMETHEUS_POLLING_PERIOD=1
-
 E2E_IMAGE=$E2E_CTST_IMAGE_NAME:$E2E_IMAGE_TAG
 POD_NAME="${ZENKO_NAME}-ctst-tests"
 CTST_VERSION=$(sed 's/.*"cli-testing": ".*#\(.*\)".*/\1/;t;d' ../../../tests/ctst/package.json)


### PR DESCRIPTION
This used to be needed as Prometheus scrapping was not working; but this was fixed by actually deploying prometheus in CI: so this workaround is not needed anymore.

Issue: ZENKO-4818
