### PR TITLE
fix(ci): sequence mongodb sharded deploy to prevent mongos hang

### DIFF
--- a/.github/scripts/end2end/install-kind-dependencies.sh
+++ b/.github/scripts/end2end/install-kind-dependencies.sh
@@ -285,8 +285,22 @@ mongodb_sharded() {
 
     kubectl apply -f "$base_yaml_path"
 
-    kubectl rollout status statefulset data-db-mongodb-sharded-mongos --timeout=5m
+    # Hold mongos back until configsvr is ready to avoid a race where mongos
+    # tries to auth against configsvr before its replica set is initialized,
+    # causing mongosh to hang indefinitely (no timeout in the entrypoint).
+    local mongos_replicas=$(kubectl get statefulset \
+        -l app.kubernetes.io/name=mongodb-sharded,app.kubernetes.io/component=mongos \
+        -o jsonpath='{.items[0].spec.replicas}')
+    kubectl scale statefulset \
+        -l app.kubernetes.io/name=mongodb-sharded,app.kubernetes.io/component=mongos \
+        --replicas=0
+
     kubectl rollout status statefulset data-db-mongodb-sharded-configsvr --timeout=5m
+
+    kubectl scale statefulset \
+        -l app.kubernetes.io/name=mongodb-sharded,app.kubernetes.io/component=mongos \
+        --replicas=$mongos_replicas
+    kubectl rollout status statefulset data-db-mongodb-sharded-mongos --timeout=5m
 
     for ((i=0; i<MONGODB_SHARD_COUNT; i++)); do
         kubectl rollout status statefulset "data-db-mongodb-sharded-shard${i}-data" --timeout=5m


### PR DESCRIPTION
## Summary

Fixes a ~20% flaky failure rate on `ctst-end2end-sharded` caused by a race condition
in the Bitnami mongodb-sharded entrypoint during mongos startup.

## Problem

When `kubectl apply` deploys all MongoDB sharded StatefulSets at once (configsvr,
mongos, shards), mongos sometimes starts before configsvr's replica set is fully
initialized. The Bitnami mongos entrypoint does:

1. `wait-for-port` on configsvr:27017 — succeeds as soon as the port is open
2. Prints `"Found MongoDB server listening at configsvr:27017 !"`
3. Runs `mongosh --host configsvr -u root -p <pw> admin` with `db.getUsers()` to
   verify the node is available

Step 3 is the problem: configsvr's port may be open while the replica set is still
initializing (primary election, auth user creation). The `mongosh` call has **no
timeout** in the entrypoint (`mongodb_execute_print_output` in `libmongodb-sharded.sh`),
so it blocks forever waiting for a usable authenticated session.

Meanwhile, shard0-data-0 completes its own replica set init, stops `mongod`, and tries
to connect to mongos to register itself as a shard. Since mongos never started, shard0
loops on `"timeout reached before the port went into state inuse"`. The liveness probe
(`pgrep mongod`, `initialDelaySeconds: 60`, `failureThreshold: 2`) kills shard0 every
~2 minutes because `mongod` was stopped for reconfiguration. The 5-minute rollout
timeout on mongos expires, and the job fails.

This was confirmed across 3 consecutive CI attempts (run 23301276674, attempts 2-4),
all showing identical behavior: configsvr healthy, mongos hung after configsvr
connection, shard0 crash-looping from liveness kills.

**Why it's flaky (not deterministic):** the race window is narrow. 80% of the time,
configsvr completes replica set init before mongos reaches the `mongosh` auth check.
20% of the time, mongos wins the race and hangs.

## Solution

Sequence the deploy so mongos only starts after configsvr is fully ready:

1. `kubectl apply` the full manifest (all StatefulSets created)
2. Immediately scale mongos to 0 replicas (configsvr and shards start normally)
3. Wait for configsvr rollout (readiness probe = `mongosh` auth succeeds = replica set
   fully initialized)
4. Scale mongos back to its original replica count
5. Wait for mongos and shard rollouts

This ensures that when mongos starts, configsvr is guaranteed to be fully initialized,
so the `mongosh` auth check succeeds immediately.

## Alternatives considered

**Enable `startupProbe` on mongos and shard data nodes:** The Bitnami chart ships with
`startupProbe.enabled: false` for mongos and shards (only configsvr has it enabled).
Enabling it would prevent the liveness probe from killing shard0 during init, giving
more time for the deadlock to self-resolve. However, this only treats the symptom — it
gives more time but doesn't prevent the `mongosh` hang on mongos. If configsvr is slow
enough, mongos would still hang indefinitely. We may still want to enable startupProbes
as a defense-in-depth measure separately.

**Wrap `mongosh` with `timeout` in the entrypoint:** Would fix the root cause (the
missing timeout), but requires patching the Bitnami container image or injecting a
custom entrypoint script. Higher maintenance burden for a vendored chart.

**Increase `MONGODB_INIT_RETRY_ATTEMPTS` / `MONGODB_INIT_RETRY_DELAY`:** These control
the `retry_while` wrapper around the `mongosh` call. However, since `mongosh` itself
blocks indefinitely (the first attempt never returns), `retry_while` never gets a
chance to retry. These settings would have no effect on the hang.

**Split the manifest and apply resources separately:** Would also work, but requires
`yq` to filter multi-document YAML by resource kind. The scale-to-zero approach is
simpler — it uses only `kubectl` and doesn't require parsing the manifest.

Issue: ZENKO-5229