### PR TITLE
Add Fluent Bit DaemonSet to CI for persistent log collection

### DIFF
--- a/.github/actions/archive-artifacts/action.yaml
+++ b/.github/actions/archive-artifacts/action.yaml
@@ -74,6 +74,12 @@ runs:
         kubectl get zenkodrsink -A -o yaml > /tmp/artifacts/data/${STAGE}/kind-logs/all-zenkodrsinks.log || true
         kind export logs /tmp/artifacts/data/${STAGE}/kind-logs/kind-export || true
         cp -r /artifacts/data/fluentbit-logs /tmp/artifacts/data/${STAGE}/kind-logs/fluentbit-logs 2>/dev/null || true
+        for container_log in /tmp/artifacts/data/${STAGE}/kind-logs/kind-export/*/containers/*.log; do
+          [ -f "$container_log" ] || continue
+          fb_file="/tmp/artifacts/data/${STAGE}/kind-logs/fluentbit-logs/$(basename "$container_log")"
+          [ -f "$fb_file" ] || continue
+          ln -sf "../../../fluentbit-logs/$(basename "$container_log")" "$container_log"
+        done
         tar zcvf /tmp/artifacts/${{ github.sha }}-${STAGE}-logs-volumes.tgz /tmp/artifacts/data/${STAGE}/kind-logs
       env:
         STAGE: ${{ inputs.stage }}

--- a/.github/actions/archive-artifacts/action.yaml
+++ b/.github/actions/archive-artifacts/action.yaml
@@ -73,6 +73,7 @@ runs:
         kubectl get zenkodrsource -A -o yaml > /tmp/artifacts/data/${STAGE}/kind-logs/all-zenkodrsources.log || true
         kubectl get zenkodrsink -A -o yaml > /tmp/artifacts/data/${STAGE}/kind-logs/all-zenkodrsinks.log || true
         kind export logs /tmp/artifacts/data/${STAGE}/kind-logs/kind-export || true
+        cp -r /artifacts/data/fluentbit-logs /tmp/artifacts/data/${STAGE}/kind-logs/fluentbit-logs 2>/dev/null || true
         tar zcvf /tmp/artifacts/${{ github.sha }}-${STAGE}-logs-volumes.tgz /tmp/artifacts/data/${STAGE}/kind-logs
       env:
         STAGE: ${{ inputs.stage }}

--- a/.github/scripts/end2end/configs/fluentbit.yaml
+++ b/.github/scripts/end2end/configs/fluentbit.yaml
@@ -1,0 +1,77 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluent-bit-config
+data:
+  fluent-bit.conf: |
+    [SERVICE]
+        Flush        5
+        Log_Level    warn
+
+    [INPUT]
+        Name         tail
+        Tag          kube.*
+        Path         /var/log/containers/*.log
+        DB           /var/lib/fluent-bit/flb_kube.db
+        Mem_Buf_Limit 16MB
+        Skip_Long_Lines On
+
+    [OUTPUT]
+        Name         file
+        Match        *
+        Path         /data/fluentbit-logs/
+        Mkdir        true
+        Format       template
+        Template     {log}
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fluent-bit
+  labels:
+    app: fluent-bit
+spec:
+  selector:
+    matchLabels:
+      app: fluent-bit
+  template:
+    metadata:
+      labels:
+        app: fluent-bit
+    spec:
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
+      containers:
+        - name: fluent-bit
+          image: cr.fluentbit.io/fluent/fluent-bit:4.0
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          volumeMounts:
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+            - name: fluentbit-output
+              mountPath: /data/fluentbit-logs
+            - name: fluentbit-db
+              mountPath: /var/lib/fluent-bit
+            - name: config
+              mountPath: /fluent-bit/etc
+      volumes:
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: fluentbit-output
+          hostPath:
+            path: /data/fluentbit-logs
+            type: DirectoryOrCreate
+        - name: fluentbit-db
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: fluent-bit-config

--- a/.github/scripts/end2end/configs/fluentbit.yaml
+++ b/.github/scripts/end2end/configs/fluentbit.yaml
@@ -10,7 +10,8 @@ data:
 
     [INPUT]
         Name         tail
-        Tag          kube.*
+        Tag          <basename>
+        Tag_Regex    /var/log/containers/(?<basename>[^/]+)$
         Path         /var/log/containers/*.log
         DB           /var/lib/fluent-bit/flb_kube.db
         Mem_Buf_Limit 16MB

--- a/.github/scripts/end2end/install-kind-dependencies.sh
+++ b/.github/scripts/end2end/install-kind-dependencies.sh
@@ -59,6 +59,10 @@ helm repo add --force-update banzaicloud-stable https://kubernetes-charts.banzai
 	}
 helm repo update
 
+# fluent-bit log collector — captures container logs before pod deletion
+kubectl apply -f $DIR/configs/fluentbit.yaml
+kubectl rollout status daemonset/fluent-bit --timeout=5m
+
 # nginx-controller
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/${INGRESS_NGINX_VERSION}/deploy/static/provider/kind/deploy.yaml
 kubectl rollout status -n ingress-nginx deployment/ingress-nginx-controller --timeout=10m

--- a/.github/scripts/end2end/install-kind-dependencies.sh
+++ b/.github/scripts/end2end/install-kind-dependencies.sh
@@ -60,8 +60,10 @@ helm repo add --force-update banzaicloud-stable https://kubernetes-charts.banzai
 helm repo update
 
 # fluent-bit log collector — captures container logs before pod deletion
-kubectl apply -f $DIR/configs/fluentbit.yaml
-kubectl rollout status daemonset/fluent-bit --timeout=5m
+if [ "${CI:-}" = "true" ]; then
+  kubectl apply -f $DIR/configs/fluentbit.yaml
+  kubectl rollout status daemonset/fluent-bit --timeout=5m
+fi
 
 # nginx-controller
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/${INGRESS_NGINX_VERSION}/deploy/static/provider/kind/deploy.yaml


### PR DESCRIPTION
## Summary

- Deploy a Fluent Bit DaemonSet on all kind nodes to capture container logs in real-time
- Logs are written to the shared `/data` hostPath volume and included in the `logs-volumes.tgz` artifact
- Lightweight: ~50m CPU / 64Mi RAM per node, estimated ~100-200 MB compressed output

## Why this is needed

When the Zenko operator reconciles, it triggers rolling restarts that replace pods. Kubelet deletes container logs from `/var/log/pods/` on pod deletion, and `kind export logs` only captures logs from pods alive at export time. **Every log from before the restart is permanently lost.**

### Concrete example

While investigating [ctst-end2end-sharded #66912102578](https://github.com/scality/Zenko/actions/runs/23023382868/job/66912102578), all 11 Azure archive tests failed because objects were stuck at `transition-in-progress: true`. The transition pipeline (lifecycle → cloudserver → Kafka → sorbet-fwd → sorbet-azure) was broken, but we could not determine where because:

- The operator's reconciliation loop triggered a mass rolling restart at 07:20, replacing ALL data service pods
- `kind export logs` ran at 08:22, capturing only the post-restart pod logs
- All container logs from the 06:36–06:38 failure window were gone
- We could not determine whether sorbet-fwd crashed (it has a known pattern of committing Kafka offsets during shutdown, permanently losing in-flight messages), whether sorbet-azure was unreachable, or whether internal-cloudserver had the wrong config

With Fluent Bit tailing logs continuously, all of these would have been preserved regardless of pod lifecycle.

## Changes

- **`.github/scripts/end2end/configs/fluentbit.yaml`** — ConfigMap + DaemonSet manifest. Tails `/var/log/containers/*.log`, writes raw CRI log lines (with timestamps) to `/data/fluentbit-logs/`, one file per container instance
- **`.github/scripts/end2end/install-kind-dependencies.sh`** — Deploys Fluent Bit early (before nginx-controller) so it starts capturing logs before any other workloads
- **`.github/actions/archive-artifacts/action.yaml`** — Copies Fluent Bit output into `kind-logs/fluentbit-logs/` before tarring

Issue: [ZENKO-5216](https://scality.atlassian.net/browse/ZENKO-5216)

[ZENKO-5216]: https://scality.atlassian.net/browse/ZENKO-5216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ