### PR TITLE
Revert "Bump cloudserver 9.3.0-preview.1"

### DIFF
--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -16,7 +16,7 @@ cloudserver:
   sourceRegistry: ghcr.io/scality
   dashboard: cloudserver/cloudserver-dashboards
   image: cloudserver
-  tag: 9.3.0-preview.1
+  tag: 9.1.8
   envsubst: CLOUDSERVER_TAG
 drctl:
   sourceRegistry: ghcr.io/scality


### PR DESCRIPTION
This reverts commit 54e6fdf406bad998185e0f3d1dca7b7f27cfb5e1.

Issue: ZENKO-4953
