### PR TITLE
ZENKO-5254 Update GitHub Actions to Node 24 runtime

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -121,7 +121,7 @@ jobs:
             core.exportVariable('RELEASE_NOTES', releaseNotes.body);
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2.5.0
+        uses: softprops/action-gh-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Summary
Update GitHub Actions workflow files to use action versions running on Node 24.

Closes ZENKO-5254

## Context
GitHub is deprecating Node 20 as the JavaScript runtime for GitHub Actions runners:
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Timeline:
- June 2, 2026: Runners default to Node 24 (deprecation warnings)
- Fall 2026: Node 20 completely removed

## Changes
Updated action versions across all workflow files to Node 24-compatible versions:
- `softprops/action-gh-release@v2.5.0` → `@v3`