### PR TITLE
Add StorageUsageReporter persona to CTST tests

### DIFF
--- a/.github/scripts/end2end/configs/keycloak_config.json
+++ b/.github/scripts/end2end/configs/keycloak_config.json
@@ -35,6 +35,14 @@
         "clientRole": false,
         "containerId": "${OIDC_REALM}",
         "attributes": {}
+      },
+      {
+        "id": "a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6",
+        "name": "StorageUsageReporter",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "${OIDC_REALM}",
+        "attributes": {}
       }
     ]
   },
@@ -181,6 +189,44 @@
         "uma_authorization",
         "offline_access",
         "AccountTest::StorageAccountOwner"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "notBefore": 0,
+      "groups": []
+    },
+    {
+      "username": "storage_usage_reporter",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "email": "storage_usage_reporter@zenko.local",
+      "attributes": {
+        "instanceIds": [
+            "${INSTANCE_ID}"
+        ],
+        "role": [
+          "user"
+        ]
+      },
+      "credentials": [
+        {
+          "type": "password",
+          "createdDate": 1636387191985,
+          "secretData": "{\"value\":\"01QgDEQ47XueKXybwHAwspMlIQ6mu0aW/gmEQTOJb7bL4Jwp2T/AHkr2GObmnEkDBgFcr+zfwJRLiNf/g1K8Ug==\",\"salt\":\"s0RiY3/xmlDVyPB1mkG/kg==\"}",
+          "credentialData": "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\"}"
+        }
+      ],
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "uma_authorization",
+        "StorageUsageReporter",
+        "offline_access"
       ],
       "clientRoles": {
         "account": [

--- a/.github/scripts/end2end/keycloak-helper.sh
+++ b/.github/scripts/end2end/keycloak-helper.sh
@@ -53,11 +53,11 @@ case $COMMAND in
 
         export INSTANCE_ID=`kubectl -n ${NAMESPACE} get zenko -o jsonpath='{.items[0].status.instanceID}'`
 
-        # get user id
-        USER_ID=$(${KEYCLOAK_EXEC} /opt/jboss/keycloak/bin/kcadm.sh get users -r ${OIDC_REALM} -q "username=${OIDC_USERNAME}" | jq -r '.[0].id')
-        # set instanceIds array attribute for user
-        ${KEYCLOAK_EXEC} /opt/jboss/keycloak/bin/kcadm.sh update users/${USER_ID} -r ${OIDC_REALM} -s 'attributes={"instanceIds":["'"${INSTANCE_ID}"'"],"role":"user"}'
-
+        # set instanceIds for all users in the realm
+        USER_IDS=$(${KEYCLOAK_EXEC} /opt/jboss/keycloak/bin/kcadm.sh get users -r ${OIDC_REALM} | jq -r '.[].id')
+        for USER_ID in ${USER_IDS}; do
+            ${KEYCLOAK_EXEC} /opt/jboss/keycloak/bin/kcadm.sh update users/${USER_ID} -r ${OIDC_REALM} -s 'attributes={"instanceIds":["'"${INSTANCE_ID}"'"],"role":"user"}'
+        done
 
         ;;
     *)

--- a/tests/ctst/features/reporting/StorageUsageReporting.feature
+++ b/tests/ctst/features/reporting/StorageUsageReporting.feature
@@ -12,8 +12,9 @@ Feature: Storage Usage Reporting API
 
         Examples:
           | persona          | expectedStatus |
-          | storage_manager  | 200            |
-          | data_consumer    | 403            |
+          | storage_manager          | 200            |
+          | storage_usage_reporter   | 200            |
+          | data_consumer            | 403            |
 
     @2.14.0
     @PreMerge


### PR DESCRIPTION
## Summary

- Add `StorageUsageReporter` Keycloak realm role and `storage_usage_reporter` base user to the test environment
- Update `keycloak-helper.sh` to set `instanceIds` for all realm users automatically
- Add `storage_usage_reporter | 200` row to the storage usage reporting access control test

Addresses [ZENKO-5219](https://scality.atlassian.net/browse/ZENKO-5219), follow-up from #2340 ([review thread](https://github.com/scality/Zenko/pull/2340#discussion_r2923206907)).

## Design decisions

**Base user in `keycloak_config.json` rather than cli-testing seeder:**
The storage usage reporting tests use `managementAPIRequest()` which authenticates via a direct Keycloak JWT (not AssumeRoleWithWebIdentity). Pensieve-api validates `instanceIds` from the JWT, so the user must have this attribute set. Base users in `keycloak_config.json` get `instanceIds` at realm creation time, while seeder-created `ctst_*` users do not. Since this persona is only needed for management API access, adding it as a base user is sufficient — no cli-testing changes required.

**Auto-discover users for `set-user-instance-ids`:**
Previously, `keycloak-helper.sh set-user-instance-ids` only updated `$OIDC_USERNAME` (i.e., `storage_manager`). Rather than adding a second hardcoded call for the new user, we changed the command to list all users in the realm and set `instanceIds` on each. This means future persona additions won't require workflow changes.

**No `EntityType` / ARWWI support:**
The `StorageUsageReporter` persona is only used for direct JWT auth against the management API. It doesn't need `EntityType` enum entries, `setupEntity()` cases, world parameters, or ARWWI flow support. These can be added later if S3/Vault operations are needed under this persona.

## Alternatives considered

- **cli-testing seeder + instanceIds fix**: Would have required a companion PR to cli-testing's `utils/Keycloak.ts` and updating the seeder to set `instanceIds`. More complex, no benefit for the current use case.
- **Multiple `set-user-instance-ids` calls in CI**: Would keep the helper single-user but require workflow changes for each new persona. Less maintainable than auto-discovery.

[ZENKO-5219]: https://scality.atlassian.net/browse/ZENKO-5219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ