### PR TITLE
Update keycloak config for bitnami change

### DIFF
--- a/.github/scripts/end2end/configs/keycloak_options.yaml
+++ b/.github/scripts/end2end/configs/keycloak_options.yaml
@@ -61,3 +61,12 @@ postgresql:
       enabled: true
       additionalLabels:
         release: prometheus-operator
+    image:
+      repository: bitnamilegacy/postgres-exporter
+      tag: 0.10.0
+  image:
+    repository: bitnamilegacy/postgresql
+    tag: 11.14.0
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell


### PR DESCRIPTION
The chart depends on postgresql chart from bitnami, so we must override
the image to use bitnamilegacy.

Not all tags have copied, so we must override some tags as well; no
upgrade though, still using the same versions as the current chart.

Issue: ZENKO-5072
