### PR TITLE
e2e scripts: add rootless podman and local environment support

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -3,6 +3,16 @@
 
 A [VS Code extension](https://marketplace.visualstudio.com/items?itemName=GitHub.codespaces) is available for Codespaces.
 
+## Pre-setup: /etc/hosts (local environments only)
+
+When running locally (not in a Codespace/devcontainer where you are root),
+the CTST configuration script needs Zenko hostnames to resolve to localhost.
+Add them before running setup to avoid a `sudo` prompt mid-run:
+
+```bash
+echo "127.0.0.1 iam.zenko.local s3-local-file.zenko.local keycloak.zenko.local sts.zenko.local management.zenko.local s3.zenko.local website.mywebsite.com utilization.zenko.local aws-mock.zenko.local azure-mock.zenko.local blob.azure-mock.zenko.local queue.azure-mock.zenko.local devstoreaccount1.blob.azure-mock.zenko.local devstoreaccount1.queue.azure-mock.zenko.local dr.zenko.local" | sudo tee -a /etc/hosts
+```
+
 ## Running CTST tests in the codespace
 
 ```bash

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -6,6 +6,9 @@ env_variables=$(yq eval '.env | to_entries | .[] | .key + "=" + .value' .github/
 export GIT_ACCESS_TOKEN=${GITHUB_TOKEN}
 export E2E_IMAGE_TAG=latest
 
+export VOLUME_ROOT=$PWD/artifacts
+mkdir -p "${VOLUME_ROOT}/data"
+
 # Disable GCP tests as we don't have credentials setup in devcontainer
 export GCP_BACKEND_DESTINATION_LOCATION=
 

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -7,6 +7,7 @@ export GIT_ACCESS_TOKEN=${GITHUB_TOKEN}
 export E2E_IMAGE_TAG=latest
 
 export VOLUME_ROOT=$PWD/artifacts
+export HOST_DNS=$(awk '/^nameserver/{print $2; exit}' /etc/resolv.conf)
 mkdir -p "${VOLUME_ROOT}/data"
 
 # Disable GCP tests as we don't have credentials setup in devcontainer

--- a/.github/scripts/end2end/bootstrap-kind.sh
+++ b/.github/scripts/end2end/bootstrap-kind.sh
@@ -82,13 +82,37 @@ $(add_workers)
 EOF
 }
 
+needs_delegated_scope() {
+  # When running rootless podman from a graphical terminal (e.g. GNOME/VTE),
+  # cgroup controllers may not be delegated to the process's cgroup, causing
+  # kind to fail. Detect this by checking what podman sees.
+  # See https://kind.sigs.k8s.io/docs/user/rootless/#creating-a-kind-cluster-with-rootless-podman
+  if [ "$(docker info --format '{{.Host.Security.Rootless}}' 2>/dev/null)" != "true" ]; then
+    return 1
+  fi
+  controllers=$(docker info --format '{{.Host.CgroupControllers}}' 2>/dev/null) || return 1
+  for c in cpu memory pids; do
+    case "$controllers" in
+      *"$c"*) ;;
+      *) return 0 ;;
+    esac
+  done
+  return 1
+}
+
 create_cluster() {
   if kind get clusters | grep -q "^${CLUSTER_NAME}$"; then
     echo "Kind cluster ${CLUSTER_NAME} already exists. Skipping creation."
     return
   fi
 
-  kind create cluster --name=${CLUSTER_NAME} --config=config.yaml
+  DELEGATE=""
+  if needs_delegated_scope; then
+    echo "cgroup controllers not fully available, running kind under a delegated systemd scope"
+    DELEGATE="systemd-run --user --scope --property=Delegate=yes"
+  fi
+
+  $DELEGATE kind create cluster --name=${CLUSTER_NAME} --config=config.yaml
 }
 
 create_registry

--- a/.github/scripts/end2end/bootstrap-kind.sh
+++ b/.github/scripts/end2end/bootstrap-kind.sh
@@ -6,29 +6,6 @@ NODE_IMAGE=${1:-kindest/node:kindest/node:v1.32.8@sha256:abd489f042d2b644e2d033f
 VOLUME_ROOT=${2:-/artifacts}
 WORKER_NODE_COUNT=${3:-0}
 CLUSTER_NAME=${CLUSTER_NAME:-kind}
-REG_NAME='kind-registry'
-REG_PORT='5000'
-
-create_registry() {
-    echo "Creating local image registry on localhost:${REG_PORT}"
-
-    if [ "$(docker inspect -f '{{.State.Running}}' "${REG_NAME}" 2>/dev/null)" != 'true' ]; then
-        docker run \
-            -d --restart=always -p "${REG_PORT}:5000" --name "${REG_NAME}" \
-            registry:2
-    fi
-}
-
-connect_registry() {
-    local inspect_filter="{{range .Containers}}{{if eq .Name \"${REG_NAME}\"}}true{{end}}{{end}}"
-    if [ "$(docker network inspect -f "${inspect_filter}" kind 2>/dev/null)" != 'true' ]; then
-      docker network connect kind "${REG_NAME}"
-    fi
-
-    for node in $(kind get nodes --name ${CLUSTER_NAME}); do
-      kubectl annotate --overwrite node "${node}" "kind.x-k8s.io/registry=localhost:${REG_PORT}";
-    done
-}
 
 add_workers() {
     local count=0
@@ -48,10 +25,6 @@ bootstrap_kind() {
     cat > config.yaml << EOF
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
-containerdConfigPatches: 
-- |-
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${REG_PORT}"]
-    endpoint = ["http://${REG_NAME}:${REG_PORT}"]
 nodes:
 - role: control-plane
   image: ${NODE_IMAGE}
@@ -115,7 +88,5 @@ create_cluster() {
   $DELEGATE kind create cluster --name=${CLUSTER_NAME} --config=config.yaml
 }
 
-create_registry
 bootstrap_kind
 create_cluster
-connect_registry

--- a/.github/scripts/end2end/common.sh
+++ b/.github/scripts/end2end/common.sh
@@ -1,11 +1,16 @@
 get_token() {
+    if [[ "${ENABLE_KEYCLOAK_HTTPS}" == "true" ]]; then
+        local scheme=https
+    else
+        local scheme=http
+    fi
     curl -k -H "Host: keycloak.zenko.local" \
         -d "client_id=${OIDC_CLIENT_ID}" \
         -d "username=${OIDC_USERNAME}" \
         -d "password=${OIDC_PASSWORD}" \
         -d "grant_type=password" \
         -d "scope=openid" \
-        https://localhost/auth/realms/${OIDC_REALM}/protocol/openid-connect/token | \
+        ${scheme}://127.0.0.1/auth/realms/${OIDC_REALM}/protocol/openid-connect/token | \
         jq -cr '.id_token'
 }
 

--- a/.github/scripts/end2end/config.yaml
+++ b/.github/scripts/end2end/config.yaml
@@ -1,0 +1,44 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  dnsSearch: []
+nodes:
+- role: control-plane
+  image: kindest/node:v1.32.8@sha256:abd489f042d2b644e2d033f5c2d900bc707798d075e8186cb65e3f1367a9d5a1
+  kubeadmConfigPatches:
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        node-labels: "ingress-ready=true"
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+      extraArgs:
+        event-ttl: "4h0m0s"
+  extraMounts:
+  - hostPath: /home/user/src/Zenko/artifacts/data
+    containerPath: /data
+  - hostPath: /home/user/.docker/config.json
+    containerPath: /var/lib/kubelet/config.json
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 80
+    protocol: TCP
+  - containerPort: 443
+    hostPort: 443
+    protocol: TCP
+- role: worker
+  image: kindest/node:v1.32.8@sha256:abd489f042d2b644e2d033f5c2d900bc707798d075e8186cb65e3f1367a9d5a1
+  extraMounts:
+  - hostPath: /home/user/src/Zenko/artifacts/data
+    containerPath: /data
+  - hostPath: /home/user/.docker/config.json
+    containerPath: /var/lib/kubelet/config.json
+- role: worker
+  image: kindest/node:v1.32.8@sha256:abd489f042d2b644e2d033f5c2d900bc707798d075e8186cb65e3f1367a9d5a1
+  extraMounts:
+  - hostPath: /home/user/src/Zenko/artifacts/data
+    containerPath: /data
+  - hostPath: /home/user/.docker/config.json
+    containerPath: /var/lib/kubelet/config.json

--- a/.github/scripts/end2end/configure-e2e-ctst.sh
+++ b/.github/scripts/end2end/configure-e2e-ctst.sh
@@ -76,8 +76,12 @@ UUID=$(kubectl get secret -l app.kubernetes.io/name=backbeat-config,app.kubernet
 UUID=${UUID%.*}
 UUID=${UUID:1}
 
-echo "127.0.0.1 iam.zenko.local s3-local-file.zenko.local keycloak.zenko.local \
-    sts.zenko.local management.zenko.local s3.zenko.local website.mywebsite.com utilization.zenko.local" | sudo tee -a /etc/hosts
+ZENKO_HOSTS="iam.zenko.local s3-local-file.zenko.local keycloak.zenko.local sts.zenko.local management.zenko.local s3.zenko.local website.mywebsite.com utilization.zenko.local"
+for host in $ZENKO_HOSTS; do
+    if ! grep -q "$host" /etc/hosts; then
+        echo "127.0.0.1 $host" | sudo tee -a /etc/hosts
+    fi
+done
 
 # Add bucket notification target
 envsubst < ./configs/notification_destinations.yaml | kubectl apply -f -

--- a/.github/scripts/end2end/deploy-zkop.sh
+++ b/.github/scripts/end2end/deploy-zkop.sh
@@ -7,11 +7,19 @@ set -ex
 
 docker pull "${OPERATOR_IMAGE_NAME}:${OPERATOR_IMAGE_TAG}"
 kind load docker-image "${OPERATOR_IMAGE_NAME}:${OPERATOR_IMAGE_TAG}"
+docker rmi "${OPERATOR_IMAGE_NAME}:${OPERATOR_IMAGE_TAG}"
 
 OPERATOR_PATH=./.github/scripts/end2end/operator
-git init $OPERATOR_PATH
-cd $OPERATOR_PATH
-git fetch --depth 1 --no-tags https://git:${GIT_ACCESS_TOKEN}@github.com/scality/zenko-operator.git ${OPERATOR_IMAGE_TAG}
-git checkout FETCH_HEAD
+LOCAL_OPERATOR_PATH=../zenko-operator
+if [ -d "$LOCAL_OPERATOR_PATH" ]; then
+    echo "Using local zenko-operator checkout at $LOCAL_OPERATOR_PATH"
+    ln -sfn "$(readlink -f "$LOCAL_OPERATOR_PATH")" "$OPERATOR_PATH"
+else
+    git init $OPERATOR_PATH
+    cd $OPERATOR_PATH
+    git fetch --depth 1 --no-tags https://git:${GIT_ACCESS_TOKEN}@github.com/scality/zenko-operator.git ${OPERATOR_IMAGE_TAG}
+    git checkout FETCH_HEAD
+fi
 
+cd $OPERATOR_PATH
 tilt ci

--- a/.github/scripts/end2end/patch-coredns.sh
+++ b/.github/scripts/end2end/patch-coredns.sh
@@ -4,6 +4,12 @@ set -exu
 
 export ZENKO_NAME=${1:-end2end}
 
+if [ -n "${HOST_DNS:-}" ]; then
+    COREDNS_FORWARD_TARGET="$HOST_DNS"
+else
+    COREDNS_FORWARD_TARGET="/etc/resolv.conf"
+fi
+
 corefile="
 .:53 {
     errors
@@ -41,7 +47,7 @@ corefile="
         ttl 30
     }
     prometheus :9153
-    forward . /etc/resolv.conf
+    forward . ${COREDNS_FORWARD_TARGET}
     cache 30
     loop
     reload


### PR DESCRIPTION
## Summary
- Auto-detect rootless podman and configure kind with delegated systemd scope
- Fix DNS resolution issues caused by podman injecting `dns.podman` search domains
- Support HOST_DNS override for CoreDNS patching in podman environments
- Use `127.0.0.1` instead of `localhost` and add scheme variable for get_token
- Override VOLUME_ROOT for local development, remove unused local registry setup
- Allow using a local zenko-operator checkout if available
- Add /etc/hosts pre-setup documentation and idempotent hosts file checks