### PR TITLE
Add CTST tests for live replication with oplog location stripping

### DIFF
--- a/.github/scripts/end2end/configs/zenko.yaml
+++ b/.github/scripts/end2end/configs/zenko.yaml
@@ -31,6 +31,8 @@ spec:
       triggerTransitionsOneDayEarlierForTesting: ${TRANSITION_ONE_DAY_EARLIER}
     ingestionProcessor:
       concurrency: 2
+    replicationDataProcessor:
+      objectRefreshSizeThresholdMB: 2
     logging:
       logLevel: debug
   mongodb:

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -6,7 +6,7 @@ backbeat:
   dashboard: backbeat/backbeat-dashboards
   image: backbeat
   policy: backbeat/backbeat-policies
-  tag: 9.2.1
+  tag: 9.3.0
   envsubst: BACKBEAT_TAG
 busybox:
   image: busybox

--- a/tests/ctst/features/replication.feature
+++ b/tests/ctst/features/replication.feature
@@ -1,0 +1,26 @@
+Feature: Live Object Replication
+    This feature tests live replication of objects across different sizes,
+    verifying that oplog location stripping does not affect replication
+    correctness.
+
+    The objectRefreshSizeThresholdMB is set to 2 in the Zenko CR, meaning
+    objects >= 2 MiB have their location stripped from the MongoDB change
+    stream event. The replication consumer detects this and re-fetches
+    metadata from the source before replicating.
+
+    @2.14.0
+    @PreMerge
+    @ReplicationTest
+    Scenario Outline: Object of <objectDescription> replicates with location stripping threshold
+        Given an existing bucket "repl-strip-<sizeBytes>" "with" versioning, "without" ObjectLock "without" retention mode
+        And a replication configuration to "awsbackendmismatch" location
+        And 1 objects "repl-strip-obj" of size <sizeBytes> bytes
+        Then the object replication should "succeed" within 300 seconds
+        And the replicated object should be the same as the source object
+
+        Examples:
+            | sizeBytes | objectDescription                  |
+            |         0 | 0 bytes (zero-byte)                |
+            |   1048576 | 1 MiB (below threshold)            |
+            |   2097152 | 2 MiB (at threshold, stripped)     |
+            |   4194304 | 4 MiB (above threshold, stripped)  |


### PR DESCRIPTION
Add replication.feature with a Scenario Outline testing live object
replication across 4 sizes (0B, 1MiB, 2MiB, 4MiB) against a 2MiB
stripping threshold. Configure objectRefreshSizeThresholdMB in the
E2E Zenko CR so tests exercise both stripped and preserved paths.

Issue: ZENKO-5204