### PR TITLE
fix: add @Exclusive tag to prevent cluster-mutating tests from running in parallel

### DIFF
--- a/tests/ctst/HOW_TO_WRITE_TESTS.md
+++ b/tests/ctst/HOW_TO_WRITE_TESTS.md
@@ -36,13 +36,16 @@ restart of multiple services, must be created before the test starts, or in a
 dedicated set of tests, that is, a set of test executed before all tests having
 a specific tag used for identifying the feature(s).
 
-Note: Testing the reconfiguration of the environment is recommended, but it
-should be done carefully to not affect other tests.
+When a scenario *must* reconfigure the environment (e.g., create or modify
+locations, add overlay endpoints), tag it with `@Exclusive`. This ensures no
+other scenario runs in parallel while the exclusive scenario executes, and the
+exclusive scenario only starts once all running scenarios have finished. See
+the implementation in `common/hooks.ts`.
 
-## 4. Do not use `atMostOnePicklePerTag`.
+## 4. Avoid unnecessary parallel restrictions.
 
-If a set of scenario requires the use of `atMostOnePicklePerTag`, they won't
-be executed in parallel, which is:
+Adding `atMostOnePicklePerTag` for a set of scenarios means they won't be
+executed in parallel, which is:
 
 - Not realistic for the production environment.
 - Not efficient for the test execution: the duration of tests will suffer.
@@ -58,6 +61,11 @@ possible. Solutions exist:
   for unit or functional testing, but in integration tests, prefer using
   relative checks.
 - As a last resort, we might have a dedicated test suite.
+
+Note: `@Exclusive` (see **Rule #3**) is an exception — it is reserved for
+scenarios that mutate cluster-wide state (location creation, overlay changes)
+and cannot be made idempotent because the operator reconciliation affects all
+running pods. Use it sparingly.
 
 ## 5. Focus on validating features.
 

--- a/tests/ctst/common/hooks.ts
+++ b/tests/ctst/common/hooks.ts
@@ -32,7 +32,21 @@ const noParallelRun = atMostOnePicklePerTag([
     ...replicationLockTags
 ]);
 
-setParallelCanAssign(noParallelRun);
+const EXCLUSIVE_TAG = '@Exclusive';
+
+function hasTag(pickle: { tags: readonly { name: string }[] }, tagName: string): boolean {
+    return pickle.tags.some(t => t.name === tagName);
+}
+
+setParallelCanAssign((pickle, runningPickles) => {
+    if (runningPickles.some(p => hasTag(p, EXCLUSIVE_TAG))) {
+        return false;
+    }
+    if (hasTag(pickle, EXCLUSIVE_TAG)) {
+        return runningPickles.length === 0;
+    }
+    return noParallelRun(pickle, runningPickles);
+});
 
 Before(async function (this: Zenko, scenario: ITestCaseHookParameter) {
     this.resetSaved();

--- a/tests/ctst/features/azureArchive.feature
+++ b/tests/ctst/features/azureArchive.feature
@@ -45,6 +45,7 @@ Feature: Azure Archive
     @Flaky
     @AzureArchive
     @ColdStorage
+    @Exclusive
     Scenario Outline: Create, read, update and delete azure archive location
     Given an azure archive location "<locationName>"
     And a "<versioningConfiguration>" bucket

--- a/tests/ctst/features/bucketWebsite.feature
+++ b/tests/ctst/features/bucketWebsite.feature
@@ -3,6 +3,7 @@ Feature: Bucket Websites
     @2.6.0
     @PreMerge
     @BucketWebsite
+    @Exclusive
     Scenario Outline: Bucket Website CRUD
         # The scenario should test that we can put a bucket website configuration on a bucket
         # send an index.html

--- a/tests/ctst/features/pra.feature
+++ b/tests/ctst/features/pra.feature
@@ -5,6 +5,7 @@ Feature: PRA operations
     @Dmf
     @PRA
     @ColdStorage
+    @Exclusive
     Scenario Outline: PRA (nominal case)
     # Prepare objects in the primary site
     Given a "<versioningConfiguration>" bucket


### PR DESCRIPTION
## Summary

Fixes intermittent CI failures in `ctst-end2end-sharded` caused by parallel cucumber workers interfering with each other when one worker runs scenarios that mutate cluster-wide state.

## Problem

The `ctst-end2end-sharded` job runs cucumber with 4 parallel workers (`--parallel $PARALLEL_RUNS`). Some test scenarios create or modify Zenko locations via the management API, which triggers operator reconciliation and rolling restarts of backbeat components (replication data processor, notification processors, sorbet, etc.).

When these cluster-mutating scenarios run in one worker, the other 3 workers' tests are affected — their backbeat pods get killed and recreated mid-flight, causing replication timeouts, kafka cleaner failures, and azure archive restore retry timeouts.

### Observed failure (run [#8809](https://github.com/scality/Zenko/actions/runs/23290876091/job/67726138043))

8 out of 4418 scenarios failed:
- 6 replication scenarios (s3utils + location stripping) — objects stuck in pending/processing state
- 1 azure archive restore retry — timeout waiting for restored state
- 1 kafka cleaner — topics not cleaned in time

### Root cause timeline

1. **11:08** — Azure archive CRUD test starts on worker pid:62, creates location `e2e-azure-archive-2-non-versioned` via `POST /config/{id}/location`
2. **11:08–11:28** — Operator reconciles, triggering **23+ rolling update events** for `backbeat-replication-data-processor` across 6 different ReplicaSets. The data processor is killed and recreated **15 times**.
3. **11:22–11:28** — A replication-data-processor pod fails to mount `backbeat-config` secret (v21 doesn't exist yet), is killed. Processor is **completely down** for 6 minutes.
4. **11:28:39** — Final processor pod created, becomes ready at ~11:29
5. **11:29:10** — Replication tests start on workers pid:48 and pid:54 — **seconds** after the processor came up. The freshly-started processor hasn't re-joined Kafka consumer groups yet.
6. **11:34–11:46** — All 6 replication scenarios timeout (300s) because the processor can't keep up.

The CRUD scenario creates 3 locations + modifies 3 locations = 6 reconciliation rounds, each triggering a full rolling restart of all backbeat deployments. The `waitForZenkoToStabilize()` call in the CRUD test only blocks that specific worker — the other 3 workers are unaware that pods are being churned.

## Solution

Add an `@Exclusive` tag mechanism to cucumber's `setParallelCanAssign` that gives tagged scenarios **exclusive access to all workers**:

- When an `@Exclusive` scenario is running, no other scenario can start on any worker
- An `@Exclusive` scenario only starts when all other running scenarios have finished
- The existing `atMostOnePicklePerTag` logic for `@ColdStorage`, `@PRA`, etc. is preserved as a fallback

This is safe from races because the coordinator runs in a single Node.js process — `setParallelCanAssign` is called synchronously from the event loop when deciding work placement. Cucumber also has a built-in deadlock safety valve: if all workers go idle but pickles remain, it force-assigns the first one.

### Scenarios tagged with `@Exclusive`

| Scenario | Feature | Mutation |
|---|---|---|
| Create, read, update and delete azure archive location | azureArchive.feature | Creates 3 locations + modifies them → 6 reconciliation rounds |
| Bucket Website CRUD | bucketWebsite.feature | Adds endpoint to overlay (no stabilization wait) |
| PRA (nominal case) | pra.feature | Installs/uninstalls entire DR site |

Note: "Pause and resume archiving to azure" was initially tagged but removed after review — it only calls the Backbeat API (`/_/lifecycle/pause/{location}`) and does not modify the overlay or trigger operator reconciliation.

## Alternatives considered

1. **Move location creation to `configure-e2e-ctst.sh`** — Would eliminate the problem for azure archive CRUD but doesn't generalize to other cluster-mutating scenarios (PRA, website). Would also require significant refactoring of the CRUD test itself.

2. **Tag-based ordering (run mutating tests in a separate phase)** — Cucumber doesn't natively support phased execution. Would require splitting into multiple `cucumber-js` invocations, losing the single-report output.

3. **Reduce parallelism globally** — Would slow down all tests, not just the problematic ones.

The `@Exclusive` approach is the most targeted: it only serializes the specific scenarios that cause cluster-wide churn, while allowing all other tests to run in parallel as before.

## Estimated performance impact

Based on a successful run ([attempt 4 of #8809](https://github.com/scality/Zenko/actions/runs/23298613626/job/67798316620)):

| Scenario | Duration | Extra wall-clock if exclusive |
|---|---|---|
| Azure CRUD (3 examples + 1 retry) | ~17 min | ~13 min |
| Bucket Website CRUD | ~1s | ~0s |
| PRA | N/A (excluded by `not @PRA`) | 0 |

**Current pipeline: ~82 min → estimated with `@Exclusive`: ~95 min (+16%)**

Without retries, the cost drops to ~10%. This is a worthwhile tradeoff for eliminating a major source of CI flakiness that currently requires re-running the entire job (adding 82+ min per retry).

Issue: ZENKO-5228