### PR TITLE
Fix CI cgroupv2 failures by disabling JMX

### DIFF
--- a/.github/scripts/end2end/configure-e2e-ctst.sh
+++ b/.github/scripts/end2end/configure-e2e-ctst.sh
@@ -21,6 +21,7 @@ kubectl get zookeepercluster "${ZENKO_NAME}-base-quorum" -o json | jq '.
 | del(.spec.labels)
 | del(.spec.persistence)
 | .spec.storageType |= "ephemeral"
+| .spec.pod.env |= . + [{name: "JMXDISABLE", value: "true"}]
 | del(.spec.pod.affinity)
 | del(.spec.pod.labels)
 | del(.status)

--- a/.github/scripts/end2end/fix-zookeeper.sh
+++ b/.github/scripts/end2end/fix-zookeeper.sh
@@ -63,6 +63,9 @@ done
 
 # Patch the StatefulSet with JVM flags to disable container support
 # as ubuntu runners now are incompatible with zookeeper.
+# Also disable JMX: zkServer.sh enables it by default, and the JMX
+# local connector triggers CgroupV2Subsystem.getInstance() which NPEs
+# on runners with incomplete cgroup v2 controllers (missing cpuset).
 kubectl -n "${NAMESPACE}" patch statefulset "${ZK_STS_NAME}" --type='strategic' \
   -p '{
     "spec": {
@@ -75,6 +78,10 @@ kubectl -n "${NAMESPACE}" patch statefulset "${ZK_STS_NAME}" --type='strategic' 
                 {
                   "name": "JVMFLAGS",
                   "value": "-Xmx512m -Xms512m -XX:-UseContainerSupport -XX:ActiveProcessorCount=1 -Djava.awt.headless=true -Dzookeeper.log.dir=/data/logs -Dzookeeper.root.logger=INFO,CONSOLE -Dlog4j.configuration=file:/data/conf/log4j.properties"
+                },
+                {
+                  "name": "JMXDISABLE",
+                  "value": "true"
                 }
               ]
             }


### PR DESCRIPTION
Issue: ZENKO-5194
See: https://github.com/actions/runner-images/issues/13684
