### PR TITLE
Use sourceRegistry from deps.yaml for sorbet/drctl in ctst Dockerfile

### DIFF
--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -425,8 +425,10 @@ jobs:
         working-directory: solution
         run: |-
           cat <<EOF >> $GITHUB_ENV
+          SORBET_IMAGE=$(yq eval '.sorbet | .sourceRegistry + "/" + .image' deps.yaml)
           SORBET_TAG=$(yq eval '.sorbet.tag' deps.yaml)
-          DRCTL_TAG=$(yq eval .drctl.tag deps.yaml)
+          DRCTL_IMAGE=$(yq eval '.drctl | .sourceRegistry + "/" + .image' deps.yaml)
+          DRCTL_TAG=$(yq eval '.drctl.tag' deps.yaml)
           EOF
       - name: Build and push CI image
         uses: docker/build-push-action@v5
@@ -437,7 +439,9 @@ jobs:
           secrets: |
             GIT_AUTH_TOKEN=${{ steps.app-token.outputs.token }}
           build-args: |
+            SORBET_IMAGE=${{ env.SORBET_IMAGE }}
             SORBET_TAG=${{ env.SORBET_TAG }}
+            DRCTL_IMAGE=${{ env.DRCTL_IMAGE }}
             DRCTL_TAG=${{ env.DRCTL_TAG }}
           tags: "${{ env.E2E_CTST_IMAGE_NAME }}:${{ env.E2E_IMAGE_TAG }}"
           cache-from: type=gha,scope=end2end-ctst

--- a/tests/ctst/Dockerfile
+++ b/tests/ctst/Dockerfile
@@ -1,8 +1,10 @@
+ARG SORBET_IMAGE=ghcr.io/scality/sorbet
 ARG SORBET_TAG=latest
+ARG DRCTL_IMAGE=ghcr.io/scality/zenko-drctl
 ARG DRCTL_TAG=latest
 
-FROM ghcr.io/scality/sorbet:$SORBET_TAG AS sorbet
-FROM ghcr.io/scality/zenko-drctl:$DRCTL_TAG AS drctl
+FROM $SORBET_IMAGE:$SORBET_TAG AS sorbet
+FROM $DRCTL_IMAGE:$DRCTL_TAG AS drctl
 
 FROM node:22.19.0-bookworm-slim
 


### PR DESCRIPTION
## Summary

- The ctst Dockerfile hardcoded `ghcr.io/scality` as the registry for sorbet and drctl images, ignoring the `sourceRegistry` field in `deps.yaml`
- Extract the full image path (`sourceRegistry + image`) from `deps.yaml` using `yq` in the workflow, pass it as Docker build args
- The Dockerfile now uses `SORBET_IMAGE` and `DRCTL_IMAGE` ARGs with backward-compatible defaults

## Why inline yq rather than a shared helper

The `sourceRegistry + "/" + image` extraction pattern is already duplicated across 13 call sites in 7 files, each with slightly different needs (with/without tag, with/without `docker.io` fallback, iterating all images vs. a single named image). Here is the full picture:

### Existing sourceRegistry extraction patterns

| File | Function | yq pattern | `docker.io` fallback | Includes tag | Call stack |
|---|---|---|---|---|---|
| `solution/kafka_build_vars.sh:10` | `get_image_from_deps()` | `.$dep_name \| .sourceRegistry + "/" + .image` | Yes | No | `end2end.yaml:320` (build-kafka job) |
| `solution/build.sh:87` | `flatten_source_images()` | `.* \| select(.image) \| .sourceRegistry + "/" + .image + ":" + .tag` | Yes | Yes | `end2end.yaml:280` (build-iso job) |
| `solution/build.sh:98` | `dependencies_versions_env()` | `.[] \| select(.image) \| .envsubst + "=" + .image` | **No registry at all** | No | `end2end.yaml:280` (build-iso job) |
| `solution/build.sh:226` | `get_component_dashboards()` | `.* \| select(.dashboard) \| .sourceRegistry + "/" + .dashboard + ":" + .tag` | No | Yes | build-iso job |
| `solution/build.sh:243` | `copy_iam_policies()` | `.* \| select(.policy) \| .sourceRegistry + "/" + .policy + ":" + .tag` | No | Yes | build-iso job |
| `solution/build.sh:255` | `copy_config()` | `.* \| select(.config) \| .sourceRegistry + "/" + .config + ":" + .tag` | No | Yes | build-iso job |
| `solution/build.sh:356` | `download_tools()` | `.[] \| .sourceRegistry + "/" + .image + ":" + .tag` | No | Yes | build-iso job |
| `solution-base/build.sh:67` | `flatten_source_images()` | `.* \| .sourceRegistry + "/" + .image + ":" + .tag` | Yes | Yes | `install-kind-dependencies.sh:211` |
| `install-kind-dependencies.sh:236` | `get_image_from_deps()` | `.$dep_name \| .sourceRegistry + "/" + .image + ":" + .tag` | Yes | Yes | deploy action |
| `deploy-zenko.sh:58` | `dependencies_image_env()` | `.[] \| .envsubst + "=" + .sourceRegistry + "/" + .image` | Yes | No | deploy action |
| `deploy-zenko.sh:64` | `dependencies_dashboard_env()` | `.[] \| .envsubst + "=" + .sourceRegistry + "/" + .dashboard` | Yes | No | deploy action |
| `deploy-zenko.sh:70` | `dependencies_policy_env()` | `.[] \| .envsubst + "=" + .sourceRegistry + "/" + .policy` | Yes | No | deploy action |
| `deploy-zenko.sh:76` | `dependencies_config_env()` | `.[] \| .envsubst + "=" + .sourceRegistry + "/" + .config` | Yes | No | deploy action |
| `deploy-zkop.sh:5` | inline | `."zenko-operator" \| .sourceRegistry + "/" + .image` | No | No | deploy action |

Each function builds the string slightly differently depending on its needs. Refactoring all 13 sites into a shared helper would be a separate effort. This PR adds one more inline call, consistent with the existing `deploy-zkop.sh` style (no `docker.io` fallback, no tag — both sorbet and drctl always have `sourceRegistry` defined in `deps.yaml`).

Consolidating the duplication into a shared utility could be done in a follow-up PR.

Fixes [ZENKO-5220](https://scality.atlassian.net/browse/ZENKO-5220)

[ZENKO-5220]: https://scality.atlassian.net/browse/ZENKO-5220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ