### PR TITLE
fix(ci): wait for operator reconciliation in bucket website test

### DIFF
--- a/tests/ctst/steps/website/website.ts
+++ b/tests/ctst/steps/website/website.ts
@@ -2,6 +2,7 @@ import assert from 'assert';
 import { Given, When, Then } from '@cucumber/cucumber';
 import Zenko from '../../world/Zenko';
 import { putObject } from '../utils/utils';
+import { waitForZenkoToStabilize, waitForDataServicesToStabilize } from '../utils/kubernetes';
 import { S3, Utils } from 'cli-testing';
 
 const pageMessage = Utils.randomString();
@@ -29,9 +30,12 @@ When('the user puts the bucket website configuration', async function (this: Zen
     });
 });
 
-When('the {string} endpoint is added to the overlay', async function (this: Zenko, endpoint: string) {
-    await this.addWebsiteEndpoint(endpoint);
-});
+When('the {string} endpoint is added to the overlay', { timeout: 15 * 60 * 1000 },
+    async function (this: Zenko, endpoint: string) {
+        await this.addWebsiteEndpoint(endpoint);
+        await waitForZenkoToStabilize(this, true);
+        await waitForDataServicesToStabilize(this);
+    });
 
 When('the user creates an S3 Bucket policy granting public read access', async function (this: Zenko) {
     const policy = {
@@ -82,5 +86,5 @@ Then('the user should be able to load the index.html file from the {string} endp
                 await Utils.sleep(1000);
             }
         }
-        assert.fail('Failed to fetch the bucket website after 20 tries');
+        assert.fail('Failed to fetch the bucket website after 60 tries');
     });


### PR DESCRIPTION
## Summary

The **Bucket Website CRUD** test was flaky in `ctst-end2end-sharded` — it failed in 2 out of 3 run attempts on [run 23431247112](https://github.com/scality/Zenko/actions/runs/23431247112), and only passed the third attempt by 6 seconds.

## Root cause

Adding a website endpoint to the overlay (`POST /config/.../website/endpoint`) triggers a **zenko-operator reconciliation cascade**: the operator detects the overlay change and performs rolling restarts of dependent deployments in sequence:

1. `ops-scuba` (config hash changes)
2. `ops-scuba-external-api`
3. `connector-cloudserver`
4. Ingress creation for the new endpoint

This cascade takes **60–95 seconds**. The test was immediately trying to fetch the website after the API call, with a 60-second retry window (`60 tries × 1s`). When reconciliation took longer than 60 seconds — which it often does — the test timed out before the ingress was even created.

## Solution

After calling `addWebsiteEndpoint()`, wait for the operator to finish reconciling before attempting to fetch:

- **`waitForZenkoToStabilize(this, true)`** — polls the Zenko CR status conditions, first waiting for `DeploymentInProgress=True` (reconciliation detected), then waiting for `Available=True` and `DeploymentInProgress=False` (reconciliation complete).
- **`waitForDataServicesToStabilize(this)`** — waits for deployments depending on `connector-cloudserver-config` and `backbeat-config` to be fully rolled out.

## Design decisions

**Alignment with existing pattern**: This is the same approach used by the azure archive tests, which also modify the overlay (adding/changing locations) and face the same reconciliation cascade. See [`azureArchive.ts` L447–452](https://github.com/scality/Zenko/blob/cdb197d6844d83df3ccf34e7f06b74ac74ab365c/tests/ctst/steps/azureArchive.ts#L447-L452) (creating a location) and [`azureArchive.ts` L455–481](https://github.com/scality/Zenko/blob/cdb197d6844d83df3ccf34e7f06b74ac74ab365c/tests/ctst/steps/azureArchive.ts#L455-L481) (changing a location) — both call `waitForZenkoToStabilize` + `waitForDataServicesToStabilize` after the overlay mutation.

**Step timeout (`{ timeout: 15 * 60 * 1000 }`)**: The project's default cucumber step timeout is 100 seconds (set via `setDefaultTimeout` in `common/common.ts`). Since `waitForZenkoToStabilize` polls until reconciliation completes (up to 15 minutes in the worst case), the step needs an explicit timeout override to avoid being killed prematurely. This matches the timeout used by the [azure archive step](https://github.com/scality/Zenko/blob/cdb197d6844d83df3ccf34e7f06b74ac74ab365c/tests/ctst/steps/azureArchive.ts#L455).

**Stale error message fix**: The retry loop uses 60 iterations but the failure message said "after 20 tries" — corrected to match the actual retry count.

Fixes: [ZENKO-5245](https://scality.atlassian.net/browse/ZENKO-5245)

[ZENKO-5245]: https://scality.atlassian.net/browse/ZENKO-5245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ