### PR TITLE
Fix CI artifact archival failing when CRDs are missing

### DIFF
--- a/.github/actions/archive-artifacts/action.yaml
+++ b/.github/actions/archive-artifacts/action.yaml
@@ -67,12 +67,12 @@ runs:
         set -exu
 
         mkdir -p /tmp/artifacts/data/${STAGE}/kind-logs
-        kubectl get pods -A -o yaml > /tmp/artifacts/data/${STAGE}/kind-logs/all-pods.log
-        kubectl get events -A -o yaml > /tmp/artifacts/data/${STAGE}/kind-logs/all-events.log
-        kubectl get zenko -A -o yaml > /tmp/artifacts/data/${STAGE}/kind-logs/all-zenkos.log
-        kubectl get zenkodrsource -A -o yaml > /tmp/artifacts/data/${STAGE}/kind-logs/all-zenkodrsources.log
-        kubectl get zenkodrsink -A -o yaml > /tmp/artifacts/data/${STAGE}/kind-logs/all-zenkodrsinks.log
-        kind export logs /tmp/artifacts/data/${STAGE}/kind-logs/kind-export
+        kubectl get pods -A -o yaml > /tmp/artifacts/data/${STAGE}/kind-logs/all-pods.log || true
+        kubectl get events -A -o yaml > /tmp/artifacts/data/${STAGE}/kind-logs/all-events.log || true
+        kubectl get zenko -A -o yaml > /tmp/artifacts/data/${STAGE}/kind-logs/all-zenkos.log || true
+        kubectl get zenkodrsource -A -o yaml > /tmp/artifacts/data/${STAGE}/kind-logs/all-zenkodrsources.log || true
+        kubectl get zenkodrsink -A -o yaml > /tmp/artifacts/data/${STAGE}/kind-logs/all-zenkodrsinks.log || true
+        kind export logs /tmp/artifacts/data/${STAGE}/kind-logs/kind-export || true
         tar zcvf /tmp/artifacts/${{ github.sha }}-${STAGE}-logs-volumes.tgz /tmp/artifacts/data/${STAGE}/kind-logs
       env:
         STAGE: ${{ inputs.stage }}


### PR DESCRIPTION
## Summary

- The `archive-artifacts` action uses `set -exu`, which aborts the script on the first non-zero exit. When a CRD like `zenko` is not registered (e.g. deploy failed before the operator installed CRDs), `kubectl get zenko` fails and the script exits before `tar zcvf` runs — so no logs tgz is created and no useful artifacts are uploaded.
- Add `|| true` to each kubectl/kind data-collection command so individual failures don't prevent the tgz from being created with whatever data was successfully collected.

Issue: [ZENKO-5205](https://scality.atlassian.net/browse/ZENKO-5205)

[ZENKO-5205]: https://scality.atlassian.net/browse/ZENKO-5205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ