### PR TITLE
Fix detection of test errors

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -5,7 +5,7 @@ set -ex
 # Persist workflow env vars so they survive across terminal sessions
 ZENKO_ENV_FILE="$HOME/.zenko.env"
 yq eval '.env | to_entries | .[] | "export " + .key + "=" + (.value | tostring | @sh)' .github/workflows/end2end.yaml \
-    | sed 's/\${{[^}]*}}//g' > "$ZENKO_ENV_FILE"
+    | sed -e "s|\${{ *github.workspace *}}|$(pwd)|g" -e 's/\${{[^}]*}}//g' > "$ZENKO_ENV_FILE"
 echo 'export GIT_ACCESS_TOKEN="${GITHUB_TOKEN}"' >> "$ZENKO_ENV_FILE"
 
 echo 'export VOLUME_ROOT=$PWD/artifacts' >> "$ZENKO_ENV_FILE"

--- a/.github/actions/archive-artifacts/action.yaml
+++ b/.github/actions/archive-artifacts/action.yaml
@@ -11,7 +11,7 @@ inputs:
     required: true
   junit-paths:
     description: Path to junit reports
-    default: /artifacts/data/reports/*.xml
+    default: ${{ github.workspace }}/_reports/*.xml
     required: true
   stage:
     description: Stage name

--- a/.github/actions/archive-artifacts/action.yaml
+++ b/.github/actions/archive-artifacts/action.yaml
@@ -111,6 +111,7 @@ runs:
         report_paths: /tmp/artifacts/data/${{ inputs.stage }}/junit-merged.xml
         job_summary: false
         check_retries: true
+        require_tests: true
         fail_on_failure: true
 
     - name: Upload results

--- a/.github/actions/install-end2end-dependencies/action.yaml
+++ b/.github/actions/install-end2end-dependencies/action.yaml
@@ -77,6 +77,6 @@ runs:
           sudo curl -sSL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${{ env.KUSTOMIZE_VERSION }}/kustomize_${{ env.KUSTOMIZE_VERSION }}_linux_amd64.tar.gz | sudo tar -xvz
           sudo install kustomize /usr/local/bin
     - name: Kubectl tool installer
-      uses: Azure/setup-kubectl@v4
+      uses: Azure/setup-kubectl@v5
       with:
         version: 'v${{ env.KUBECTL_VERSION }}'

--- a/.github/scripts/end2end/deploy-metadata.sh
+++ b/.github/scripts/end2end/deploy-metadata.sh
@@ -10,7 +10,7 @@ kubectl create namespace metadata --dry-run=client -o yaml | kubectl apply -f -
 # clone the metadata repository
 git init metadata
 cd metadata
-git fetch --depth 1 --no-tags https://git:${GIT_ACCESS_TOKEN}@github.com/scality/metadata.git
+git fetch --depth 1 --no-tags "https://git:${GIT_ACCESS_TOKEN}@github.com/scality/metadata.git" refs/tags/9.9.0
 git checkout FETCH_HEAD
 
 # install metadata chart in a separate namespace

--- a/.github/scripts/end2end/run-e2e-ctst.sh
+++ b/.github/scripts/end2end/run-e2e-ctst.sh
@@ -184,6 +184,7 @@ kubectl run $POD_NAME \
         --env=AZURE_QUEUE_URL=$AZURE_BACKEND_QUEUE_ENDPOINT \
         --env=VERBOSE=1 \
         --env=SDK=true \
+        --env=CI_PASS_ON_TEST_FAILURE=${CI_PASS_ON_TEST_FAILURE:-} \
         --override-type strategic \
         --overrides='
 {

--- a/.github/scripts/end2end/setup-e2e-env.sh
+++ b/.github/scripts/end2end/setup-e2e-env.sh
@@ -107,7 +107,10 @@ export RING_S3C_BACKEND_SOURCE_NON_VERSIONED_LOCATION
 export RING_S3C_INGESTION_SRC_NON_VERSIONED_BUCKET_NAME
 export RING_S3C_INGESTION_NON_VERSIONED_OBJECT_COUNT_PER_TYPE
 export CRR_SOURCE_LOCATION_NAME CRR_DESTINATION_LOCATION_NAME CRR_ROLE_NAME
-export MOCHA_FILE=${MOCHA_FILE:-}
+export MOCHA_FILE=${MOCHA_FILE:-_reports/test-results-[hash].xml}
+
+# Ensure test results dir exists for Mocha JUnit reporter
+mkdir -p "$(dirname "$MOCHA_FILE")"
 
 # --- 8. TLS CA cert for ingress endpoints ---
 ZENKO_CA_CERT_FILE="$(mktemp /tmp/zenko-ca-cert-XXXXXX.pem)"

--- a/.github/scripts/end2end/setup-e2e-env.sh
+++ b/.github/scripts/end2end/setup-e2e-env.sh
@@ -39,11 +39,6 @@ MONGO_NS=$(echo "${MONGO_FQDN}" | cut -d. -f2)
 if ! ss -tlnp 2>/dev/null | grep -q ":${MONGO_PORT}" && \
    ! lsof -i ":${MONGO_PORT}" &>/dev/null; then
     kubectl port-forward -n "${MONGO_NS}" "svc/${MONGO_SVC}" "${MONGO_PORT}:${MONGO_PORT}" &
-    _MONGO_PF_PID=$!
-    if [ -z "${_SETUP_E2E_CLEANUP_SET:-}" ]; then
-        trap "kill ${_MONGO_PF_PID} 2>/dev/null || true" EXIT
-        export _SETUP_E2E_CLEANUP_SET=1
-    fi
     # Wait until the port is actually listening (poll every 200ms, fail after 10s)
     timeout 10 bash -c "until ss -tlnp 2>/dev/null | grep -q ':${MONGO_PORT}'; do sleep 0.2; done"
 fi

--- a/.github/workflows/alerts.yaml
+++ b/.github/workflows/alerts.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Get token to access private repositories
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ vars.ACTIONS_APP_ID }}

--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -640,7 +640,7 @@ jobs:
       - name: Wait for Docker daemon to be ready
         uses: ./.github/actions/wait-docker-ready
       - name: Kubectl tool installer
-        uses: Azure/setup-kubectl@v4
+        uses: Azure/setup-kubectl@v5
       - name: Login to Registry
         uses: docker/login-action@v4
         with:

--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -13,6 +13,7 @@ on:
 
 env:
   # kind-env
+  CI_PASS_ON_TEST_FAILURE: 'true'
   WORKER_COUNT: '2'
   OPERATOR_REPO: git@github.com:scality/zenko-operator.git
   OPERATOR_IMAGE: ""
@@ -496,7 +497,6 @@ jobs:
       - name: Run CTST end to end tests
         run: bash run-e2e-ctst.sh "@PRA"
         working-directory: ./.github/scripts/end2end
-        continue-on-error: true
       - name: Debug wait
         uses: ./.github/actions/debug-wait
         timeout-minutes: 60
@@ -546,26 +546,21 @@ jobs:
       - name: Run init CI test
         working-directory: tests/zenko_tests/node_tests
         run: yarn run test_operator
-        continue-on-error: true
       - name: Run iam policies tests
         working-directory: tests/zenko_tests/node_tests
         run: yarn run test_iam_policies
-        continue-on-error: true
       - name: Run cloudserver tests
         working-directory: tests/zenko_tests/node_tests
         run: yarn run test_object_api
-        continue-on-error: true
       - name: Run smoke tests
         working-directory: tests/zenko_tests/node_tests
         run: yarn run test_smoke
-        continue-on-error: true
       - name: Enable HTTPS
         run: bash enable-https.sh
         working-directory: ./.github/scripts/end2end
       - name: Run smoke tests (HTTPS)
         working-directory: tests/zenko_tests/node_tests
         run: yarn run test_smoke
-        continue-on-error: true
       - name: Debug wait
         uses: ./.github/actions/debug-wait
         timeout-minutes: 60
@@ -620,7 +615,6 @@ jobs:
         run: |
           ./gcp_shim.sh
           yarn run test_all_extensions
-        continue-on-error: true
       - name: Debug wait
         uses: ./.github/actions/debug-wait
         timeout-minutes: 60
@@ -675,7 +669,6 @@ jobs:
       - name: Run CTST end to end tests
         run: bash run-e2e-ctst.sh "@PreMerge and not @PRA"
         working-directory: ./.github/scripts/end2end
-        continue-on-error: true
       - name: Debug wait
         uses: ./.github/actions/debug-wait
         timeout-minutes: 60

--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -125,7 +125,7 @@ env:
   TMATE_SERVER_RSA_FINGERPRINT: ${{ secrets.TMATE_SERVER_RSA_FINGERPRINT }}
   TMATE_SERVER_ED25519_FINGERPRINT: ${{ secrets.TMATE_SERVER_ED25519_FINGERPRINT }}
   # Mocha reporter configuration
-  MOCHA_FILE: /reports/test-results-[hash].xml
+  MOCHA_FILE: ${{ github.workspace }}/_reports/test-results-[hash].xml
 
 jobs:
   check-dashboard-versions:
@@ -507,6 +507,7 @@ jobs:
           user: ${{ secrets.ARTIFACTS_USER }}
           password: ${{ secrets.ARTIFACTS_PASSWORD }}
           trunk_token: ${{ secrets.TRUNK_TOKEN }}
+          junit-paths: /artifacts/data/reports/*.xml
         if: always()
 
   end2end-2-shards-http:
@@ -679,6 +680,7 @@ jobs:
           user: ${{ secrets.ARTIFACTS_USER }}
           password: ${{ secrets.ARTIFACTS_PASSWORD }}
           trunk_token: ${{ secrets.TRUNK_TOKEN }}
+          junit-paths: /artifacts/data/reports/*.xml
         if: always()
 
   write-final-status:

--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -264,7 +264,7 @@ jobs:
           username: "${{ secrets.DOCKERHUB_LOGIN }}"
           password: "${{ secrets.DOCKERHUB_PASSWORD }}"
       - name: Get token to access ZKOP
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ vars.ACTIONS_APP_ID }}
@@ -375,7 +375,7 @@ jobs:
         with:
           persist-credentials: false # otherwise, the token is not passed to the next steps
       - name: Get token to access private repositories
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ vars.ACTIONS_APP_ID }}
@@ -461,7 +461,7 @@ jobs:
           password: "${{ github.token }}"
           registry: ghcr.io
       - name: Get token to access private repositories
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ vars.ACTIONS_APP_ID }}
@@ -530,7 +530,7 @@ jobs:
           password: "${{ github.token }}"
           registry: ghcr.io
       - name: Get token to access private repositories
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ vars.ACTIONS_APP_ID }}
@@ -594,7 +594,7 @@ jobs:
           password: "${{ github.token }}"
           registry: ghcr.io
       - name: Get token to access private repositories
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ vars.ACTIONS_APP_ID }}
@@ -648,7 +648,7 @@ jobs:
           password: "${{ github.token }}"
           registry: ghcr.io
       - name: Get token to access private repositories
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ vars.ACTIONS_APP_ID }}

--- a/tests/ctst/cucumber.config.cjs
+++ b/tests/ctst/cucumber.config.cjs
@@ -1,3 +1,19 @@
+// In CI, make cucumber-js exit 0 on test failures so that infrastructure
+// errors still propagate while test results are evaluated via JUnit reports.
+// Cucumber-js v12 sets `process.exitCode = 1` on normal test failures and only
+// calls `process.exit(1)` when it needs to force-exit (e.g. dangling handles),
+// so we must intercept both paths.
+if (process.env.CI_PASS_ON_TEST_FAILURE === 'true') {
+    const _exit = process.exit;
+    process.exit = function exit(code) {
+        _exit(code === 1 ? 0 : code);
+    };
+    process.on('beforeExit', () => {
+        if (process.exitCode === 1) {
+            process.exitCode = 0;
+        }
+    });
+}
 
 module.exports = {
     default: {

--- a/tests/zenko_tests/node_tests/.mocharc.js
+++ b/tests/zenko_tests/node_tests/.mocharc.js
@@ -1,0 +1,5 @@
+// Allow CI to make mocha exit 0 on test failures, so that infrastructure
+// errors still propagate while test results are evaluated via JUnit reports.
+module.exports = {
+  'pass-on-failing-test-suite': process.env.CI_PASS_ON_TEST_FAILURE === 'true',
+};

--- a/tests/zenko_tests/node_tests/VaultClient.js
+++ b/tests/zenko_tests/node_tests/VaultClient.js
@@ -12,7 +12,7 @@ const {
     paginateListRoles,
     paginateListPolicies,
 } = require('@aws-sdk/client-iam');
-const { NodeHttpHandler } = require('@aws-sdk/node-http-handler');
+const { NodeHttpHandler } = require('@smithy/node-http-handler');
 const vaultclient = require('vaultclient');
 const https = require('https');
 

--- a/tests/zenko_tests/node_tests/package.json
+++ b/tests/zenko_tests/node_tests/package.json
@@ -14,7 +14,7 @@
     "@aws-sdk/client-iam": "^3.901.0",
     "@aws-sdk/client-s3": "^3.901.0",
     "@aws-sdk/client-sts": "^3.901.0",
-    "@aws-sdk/node-http-handler": "^3.374.0",
+    "@smithy/node-http-handler": "^4.0.0",
     "@azure/storage-blob": "^12.12.0",
     "@google-cloud/storage": "^7.12.1",
     "arsenal": "scality/Arsenal#8.1.38",

--- a/tests/zenko_tests/node_tests/package.json
+++ b/tests/zenko_tests/node_tests/package.json
@@ -25,7 +25,7 @@
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-scality": "scality/Guidelines#7.10.1.6",
     "eslint-plugin-import": "^2.25.4",
-    "mocha": "^10.0.0",
+    "mocha": "^10.7.0",
     "mocha-junit-reporter": "^2.2.1",
     "mocha-multi-reporters": "^1.1.7",
     "request": "^2.87.0",

--- a/tests/zenko_tests/node_tests/s3SDK.js
+++ b/tests/zenko_tests/node_tests/s3SDK.js
@@ -1,6 +1,6 @@
 const { S3Client } = require('@aws-sdk/client-s3');
 const { IAMClient } = require('@aws-sdk/client-iam');
-const { NodeHttpHandler } = require('@aws-sdk/node-http-handler');
+const { NodeHttpHandler } = require('@smithy/node-http-handler');
 
 const sharedHttpHandler = new NodeHttpHandler({
     requestTimeout: 0,

--- a/tests/zenko_tests/node_tests/yarn.lock
+++ b/tests/zenko_tests/node_tests/yarn.lock
@@ -557,14 +557,6 @@
     "@smithy/util-utf8" "^4.2.0"
     tslib "^2.6.2"
 
-"@aws-sdk/node-http-handler@^3.374.0":
-  version "3.374.0"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/node-http-handler/-/node-http-handler-3.374.0.tgz#8cd58b4d9814713e26034c12eabc119c113a5bc4"
-  integrity sha512-v1Z6m0wwkf65/tKuhwrtPRqVoOtNkDTRn2MBMtxCwEw+8V8Q+YRFqVgGN+J1n53ktE0G5OYVBux/NHiAjJHReQ==
-  dependencies:
-    "@smithy/node-http-handler" "^1.0.2"
-    tslib "^2.5.0"
-
 "@aws-sdk/region-config-resolver@3.901.0":
   version "3.901.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/region-config-resolver/-/region-config-resolver-3.901.0.tgz#6673eeda4ecc0747f93a084e876cab71431a97ca"
@@ -1070,14 +1062,6 @@
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@smithy/abort-controller@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@smithy/abort-controller/-/abort-controller-1.1.0.tgz#2da0d73c504b93ca8bb83bdc8d6b8208d73f418b"
-  integrity sha512-5imgGUlZL4dW4YWdMYAKLmal9ny/tlenM81QZY7xYyb76z9Z/QOg7oM5Ak9HQl8QfFTlGVWwcMXl+54jroRgEQ==
-  dependencies:
-    "@smithy/types" "^1.2.0"
-    tslib "^2.5.0"
-
 "@smithy/abort-controller@^4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@smithy/abort-controller/-/abort-controller-4.2.0.tgz#ced549ad5e74232bdcb3eec990b02b1c6d81003d"
@@ -1320,16 +1304,15 @@
     "@smithy/types" "^4.6.0"
     tslib "^2.6.2"
 
-"@smithy/node-http-handler@^1.0.2":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@smithy/node-http-handler/-/node-http-handler-1.1.0.tgz#887cee930b520e08043c9f41e463f8d8f5dae127"
-  integrity sha512-d3kRriEgaIiGXLziAM8bjnaLn1fthCJeTLZIwEIpzQqe6yPX0a+yQoLCTyjb2fvdLwkMoG4p7THIIB5cj5lkbg==
+"@smithy/node-http-handler@^4.0.0":
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/@smithy/node-http-handler/-/node-http-handler-4.5.2.tgz#21d70f4c9cf1ce59921567bab59ae1177b6c60b1"
+  integrity sha512-/oD7u8M0oj2ZTFw7GkuuHWpIxtWdLlnyNkbrWcyVYhd5RJNDuczdkb0wfnQICyNFrVPlr8YHOhamjNy3zidhmA==
   dependencies:
-    "@smithy/abort-controller" "^1.1.0"
-    "@smithy/protocol-http" "^1.2.0"
-    "@smithy/querystring-builder" "^1.1.0"
-    "@smithy/types" "^1.2.0"
-    tslib "^2.5.0"
+    "@smithy/protocol-http" "^5.3.13"
+    "@smithy/querystring-builder" "^4.2.13"
+    "@smithy/types" "^4.14.0"
+    tslib "^2.6.2"
 
 "@smithy/node-http-handler@^4.3.0":
   version "4.3.0"
@@ -1350,14 +1333,6 @@
     "@smithy/types" "^4.6.0"
     tslib "^2.6.2"
 
-"@smithy/protocol-http@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@smithy/protocol-http/-/protocol-http-1.2.0.tgz#a554e4dabb14508f0bc2cdef9c3710e2b294be04"
-  integrity sha512-GfGfruksi3nXdFok5RhgtOnWe5f6BndzYfmEXISD+5gAGdayFGpjWu5pIqIweTudMtse20bGbc+7MFZXT1Tb8Q==
-  dependencies:
-    "@smithy/types" "^1.2.0"
-    tslib "^2.5.0"
-
 "@smithy/protocol-http@^5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@smithy/protocol-http/-/protocol-http-5.3.0.tgz#2a2834386b706b959d20e7841099b1780ae62ace"
@@ -1366,14 +1341,13 @@
     "@smithy/types" "^4.6.0"
     tslib "^2.6.2"
 
-"@smithy/querystring-builder@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@smithy/querystring-builder/-/querystring-builder-1.1.0.tgz#de6306104640ade34e59be33949db6cc64aa9d7f"
-  integrity sha512-gDEi4LxIGLbdfjrjiY45QNbuDmpkwh9DX4xzrR2AzjjXpxwGyfSpbJaYhXARw9p17VH0h9UewnNQXNwaQyYMDA==
+"@smithy/protocol-http@^5.3.13":
+  version "5.3.13"
+  resolved "https://registry.yarnpkg.com/@smithy/protocol-http/-/protocol-http-5.3.13.tgz#1e8fcacd61282cafc2c783ab002cb0debe763588"
+  integrity sha512-+HsmuJUF4u8POo6s8/a2Yb/AQ5t/YgLovCuHF9oxbocqv+SZ6gd8lC2duBFiCA/vFHoHQhoq7QjqJqZC6xOxxg==
   dependencies:
-    "@smithy/types" "^1.2.0"
-    "@smithy/util-uri-escape" "^1.1.0"
-    tslib "^2.5.0"
+    "@smithy/types" "^4.14.0"
+    tslib "^2.6.2"
 
 "@smithy/querystring-builder@^4.2.0":
   version "4.2.0"
@@ -1382,6 +1356,15 @@
   dependencies:
     "@smithy/types" "^4.6.0"
     "@smithy/util-uri-escape" "^4.2.0"
+    tslib "^2.6.2"
+
+"@smithy/querystring-builder@^4.2.13":
+  version "4.2.13"
+  resolved "https://registry.yarnpkg.com/@smithy/querystring-builder/-/querystring-builder-4.2.13.tgz#1f3c009493a06d83f998da70f5920246dfcd88dd"
+  integrity sha512-tG4aOYFCZdPMjbgfhnIQ322H//ojujldp1SrHPHpBSb3NqgUp3dwiUGRJzie87hS1DYwWGqDuPaowoDF+rYCbQ==
+  dependencies:
+    "@smithy/types" "^4.14.0"
+    "@smithy/util-uri-escape" "^4.2.2"
     tslib "^2.6.2"
 
 "@smithy/querystring-parser@^4.2.0":
@@ -1434,12 +1417,12 @@
     "@smithy/util-stream" "^4.4.0"
     tslib "^2.6.2"
 
-"@smithy/types@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@smithy/types/-/types-1.2.0.tgz#9dc65767b0ee3d6681704fcc67665d6fc9b6a34e"
-  integrity sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==
+"@smithy/types@^4.14.0":
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/@smithy/types/-/types-4.14.0.tgz#72fb6fd315f2eff7d4878142db2d1db4ef94f9bc"
+  integrity sha512-OWgntFLW88kx2qvf/c/67Vno1yuXm/f9M7QFAtVkkO29IJXGBIg0ycEaBTH0kvCtwmvZxRujrgP5a86RvsXJAQ==
   dependencies:
-    tslib "^2.5.0"
+    tslib "^2.6.2"
 
 "@smithy/types@^4.3.2":
   version "4.3.2"
@@ -1581,17 +1564,17 @@
     "@smithy/util-utf8" "^4.2.0"
     tslib "^2.6.2"
 
-"@smithy/util-uri-escape@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@smithy/util-uri-escape/-/util-uri-escape-1.1.0.tgz#a8c5edaf19c0efdb9b51661e840549cf600a1808"
-  integrity sha512-/jL/V1xdVRt5XppwiaEU8Etp5WHZj609n0xMTuehmCqdoOFbId1M+aEeDWZsQ+8JbEB/BJ6ynY2SlYmOaKtt8w==
-  dependencies:
-    tslib "^2.5.0"
-
 "@smithy/util-uri-escape@^4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz#096a4cec537d108ac24a68a9c60bee73fc7e3a9e"
   integrity sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/util-uri-escape@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz#48e40206e7fe9daefc8d44bb43a1ab17e76abf4a"
+  integrity sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==
   dependencies:
     tslib "^2.6.2"
 
@@ -6080,7 +6063,7 @@ tsconfig-paths@^3.15.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^2.2.0, tslib@^2.5.0, tslib@^2.6.2, tslib@^2.8.1:
+tslib@^2.2.0, tslib@^2.6.2, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==

--- a/tests/zenko_tests/node_tests/yarn.lock
+++ b/tests/zenko_tests/node_tests/yarn.lock
@@ -4711,7 +4711,7 @@ mocha-multi-reporters@^1.1.7:
     debug "^4.1.1"
     lodash "^4.17.15"
 
-mocha@^10.0.0:
+mocha@^10.7.0:
   version "10.8.2"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.8.2.tgz#8d8342d016ed411b12a429eb731b825f961afb96"
   integrity sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==


### PR DESCRIPTION
Ensure we don't ignore test failure, through 2 layers for additional safety:
- test status validation (in archive-artifacts) now _requires_ a non-empty test report: so test cannot unexpectedly passed due to infra or setup failure
- remove the continue-on-error, and configure test framework to exit without error after test failure (and only in that case). Thus any setup/infra/build/... would still cause the step to fail

These limitation already caused some errors to be missed, and in particular mocha test refactoring actually broke the generation of test report (now fixed).

Issue: ZENKO-5250
