### PR TITLE
rework website ctst test to preconfigure the overlay before running t…

### DIFF
--- a/.github/scripts/end2end/configure-e2e-ctst.sh
+++ b/.github/scripts/end2end/configure-e2e-ctst.sh
@@ -2,6 +2,7 @@
 set -exu
 
 DIR=$(dirname "$0")
+. "$DIR"/common.sh
 
 # Get kafka image name and tag
 kafka_image() {
@@ -78,6 +79,21 @@ UUID=${UUID:1}
 
 echo "127.0.0.1 iam.zenko.local s3-local-file.zenko.local keycloak.zenko.local \
     sts.zenko.local management.zenko.local s3.zenko.local website.mywebsite.com utilization.zenko.local" | sudo tee -a /etc/hosts
+
+# Add website endpoint to the overlay so it doesn't trigger reconciliation during tests
+INSTANCE_ID=$(kubectl get zenko ${ZENKO_NAME} -o jsonpath='{.status.instanceID}')
+MGMT_TOKEN=$(get_token)
+WEBSITE_HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+    -H "Content-Type: application/json" \
+    -H "X-Authentication-Token: ${MGMT_TOKEN}" \
+    "http://management.zenko.local/api/v1/config/${INSTANCE_ID}/website/endpoint" \
+    -d '"mywebsite.com"')
+if [ "$WEBSITE_HTTP_CODE" = "200" ] || [ "$WEBSITE_HTTP_CODE" = "409" ]; then
+    echo "Website endpoint registered successfully (HTTP $WEBSITE_HTTP_CODE)"
+else
+    echo "Failed to register website endpoint (HTTP $WEBSITE_HTTP_CODE)" >&2
+    exit 1
+fi
 
 # Add bucket notification target
 envsubst < ./configs/notification_destinations.yaml | kubectl apply -f -

--- a/tests/ctst/features/bucketWebsite.feature
+++ b/tests/ctst/features/bucketWebsite.feature
@@ -6,13 +6,13 @@ Feature: Bucket Websites
     Scenario Outline: Bucket Website CRUD
         # The scenario should test that we can put a bucket website configuration on a bucket
         # send an index.html
-        # And also use a pensieve API to add the new endpoint to the list
         # Then using the local etc hosts, we should be able to load the html page
+        # The mywebsite.com endpoint is pre-configured in configure-e2e-ctst.sh to avoid triggering reconciliation
         Given an existing bucket "website" "" versioning, "without" ObjectLock "without" retention mode
         And an index html file
         When the user puts the bucket website configuration
         And the user creates an S3 Bucket policy granting public read access
-        And the "<domain>" endpoint is added to the overlay
+        And the "<domain>" endpoint is present in the overlay
         Then the user should be able to load the index.html file from the "<domain>" endpoint
 
         Examples:

--- a/tests/ctst/steps/website/website.ts
+++ b/tests/ctst/steps/website/website.ts
@@ -29,8 +29,10 @@ When('the user puts the bucket website configuration', async function (this: Zen
     });
 });
 
-When('the {string} endpoint is added to the overlay', async function (this: Zenko, endpoint: string) {
-    await this.addWebsiteEndpoint(endpoint);
+When('the {string} endpoint is present in the overlay', async function (this: Zenko, endpoint: string) {
+    const found = await this.verifyWebsiteEndpoint(endpoint);
+    assert.strictEqual(found, true,
+        `Website endpoint '${endpoint}' not found in overlay after 60 retries`);
 });
 
 When('the user creates an S3 Bucket policy granting public read access', async function (this: Zenko) {

--- a/tests/ctst/world/Zenko.ts
+++ b/tests/ctst/world/Zenko.ts
@@ -989,14 +989,18 @@ export default class Zenko extends World<ZenkoWorldParameters> {
         }
     }
 
-    async addWebsiteEndpoint(this: Zenko, endpoint: string):
-        Promise<{ statusCode: number; data: object } | { statusCode: number; err: unknown }> {
-        return await this.managementAPIRequest('POST',
-            `/config/${this.parameters.InstanceID}/website/endpoint`,
-            {
-                'Content-Type': 'application/json',
-            },
-            `"${endpoint}"`);
+    async verifyWebsiteEndpoint(this: Zenko, endpoint: string): Promise<boolean> {
+        const result = await this.managementAPIRequest('GET',
+            `/config/overlay/view/${this.parameters.InstanceID}`);
+        if (result.statusCode !== 200) {
+            this.logger.debug('Error when making management API request for verifyWebsiteEndpoint', {
+                statusCode: result.statusCode,
+                endpoint,
+            });
+            return false;
+        }
+        const { data } = result as { statusCode: number; data: { websiteEndpoints?: string[] } };
+        return (data.websiteEndpoints ?? []).includes(endpoint);
     }
 
     async deleteLocation(this: Zenko, locationName: string):


### PR DESCRIPTION
Issue: ZENKO-5221

Rule 3 from "how to write tests" : 

## 3. Do not reconfigure the environment if it affects other tests' resources.

If a reconfiguration triggers a reconciliation of the resources, running tests
might be affected. Also, it restarts the services, which leads to missing logs,
harder debugging, and longer test execution.

For examples, location creation or bucket Website endpoints, that triggers a
restart of multiple services, must be created before the test starts, or in a
dedicated set of tests, that is, a set of test executed before all tests having
a specific tag used for identifying the feature(s).

Note: Testing the reconfiguration of the environment is recommended, but it
should be done carefully to not affect other tests.