### PR TITLE
Increase Kind apiserver event TTL from 1h to 4h

### DIFF
--- a/.github/scripts/end2end/bootstrap-kind.sh
+++ b/.github/scripts/end2end/bootstrap-kind.sh
@@ -61,6 +61,11 @@ nodes:
     nodeRegistration:
       kubeletExtraArgs:
         node-labels: "ingress-ready=true"
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+      extraArgs:
+        event-ttl: "4h0m0s"
   extraMounts:
   - hostPath: ${VOLUME_ROOT}/data
     containerPath: /data


### PR DESCRIPTION
## Summary

- Bumps `kube-apiserver --event-ttl` from the default 1h to 4h in the Kind CI cluster configuration
- Adds a `ClusterConfiguration` kubeadm patch in `bootstrap-kind.sh`

## Context

During the investigation of Azure archive test flakiness ([PR #2340](https://github.com/scality/Zenko/pull/2340), documented in ZENKO-5216), we found that Kubernetes events from the failure window were gone by the time artifacts were collected.

The failing archive tests ran around **06:36**, but `kind export logs` didn't execute until **~08:22** — nearly 2 hours later. With the default 1-hour TTL, all events from the test window (pod scheduling, container restarts, liveness probe failures) had been garbage-collected by the apiserver. This left us unable to determine whether sorbet-fwd or sorbet-azure experienced restarts or probe failures during the critical window.

Increasing the TTL to 4 hours ensures events survive for the full duration of any CI job, making them available in the `kind export logs` output alongside the Fluent Bit persistent logs added in [PR #2350](https://github.com/scality/Zenko/pull/2350).

Issue: [ZENKO-5217](https://scality.atlassian.net/browse/ZENKO-5217)

[ZENKO-5217]: https://scality.atlassian.net/browse/ZENKO-5217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ