### PR TITLE
Fail fast when Zenko deploy times out

### DIFF
--- a/.github/scripts/end2end/deploy-zenko.sh
+++ b/.github/scripts/end2end/deploy-zenko.sh
@@ -139,12 +139,11 @@ env $(dependencies_env) envsubst < ${ZENKOVERSION_PATH} | \
     kubectl -n ${NAMESPACE} apply -f -
 env $(dependencies_env) envsubst < ${ZENKO_CR_PATH} | kubectl -n ${NAMESPACE} apply -f -
 
-k_cmd="kubectl -n ${NAMESPACE} get zenko/${ZENKO_NAME}"
-for i in $(seq 1 120); do
-    conditions=$($k_cmd -o "jsonpath={.status.conditions}")
-    if kubectl wait --for condition=Available --timeout 5s --namespace ${NAMESPACE} zenko/${ZENKO_NAME}; then
-        break;
-    fi
+retries=120
+while ! kubectl wait --for condition=Available --timeout 5s --namespace ${NAMESPACE} zenko/${ZENKO_NAME} && [ $retries -gt 0 ]; do
+    retries=$(($retries - 1))
     # Debug log to ease understanding of failures in the CI
     kubectl get pods -A
+    kubectl -n ${NAMESPACE} get zenko/${ZENKO_NAME} -o "jsonpath={.status.conditions}" || true
 done
+[ $retries -gt 0 ]


### PR DESCRIPTION
## Summary
- The `deploy-zenko.sh` wait loop ran 120 iterations without failing the script when Zenko never became Available, causing CI jobs to silently pass the deploy step and fail later with confusing errors
- Replace the `for` loop with a `while` loop that decrements a retry counter and add a `[ $retries -gt 0 ]` assertion after the loop so `set -e` aborts the script on timeout
- Print Zenko conditions explicitly for easier CI debugging

Example unrelated logs on failure: https://github.com/scality/Zenko/actions/runs/22722062676/job/65886987385#step:7:8192