### PR TITLE
fix: bump Cruise Control to 2.5.123 for cgroup v2 compatibility

### DIFF
--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -67,7 +67,7 @@ kafka-connect:
 kafka-cruise-control:
   sourceRegistry: ghcr.io/banzaicloud
   image: cruise-control
-  tag: 2.5.101
+  tag: 2.5.123
   envsubst: KAFKA_CRUISECONTROL_TAG
 kafka-lag-exporter:
   sourceRegistry: seglo


### PR DESCRIPTION
## Summary

The Cruise Control pod (`end2end-base-queue-cruisecontrol`) enters **CrashLoopBackOff** on hosts with cgroup v2 (e.g. kernel 6.19+). This PR bumps the Cruise Control image from `2.5.101` to `2.5.123` to resolve it.

Fixes [ZENKO-5227](https://scality.atlassian.net/browse/ZENKO-5227)

## Scope of impact

This only affects **local development environments and the Zenko CI pipeline** — anywhere the cluster runs on a host kernel that defaults to cgroup v2 (e.g. Arch Linux, Fedora, Ubuntu 22.04+, or any kernel 5.2+ with cgroup v2 enabled). ARTESCA production clusters are **not affected**: ARTESCA deploys on **Rocky Linux 8.10** (kernel 4.18), which uses **cgroup v1**. The JDK's `CgroupV2Subsystem` code path is never reached on cgroup v1 hosts, so the bug cannot trigger there.

That said, this would become a blocker if ARTESCA ever moves to RHEL 9 / Rocky 9 (kernel 5.14+, cgroup v2 by default).

## The error

The pod crashes on startup with a fatal JVM abort:

```
Exception in thread "main" java.lang.reflect.InvocationTargetException
Caused by: java.lang.NullPointerException
    at jdk.internal.platform.cgroupv2.CgroupV2Subsystem.getInstance(Unknown Source)
    at jdk.internal.platform.CgroupSubsystemFactory.create(Unknown Source)
    ...
    at java.lang.management.ManagementFactory.getOperatingSystemMXBean(Unknown Source)
    at io.prometheus.jmx.shaded.io.prometheus.client.hotspot.StandardExports.<init>(StandardExports.java:43)
    at io.prometheus.jmx.shaded.io.prometheus.jmx.JavaAgent.premain(JavaAgent.java:30)

FATAL ERROR in native method: processing of -javaagent failed, processJavaStart failed
```

The JMX Prometheus Java agent (`-javaagent`) runs during JVM startup. It calls `DefaultExports.initialize()` → `ManagementFactory.getOperatingSystemMXBean()` → `CgroupV2Subsystem.getInstance()`, which throws a `NullPointerException` when parsing cgroup v2 filesystem entries. Since Java treats agent `premain` failures as fatal, the entire JVM aborts before Cruise Control can start.

## Root cause

The Cruise Control image `2.5.101` ships **JDK 11.0.16.1** (Eclipse Temurin), which has a bug in its cgroup v2 support. The `CgroupV2Subsystem.getInstance()` method fails with an NPE on newer kernels (verified on 6.19.8-arch1-1 with cgroup2 mounts). This is reproducible even without the JMX agent — simply running `java -XshowSettings:system` in the container triggers the same crash.

This is **not** a JMX exporter version issue. The bug is in the JDK itself.

## The fix

Bump `cruise-control` from `2.5.101` to `2.5.123` in `solution/deps.yaml`. The `2.5.123` image ships **JDK 17.0.7** (Eclipse Temurin), which handles cgroup v2 correctly. Verified by running `java -XshowSettings:system` in a `2.5.123` container — it reads cgroup v2 metrics without error.

The upstream changes between Cruise Control 2.5.101 and 2.5.123 (LinkedIn's cruise-control) are patch-level: CVE dependency bumps (snakeyaml, scala, Netty, org.json), bug fixes (leader CPU util, offline partitions, concurrency adjuster NPE), and non-breaking additions (partition movement metrics, per-broker concurrency adjuster). No config format changes, no removed APIs. The [docker-cruise-control](https://github.com/banzaicloud/docker-cruise-control) Dockerfile diff between the two tags is just a JDK 11→17 bump, a Node 16→20 bump (build-time only), and OCI labels.

## Alternatives considered

1. **Add `-XX:-UseContainerSupport` to `KAFKA_OPTS`**: This disables the JDK's container/cgroup detection entirely, sidestepping the crash. Confirmed working. Rejected because it also disables memory/CPU limit awareness — the JVM would ignore container resource constraints, which could cause OOM kills or CPU overuse.

2. **Upgrade only the JMX exporter** (from 0.16.1 to 0.17.1+): Initially suspected as the fix, but the bug is in the JDK, not the exporter. Upgrading the exporter alone would not help since `CgroupV2Subsystem.getInstance()` is called by the JDK's `ManagementFactory`, not by the exporter directly.

3. **Pin to a patched JDK 11 build**: JDK 11.0.19+ has cgroup v2 fixes. However, there is no `cruise-control` image built with a patched JDK 11 — Banzai moved to JDK 17 starting with `2.5.113`. Building a custom image would add maintenance burden for no benefit over using the upstream `2.5.123`.

[ZENKO-5227]: https://scality.atlassian.net/browse/ZENKO-5227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ