### PR TITLE
Add local environment support

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -3,6 +3,16 @@
 
 A [VS Code extension](https://marketplace.visualstudio.com/items?itemName=GitHub.codespaces) is available for Codespaces.
 
+## Pre-setup: /etc/hosts (local environments only)
+
+When running locally (not in a Codespace/devcontainer where you are root),
+the CTST configuration script needs Zenko hostnames to resolve to localhost.
+Add them before running setup to avoid a `sudo` prompt mid-run:
+
+```bash
+echo "127.0.0.1 iam.zenko.local s3-local-file.zenko.local keycloak.zenko.local sts.zenko.local management.zenko.local s3.zenko.local website.mywebsite.com utilization.zenko.local aws-mock.zenko.local azure-mock.zenko.local blob.azure-mock.zenko.local queue.azure-mock.zenko.local devstoreaccount1.blob.azure-mock.zenko.local devstoreaccount1.queue.azure-mock.zenko.local dr.zenko.local" | sudo tee -a /etc/hosts
+```
+
 ## Running CTST tests in the codespace
 
 ```bash

--- a/.github/scripts/end2end/bootstrap-kind.sh
+++ b/.github/scripts/end2end/bootstrap-kind.sh
@@ -82,13 +82,37 @@ $(add_workers)
 EOF
 }
 
+needs_delegated_scope() {
+  # When running rootless podman from a graphical terminal (e.g. GNOME/VTE),
+  # cgroup controllers may not be delegated to the process's cgroup, causing
+  # kind to fail. Detect this by checking what podman sees.
+  # See https://kind.sigs.k8s.io/docs/user/rootless/#creating-a-kind-cluster-with-rootless-podman
+  if [ "$(docker info --format '{{.Host.Security.Rootless}}' 2>/dev/null)" != "true" ]; then
+    return 1
+  fi
+  controllers=$(docker info --format '{{.Host.CgroupControllers}}' 2>/dev/null) || return 1
+  for c in cpu memory pids; do
+    case "$controllers" in
+      *"$c"*) ;;
+      *) return 0 ;;
+    esac
+  done
+  return 1
+}
+
 create_cluster() {
   if kind get clusters | grep -q "^${CLUSTER_NAME}$"; then
     echo "Kind cluster ${CLUSTER_NAME} already exists. Skipping creation."
     return
   fi
 
-  kind create cluster --name=${CLUSTER_NAME} --config=config.yaml
+  DELEGATE=""
+  if needs_delegated_scope; then
+    echo "cgroup controllers not fully available, running kind under a delegated systemd scope"
+    DELEGATE="systemd-run --user --scope --property=Delegate=yes"
+  fi
+
+  $DELEGATE kind create cluster --name=${CLUSTER_NAME} --config=config.yaml
 }
 
 create_registry

--- a/.github/scripts/end2end/bootstrap-kind.sh
+++ b/.github/scripts/end2end/bootstrap-kind.sh
@@ -6,29 +6,6 @@ NODE_IMAGE=${1:-kindest/node:kindest/node:v1.32.8@sha256:abd489f042d2b644e2d033f
 VOLUME_ROOT=${2:-/artifacts}
 WORKER_NODE_COUNT=${3:-0}
 CLUSTER_NAME=${CLUSTER_NAME:-kind}
-REG_NAME='kind-registry'
-REG_PORT='5000'
-
-create_registry() {
-    echo "Creating local image registry on localhost:${REG_PORT}"
-
-    if [ "$(docker inspect -f '{{.State.Running}}' "${REG_NAME}" 2>/dev/null)" != 'true' ]; then
-        docker run \
-            -d --restart=always -p "${REG_PORT}:5000" --name "${REG_NAME}" \
-            registry:2
-    fi
-}
-
-connect_registry() {
-    local inspect_filter="{{range .Containers}}{{if eq .Name \"${REG_NAME}\"}}true{{end}}{{end}}"
-    if [ "$(docker network inspect -f "${inspect_filter}" kind 2>/dev/null)" != 'true' ]; then
-      docker network connect kind "${REG_NAME}"
-    fi
-
-    for node in $(kind get nodes --name ${CLUSTER_NAME}); do
-      kubectl annotate --overwrite node "${node}" "kind.x-k8s.io/registry=localhost:${REG_PORT}";
-    done
-}
 
 add_workers() {
     local count=0
@@ -48,10 +25,6 @@ bootstrap_kind() {
     cat > config.yaml << EOF
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
-containerdConfigPatches: 
-- |-
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${REG_PORT}"]
-    endpoint = ["http://${REG_NAME}:${REG_PORT}"]
 nodes:
 - role: control-plane
   image: ${NODE_IMAGE}
@@ -115,7 +88,5 @@ create_cluster() {
   $DELEGATE kind create cluster --name=${CLUSTER_NAME} --config=config.yaml
 }
 
-create_registry
 bootstrap_kind
 create_cluster
-connect_registry

--- a/.github/scripts/end2end/bootstrap-kind.sh
+++ b/.github/scripts/end2end/bootstrap-kind.sh
@@ -25,6 +25,8 @@ bootstrap_kind() {
     cat > config.yaml << EOF
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  dnsSearch: []
 nodes:
 - role: control-plane
   image: ${NODE_IMAGE}

--- a/.github/scripts/end2end/common.sh
+++ b/.github/scripts/end2end/common.sh
@@ -1,11 +1,16 @@
 get_token() {
+    if [[ "${ENABLE_KEYCLOAK_HTTPS}" == "true" ]]; then
+        local scheme=https
+    else
+        local scheme=http
+    fi
     curl -k -H "Host: keycloak.zenko.local" \
         -d "client_id=${OIDC_CLIENT_ID}" \
         -d "username=${OIDC_USERNAME}" \
         -d "password=${OIDC_PASSWORD}" \
         -d "grant_type=password" \
         -d "scope=openid" \
-        https://localhost/auth/realms/${OIDC_REALM}/protocol/openid-connect/token | \
+        ${scheme}://127.0.0.1/auth/realms/${OIDC_REALM}/protocol/openid-connect/token | \
         jq -cr '.id_token'
 }
 

--- a/.github/scripts/end2end/deploy-zkop.sh
+++ b/.github/scripts/end2end/deploy-zkop.sh
@@ -5,9 +5,15 @@ set -ex
 [ -z "${OPERATOR_IMAGE_TAG}" ] && OPERATOR_IMAGE_TAG="$(yq eval '."zenko-operator".tag' solution/deps.yaml)"
 
 OPERATOR_PATH=./.github/scripts/end2end/operator
-git init $OPERATOR_PATH
-cd $OPERATOR_PATH
-git fetch --depth 1 --no-tags https://git:${GIT_ACCESS_TOKEN}@github.com/scality/zenko-operator.git ${OPERATOR_IMAGE_TAG}
-git checkout FETCH_HEAD
+LOCAL_OPERATOR_PATH=../zenko-operator
+if [ -d "$LOCAL_OPERATOR_PATH" ]; then
+    echo "Using local zenko-operator checkout at $LOCAL_OPERATOR_PATH"
+    ln -sfn "$(readlink -f "$LOCAL_OPERATOR_PATH")" "$OPERATOR_PATH"
+else
+    git init $OPERATOR_PATH
+    git -C $OPERATOR_PATH fetch --depth 1 --no-tags https://git:${GIT_ACCESS_TOKEN}@github.com/scality/zenko-operator.git ${OPERATOR_IMAGE_TAG}
+    git -C $OPERATOR_PATH checkout FETCH_HEAD
+fi
 
+cd $OPERATOR_PATH
 tilt ci

--- a/.github/scripts/end2end/patch-coredns.sh
+++ b/.github/scripts/end2end/patch-coredns.sh
@@ -4,6 +4,12 @@ set -exu
 
 export ZENKO_NAME=${1:-end2end}
 
+if [ -n "${HOST_DNS:-}" ]; then
+    COREDNS_FORWARD_TARGET="$HOST_DNS"
+else
+    COREDNS_FORWARD_TARGET="/etc/resolv.conf"
+fi
+
 corefile="
 .:53 {
     errors
@@ -41,7 +47,7 @@ corefile="
         ttl 30
     }
     prometheus :9153
-    forward . /etc/resolv.conf
+    forward . ${COREDNS_FORWARD_TARGET}
     cache 30
     loop
     reload


### PR DESCRIPTION
## Summary

The end-to-end scripts were designed to run in GitHub Codespaces (Docker-in-Docker).
Running them locally with rootless podman on Linux exposed several issues. This PR
fixes them so the full Zenko stack can be deployed and tested on a local machine.

### DNS timeouts from podman search domains

Podman injects `search dns.podman` into kind node resolv.conf. CoreDNS can't resolve
this domain, adding an 8-second timeout to every DNS lookup. This killed pods that
rely on fast DNS during init (e.g. ZooKeeper exceeded its liveness probe). Fixed by
adding a `config.yaml` for kind with `networking: { dnsSearch: [] }`, which strips
all search clauses.

### curl hangs to localhost

`get_token()` in `common.sh` hardcoded `https://localhost`. Two issues: curl resolves
`localhost` to `::1` (IPv6) first but kind only binds on IPv4, and the scheme was
hardcoded to `https` but keycloak ingress uses `http` when `ENABLE_KEYCLOAK_HTTPS=false`.
Fixed with a scheme variable and `127.0.0.1`.

### CoreDNS can't resolve host DNS

In podman environments, the host DNS server address differs from Docker's default
(`172.17.0.1`). Added `HOST_DNS` override support in `patch-coredns.sh` so it
reads the nameserver from `/etc/resolv.conf` when running outside Docker.

### Other changes

- Auto-detect rootless podman and configure kind with a delegated systemd scope
- Override `VOLUME_ROOT` for local development (no `/mnt` in local environments)
- Remove unused local registry setup from `bootstrap-kind.sh`
- Allow using a local `zenko-operator` checkout instead of always fetching from GitHub
- Make `/etc/hosts` entries idempotent (check before appending)
- Add documentation for required `/etc/hosts` pre-setup

Issue: ZENKO-5243