### PR TITLE
fix(ci): fix flaky yarn install in lint-and-build-ctst job

### DIFF
--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -409,7 +409,7 @@ jobs:
           cache-dependency-path: tests/ctst/yarn.lock
       - name: Install ctst test dependencies
         working-directory: tests/ctst
-        run: yarn install
+        run: yarn install --network-concurrency 1 || (yarn cache clean && yarn install --network-concurrency 1)
       - name: Lint ctst tests
         working-directory: tests/ctst
         run: yarn lint


### PR DESCRIPTION
## Summary

The `lint-and-build-ctst` job intermittently fails during `yarn install` with a corrupt cache error ([example failure](https://github.com/scality/Zenko/actions/runs/23584546714/job/68674443777?pr=2367)):

```
error https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz: Extracting tar content of undefined failed,
the file appears to be corrupt: "ENOENT: no such file or directory, chmod
'/home/runner/.cache/yarn/v6/npm-picomatch-2.3.1-...-integrity/node_modules/picomatch/package.json'"
```

## Root cause

Yarn v1 fetches and extracts packages in parallel by default. This can cause a race condition where concurrent tar extractions corrupt files in the local cache directory. Once a corrupted entry is written, the `actions/setup-node` cache action persists it to the GitHub Actions cache, causing subsequent workflow runs to restore the bad state and fail deterministically until the cache key rotates.

## Solution

Two complementary mitigations:

1. **`--network-concurrency 1`** — serializes package fetching and extraction, preventing the race condition that causes corruption in the first place. This is the primary fix; the slight increase in install time is negligible compared to the cost of flaky CI reruns.

2. **`|| (yarn cache clean && yarn install --network-concurrency 1)`** — if the cache is *already* corrupt from a previous run, the first `yarn install` fails, the fallback wipes the local cache, and the retry succeeds with a clean slate. This handles the transitional period until all runners pick up a fresh cache.

Fixes [ZENKO-5246](https://scality.atlassian.net/browse/ZENKO-5246)

[ZENKO-5246]: https://scality.atlassian.net/browse/ZENKO-5246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ