### PR TITLE
Bump dependencies

### DIFF
--- a/solution-base/deps.yaml
+++ b/solution-base/deps.yaml
@@ -3,10 +3,10 @@
 # yq eval 'sortKeys(.)' -i deps.yaml
 mongodb-sharded:
   image: bitnamilegacy/mongodb-sharded
-  tag: 7.0.6-debian-12-r0
+  tag: 7.0.9-debian-12-r2
 mongodb-sharded-exporter:
   image: bitnamilegacy/mongodb-exporter
-  tag: 0.40.0-debian-12-r12
+  tag: 0.40.0-debian-12-r40
 mongodb-shell:
   image: bitnamilegacy/os-shell
-  tag: 12-debian-12-r22
+  tag: 12-debian-12-r51

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -16,7 +16,7 @@ cloudserver:
   sourceRegistry: ghcr.io/scality
   dashboard: cloudserver/cloudserver-dashboards
   image: cloudserver
-  tag: 9.0.22
+  tag: 9.0.30
   envsubst: CLOUDSERVER_TAG
 drctl:
   sourceRegistry: ghcr.io/scality

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -94,7 +94,7 @@ redis:
 redis_exporter:
   sourceRegistry: oliver006
   image: redis_exporter
-  tag: v1.61.0
+  tag: v1.78.0
   envsubst: REDIS_EXPORTER_TAG
 s3utils:
   sourceRegistry: ghcr.io/scality

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -100,7 +100,7 @@ s3utils:
   sourceRegistry: ghcr.io/scality
   dashboard: s3utils/s3utils-dashboards
   image: s3utils
-  tag: 1.14.18
+  tag: 1.14.20
   envsubst: S3UTILS_TAG
 scuba:
   sourceRegistry: ghcr.io/scality

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -36,7 +36,7 @@ fzf: # fuzzy finder for fubectl
   toolName: fzf
 haproxy:
   image: haproxy
-  tag: 3.0.3-alpine
+  tag: 3.0.12-alpine
   envsubst: HAPROXY_TAG
 jmx-javaagent:
   sourceRegistry: ghcr.io/banzaicloud

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -116,7 +116,7 @@ sorbet:
   tag: v1.1.13
   envsubst: SORBET_TAG
 stern: # tail any pod logs with pattern matchin
-  tag: 1.30.0
+  tag: 1.33.0
   envsubst: STERN_VERSION
   toolUrl: https://github.com/stern/stern/releases/download/v${STERN_VERSION}/stern_${STERN_VERSION}_linux_amd64.tar.gz
   toolName: stern

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -89,7 +89,7 @@ rclone:
   envsubst: RCLONE_TAG
 redis:
   image: redis
-  tag: 7.2.5
+  tag: 7.2.11
   envsubst: REDIS_TAG
 redis_exporter:
   sourceRegistry: oliver006

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -136,7 +136,7 @@ vault:
 zenko-operator:
   sourceRegistry: ghcr.io/scality
   image: zenko-operator
-  tag: v1.7.7
+  tag: v1.7.8
   envsubst: ZENKO_OPERATOR_TAG
 zenko-ui:
   sourceRegistry: ghcr.io/scality

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -85,7 +85,7 @@ pensieve-api:
 rclone:
   sourceRegistry: rclone
   image: rclone
-  tag: 1.67.0
+  tag: 1.71.1
   envsubst: RCLONE_TAG
 redis:
   image: redis

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -10,7 +10,7 @@ backbeat:
   envsubst: BACKBEAT_TAG
 busybox:
   image: busybox
-  tag: 1.36.1
+  tag: 1.37.0
   envsubst: BUSYBOX_TAG
 cloudserver:
   sourceRegistry: ghcr.io/scality

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -30,7 +30,7 @@ fubectl:
   toolUrl: https://raw.githubusercontent.com/kubermatic/fubectl/${FUBECTL_VERSION}/fubectl.source
   toolName: fubectl.source
 fzf: # fuzzy finder for fubectl
-  tag: 0.54.0
+  tag: 0.65.2
   envsubst: FZF_VERSION
   toolUrl: https://github.com/junegunn/fzf/releases/download/v${FZF_VERSION}/fzf-${FZF_VERSION}-linux_amd64.tar.gz
   toolName: fzf


### PR DESCRIPTION
- Bump redis 7.2.11
- Bump redis exporter 1.78.0
- Bump busybox 1.37.0
- Bump cloudserver 9.0.30
- Bump fzf 0.65.2
- Bump haproxy 3.0.12
- Bump rclone 1.71.1
- Bump s3utils 1.14.20
- Bump stern 1.33.0
- Bump zkop 1.7.8
- Bump mongodb 7.0.9 / 8.0.13

Issue: ZENKO-5085
