### PR TITLE
Fix mongo dashboard for multiple shards

### DIFF
--- a/monitoring/mongodb/dashboard.json
+++ b/monitoring/mongodb/dashboard.json
@@ -1334,14 +1334,14 @@
       "maxDataPoints": 100,
       "targets": [
         {
-          "expr": "sum by (pod) (mongodb_dbstats_objects{rs_state=\"1\", namespace=\"${namespace}\", database!~\"admin|config|local\", job=~\"${namespace}/${jobs}\"})",
-          "query": "sum by (pod) (mongodb_dbstats_objects{rs_state=\"1\", namespace=\"${namespace}\", database!~\"admin|config|local\", job=~\"${namespace}/${jobs}\"})",
+          "expr": "sum by (rs_nm) (mongodb_dbstats_objects{rs_state=\"1\", namespace=\"${namespace}\", database!~\"admin|config|local\", job=~\"${namespace}/${jobs}\"})",
+          "query": "sum by (rs_nm) (mongodb_dbstats_objects{rs_state=\"1\", namespace=\"${namespace}\", database!~\"admin|config|local\", job=~\"${namespace}/${jobs}\"})",
           "target": "",
           "format": "time_series",
           "hide": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{ pod }}",
+          "legendFormat": "{{ rs_nm }}",
           "metric": "",
           "refId": "",
           "step": 10,
@@ -1408,14 +1408,14 @@
       "maxDataPoints": 100,
       "targets": [
         {
-          "expr": "sum by (pod) (mongodb_dbstats_indexSize{rs_state=\"1\", namespace=\"${namespace}\", database!~\"admin|config|local\", job=~\"${namespace}/${jobs}\"})",
-          "query": "sum by (pod) (mongodb_dbstats_indexSize{rs_state=\"1\", namespace=\"${namespace}\", database!~\"admin|config|local\", job=~\"${namespace}/${jobs}\"})",
+          "expr": "sum by (rs_nm) (mongodb_dbstats_indexSize{rs_state=\"1\", namespace=\"${namespace}\", database!~\"admin|config|local\", job=~\"${namespace}/${jobs}\"})",
+          "query": "sum by (rs_nm) (mongodb_dbstats_indexSize{rs_state=\"1\", namespace=\"${namespace}\", database!~\"admin|config|local\", job=~\"${namespace}/${jobs}\"})",
           "target": "",
           "format": "time_series",
           "hide": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{ pod }}",
+          "legendFormat": "{{ rs_nm }}",
           "metric": "",
           "refId": "",
           "step": 10,
@@ -1445,7 +1445,6 @@
         },
         "displayLabels": [
           "value",
-          "name",
           "percent"
         ]
       },
@@ -6349,6 +6348,6 @@
     "hidden": false
   },
   "timezone": "browser",
-  "version": 25,
+  "version": 26,
   "uid": null
 }

--- a/monitoring/mongodb/dashboard.json
+++ b/monitoring/mongodb/dashboard.json
@@ -111,14 +111,14 @@
       "maxDataPoints": 100,
       "targets": [
         {
-          "expr": "sum(mongodb_up{namespace=\"${namespace}\", job=~\"${namespace}/${jobs}\"}) by (cluster_role)",
-          "query": "sum(mongodb_up{namespace=\"${namespace}\", job=~\"${namespace}/${jobs}\"}) by (cluster_role)",
+          "expr": "sum(label_replace(mongodb_up{namespace=\"${namespace}\", job=~\"${namespace}/${jobs}\"}, 'statefulset', '$1', 'pod', '${job}-(.*)-[0-9]+')) by (statefulset)",
+          "query": "sum(label_replace(mongodb_up{namespace=\"${namespace}\", job=~\"${namespace}/${jobs}\"}, 'statefulset', '$1', 'pod', '${job}-(.*)-[0-9]+')) by (statefulset)",
           "target": "",
           "format": "time_series",
           "hide": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{cluster_role}}",
+          "legendFormat": "{{statefulset}}",
           "metric": "",
           "refId": "",
           "step": 10,
@@ -137,7 +137,7 @@
         "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
-            "mean"
+            "last"
           ],
           "fields": "",
           "values": false
@@ -568,18 +568,10 @@
               {
                 "op": "gt",
                 "yaxis": "left",
-                "color": "green",
+                "color": "dark-purple",
                 "line": true,
                 "index": 0,
                 "value": "null"
-              },
-              {
-                "op": "gt",
-                "yaxis": "left",
-                "color": "red",
-                "line": true,
-                "index": 1,
-                "value": 80.0
               }
             ]
           },
@@ -744,18 +736,10 @@
               {
                 "op": "gt",
                 "yaxis": "left",
-                "color": "green",
+                "color": "dark-purple",
                 "line": true,
                 "index": 0,
                 "value": "null"
-              },
-              {
-                "op": "gt",
-                "yaxis": "left",
-                "color": "red",
-                "line": true,
-                "index": 1,
-                "value": 80.0
               }
             ]
           },
@@ -6365,6 +6349,6 @@
     "hidden": false
   },
   "timezone": "browser",
-  "version": 24,
+  "version": 25,
   "uid": null
 }

--- a/monitoring/mongodb/dashboard.py
+++ b/monitoring/mongodb/dashboard.py
@@ -152,6 +152,7 @@ class Metrics:
         "mongodb_dbstats_indexSize",
         "database",
         "job",
+        "rs_nm",
         rs_state=RS_STATE_PRIMARY,
         namespace="${namespace}",
     ).with_defaults(DATABASE_FILTER_USER, JOB_FILTER)
@@ -160,6 +161,7 @@ class Metrics:
         "mongodb_dbstats_avgObjSize",
         "database",
         "job",
+        "rs_nm",
         rs_state=RS_STATE_PRIMARY,
         namespace="${namespace}",
     ).with_defaults(DATABASE_FILTER_USER, JOB_FILTER)
@@ -676,8 +678,8 @@ docs_distribution_pie = PieChart(
     unit="short",
     targets=[
         Target(
-            expr="sum by (pod) (" + Metrics.DBSTATS_OBJECTS() + ")",
-            legendFormat="{{ pod }}",
+            expr="sum by (rs_nm) (" + Metrics.DBSTATS_OBJECTS() + ")",
+            legendFormat="{{ rs_nm }}",
         )
     ],
     description="Distribution of user documents across all shards",
@@ -686,15 +688,15 @@ docs_distribution_pie = PieChart(
 index_size_distribution_pie = PieChart(
     title="Index Size Distribution Across Shards",
     dataSource=DATASOURCE,
-    displayLabels=["value", "name", "percent"],
+    displayLabels=["value", "percent"],
     legendDisplayMode="table",
     legendPlacement="right",
     pieType="pie",
     unit=UNITS.BYTES,
     targets=[
         Target(
-            expr="sum by (pod) (" + Metrics.DBSTATS_INDEX_SIZE() + ")",
-            legendFormat="{{ pod }}",
+            expr="sum by (rs_nm) (" + Metrics.DBSTATS_INDEX_SIZE() + ")",
+            legendFormat="{{ rs_nm }}",
         )
     ],
     description="Distribution of user index sizes across all shards",

--- a/monitoring/mongodb/dashboard.py
+++ b/monitoring/mongodb/dashboard.py
@@ -1,16 +1,11 @@
 from grafanalib.core import (
     ConstantInput,
     DataSourceInput,
-    GridPos,
-    Heatmap,
-    HeatmapColor,
-    Repeat,
     RowPanel,
     Template,
     Templating,
     Threshold,
     BarChart,
-    YAxis,
 )
 from grafanalib import core
 from grafanalib import formatunits as UNITS
@@ -18,12 +13,10 @@ from scalgrafanalib import (
     layout,
     metrics,
     Dashboard,
-    GaugePanel,
     PieChart,
     Stat,
     Target,
     TimeSeries,
-    Tooltip,
     StateTimeline,
 )
 
@@ -525,10 +518,15 @@ def mongodb_state_timeline(title, expr, description="", mappings=None, **kwargs)
 mongodb_services_state = mongodb_stat(
     "MongoDB services state",
     orientation="horizontal",
+    reduceCalc="last",
     targets=[
         Target(
-            expr="sum(" + Metrics.UP() + ") by (cluster_role)",
-            legendFormat="{{cluster_role}}",
+            expr=(
+                "sum(label_replace("
+                + Metrics.UP()
+                + ", 'statefulset', '$1', 'pod', '${job}-(.*)-[0-9]+')) by (statefulset)"
+            ),
+            legendFormat="{{statefulset}}",
         )
     ],
 )
@@ -591,6 +589,7 @@ avg_doc_size = mongodb_stat(
     format=UNITS.BYTES,
     decimals=1,
     description="Average size of documents in the database",
+    thresholds=[Threshold("dark-purple", 0, 0.0)],
 )
 
 num_docs_per_shard = mongodb_stat(
@@ -614,6 +613,7 @@ size_collections = mongodb_stat(
             legendFormat="{{collection}}",
         )
     ],
+    thresholds=[Threshold("dark-purple", 0, 0.0)],
 )
 
 index_size = mongodb_stat(
@@ -1466,7 +1466,7 @@ dashboard = (
                     name="jobs",
                     label="MongoDB instance type",
                     query='label_values(mongodb_up{namespace="${namespace}", job=~"${namespace}/${job}.*"}, job)',
-                    regex="/^${namespace}\/(.*)$/",
+                    regex="/^${namespace}\\/(.*)$/",
                     includeAll=True,
                     multi=True,
                     refresh=1,


### PR DESCRIPTION
- Fix MongoDB service state overview
- Show sharding distribution by replicaset name (`rs_nm`) instead of pod

<img width="1765" height="689" alt="image" src="https://github.com/user-attachments/assets/8c65821b-4aa9-4bae-a488-0faef9ee3f46" />

("mongodb balancing process" is empty because this panel works only with mongodb 8, and I tested in mongodb 7 ; but nothing changed there)

Issue: ZENKO-5098
