### PR TITLE
Add E2E test verifying OTEL tracing across Zenko services

### DIFF
--- a/.github/scripts/end2end/configs/jaeger.yaml
+++ b/.github/scripts/end2end/configs/jaeger.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jaeger
+  namespace: default
+  labels:
+    app: jaeger
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jaeger
+  template:
+    metadata:
+      labels:
+        app: jaeger
+    spec:
+      containers:
+      - name: jaeger
+        image: jaegertracing/all-in-one:1.76.0
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            memory: 512Mi
+        env:
+        - name: COLLECTOR_OTLP_ENABLED
+          value: "true"
+        - name: MEMORY_MAX_TRACES
+          value: "10000"
+        ports:
+        - containerPort: 16686
+          name: query
+        - containerPort: 4317
+          name: otlp-grpc
+        - containerPort: 4318
+          name: otlp-http
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 16686
+          initialDelaySeconds: 5
+          periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: jaeger
+  namespace: default
+spec:
+  selector:
+    app: jaeger
+  ports:
+  - name: query
+    port: 16686
+    targetPort: 16686
+  - name: otlp-grpc
+    port: 4317
+    targetPort: 4317
+  - name: otlp-http
+    port: 4318
+    targetPort: 4318

--- a/.github/scripts/end2end/configs/zenko.yaml
+++ b/.github/scripts/end2end/configs/zenko.yaml
@@ -135,3 +135,7 @@ spec:
     - zenko-operator-image-pull
   veeamSosApi:
     enable: ${ZENKO_ENABLE_SOSAPI}
+  tracing:
+    enabled: true
+    samplingRatio: "0"
+    endpoint: "http://jaeger.default.svc.cluster.local:4318/v1/traces"

--- a/.github/scripts/end2end/configure-e2e-ctst.sh
+++ b/.github/scripts/end2end/configure-e2e-ctst.sh
@@ -111,3 +111,4 @@ kubectl run kafka-topics \
 # Deploy PyKMIP server (infra only, does NOT patch the CR).
 # The CR is patched later, after file-backend SSE tests have run.
 bash "$(dirname "$0")/../mocks/setup-kmip.sh"
+

--- a/.github/scripts/end2end/install-kind-dependencies.sh
+++ b/.github/scripts/end2end/install-kind-dependencies.sh
@@ -153,6 +153,9 @@ helm upgrade --install --version ${KEYCLOAK_VERSION} keycloak codecentric/keyclo
 
 kubectl rollout status sts/keycloak --timeout=10m
 
+# jaeger all-in-one (OTLP collector + query UI, memory-only)
+kubectl apply -f "$(dirname "$0")/configs/jaeger.yaml"
+kubectl rollout status deployment/jaeger --timeout=5m
 
 # TODO: use zenko-operator install-deps
 kubectl apply -f - <<EOF

--- a/.github/scripts/end2end/setup-e2e-env.sh
+++ b/.github/scripts/end2end/setup-e2e-env.sh
@@ -231,6 +231,15 @@ else
     fi
     export PROMETHEUS_SERVICE="${PROMETHEUS_SVC}.${NAMESPACE}.svc.cluster.local"
 
+    # Jaeger query API — port-forward for OTEL tracing tests
+    JAEGER_QUERY_PORT=16686
+    if ! ss -tlnp 2>/dev/null | grep -q ":${JAEGER_QUERY_PORT}" && \
+       ! lsof -i ":${JAEGER_QUERY_PORT}" &>/dev/null; then
+        kubectl port-forward "svc/jaeger" "${JAEGER_QUERY_PORT}:${JAEGER_QUERY_PORT}" &>/dev/null &
+        timeout 10 bash -c "until ss -tlnp 2>/dev/null | grep -q ':${JAEGER_QUERY_PORT}'; do sleep 0.2; done"
+    fi
+    export JAEGER_QUERY_ENDPOINT="http://localhost:${JAEGER_QUERY_PORT}"
+
     # --- 14. Zenko CR metadata ---
     export TIME_PROGRESSION_FACTOR=$(kubectl get zenko ${ZENKO_NAME} -o jsonpath="{.metadata.annotations.zenko\.io/time-progression-factor}")
     export INSTANCE_ID=$(kubectl get zenko ${ZENKO_NAME} -o jsonpath='{.status.instanceID}')
@@ -334,7 +343,8 @@ else
       "DRAdminSecretKey":"${ADMIN_PRA_SECRET_ACCESS_KEY}",
       "UtilizationServiceHost":"${UTILIZATION_SERVICE_HOST}",
       "UtilizationServicePort":"${UTILIZATION_SERVICE_PORT}",
-      "KubeconfigPath":"${KUBECONFIG:-${HOME}/.kube/config}"
+      "KubeconfigPath":"${KUBECONFIG:-${HOME}/.kube/config}",
+      "JaegerQueryEndpoint":"${JAEGER_QUERY_ENDPOINT}"
     }
 EOF
     )"

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -100,7 +100,7 @@ s3utils:
   sourceRegistry: ghcr.io/scality
   dashboard: s3utils/s3utils-dashboards
   image: s3utils
-  tag: 1.17.12
+  tag: 1.19.0
   envsubst: S3UTILS_TAG
 scuba:
   sourceRegistry: ghcr.io/scality

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -16,7 +16,7 @@ cloudserver:
   sourceRegistry: ghcr.io/scality
   dashboard: cloudserver/cloudserver-dashboards
   image: cloudserver
-  tag: 9.3.9
+  tag: 9.4.0-preview.2
   envsubst: CLOUDSERVER_TAG
 drctl:
   sourceRegistry: ghcr.io/scality

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -125,7 +125,7 @@ vault:
   dashboard: vault2/vault-dashboards
   policy: vault2/vault-policies
   image: vault2
-  tag: 8.11.6
+  tag: 8.11.7
   envsubst: VAULT_TAG
 zenko-operator:
   sourceRegistry: ghcr.io/scality

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -6,7 +6,7 @@ backbeat:
   dashboard: backbeat/backbeat-dashboards
   image: backbeat
   policy: backbeat/backbeat-policies
-  tag: 9.4.0
+  tag: 9.5.0-preview.1
   envsubst: BACKBEAT_TAG
 busybox:
   image: busybox

--- a/tests/functional/ctst/features/otel-tracing.feature
+++ b/tests/functional/ctst/features/otel-tracing.feature
@@ -1,0 +1,13 @@
+@2.16.0
+@PreMerge
+Feature: OpenTelemetry Tracing
+  Even when global sampling is disabled, a request carrying a W3C
+  traceparent header from a trusted (in-cluster) source must produce
+  a trace spanning all the Zenko services it touches.
+
+  Scenario: PutObject with injected traceparent produces a trace spanning cloudserver and vault
+    Given a "Non versioned" bucket
+    When I put an object with an injected traceparent
+    Then the injected trace should be found in Jaeger
+    And the trace should contain spans from service "connector-cloudserver"
+    And the trace should contain spans from service "connector-vault"

--- a/tests/functional/ctst/steps/otel-tracing.ts
+++ b/tests/functional/ctst/steps/otel-tracing.ts
@@ -1,0 +1,130 @@
+import { Then, When } from '@cucumber/cucumber';
+import { strict as assert } from 'assert';
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { randomBytes } from 'crypto';
+import { Utils } from 'cli-testing';
+import Zenko from 'world/Zenko';
+
+const JAEGER_POLL_TIMEOUT = 30000;
+const JAEGER_POLL_INTERVAL = 2000;
+const TRACED_OBJECT_KEY = 'otel-trace-test-object';
+
+interface JaegerTrace {
+    traceID: string;
+    spans: { processID: string }[];
+    processes: Record<string, { serviceName: string }>;
+}
+
+function generateTraceContext(): { traceparent: string; traceId: string } {
+    const traceId = randomBytes(16).toString('hex');
+    const spanId = randomBytes(8).toString('hex');
+    return { traceparent: `00-${traceId}-${spanId}-01`, traceId };
+}
+
+function injectTraceparent(client: S3Client, traceparent: string): void {
+    // traceparent is not part of any SigV4 signed-header set, so injecting at
+    // the 'build' step (pre-signing) does not invalidate the signature.
+    client.middlewareStack.add(
+        next => async args => {
+            const request = args.request as { headers: Record<string, string> };
+            request.headers.traceparent = traceparent;
+            return next(args);
+        },
+        { step: 'build', name: 'injectTraceparent' },
+    );
+}
+
+async function fetchTraceById(endpoint: string, traceId: string): Promise<JaegerTrace | null> {
+    const response = await fetch(`${endpoint}/api/traces/${traceId}`, {
+        signal: AbortSignal.timeout(5000),
+    });
+    if (response.status === 404) {
+        return null;
+    }
+    if (!response.ok) {
+        throw new Error(`Jaeger query returned HTTP ${response.status}`);
+    }
+    const body = await response.json() as { data: JaegerTrace[] };
+    return body.data?.[0] ?? null;
+}
+
+async function pollJaegerForTrace(
+    endpoint: string,
+    traceId: string,
+    timeoutMs = JAEGER_POLL_TIMEOUT,
+    intervalMs = JAEGER_POLL_INTERVAL,
+): Promise<JaegerTrace> {
+    const deadline = Date.now() + timeoutMs;
+    let lastError: Error | null = null;
+
+    while (Date.now() < deadline) {
+        try {
+            const trace = await fetchTraceById(endpoint, traceId);
+            if (trace) {
+                return trace;
+            }
+        } catch (err) {
+            lastError = err as Error;
+        }
+        await Utils.sleep(intervalMs);
+    }
+
+    throw new Error(
+        `pollJaegerForTrace timed out after ${timeoutMs}ms waiting for trace ${traceId}` +
+        `${lastError ? `: ${lastError.message}` : ''}`,
+    );
+}
+
+function traceHasSpansFromService(trace: JaegerTrace, serviceName: string): boolean {
+    const processIds = Object.entries(trace.processes)
+        .filter(([, proc]) => proc.serviceName === serviceName)
+        .map(([id]) => id);
+
+    return trace.spans.some(span => processIds.includes(span.processID));
+}
+
+When('I put an object with an injected traceparent',
+    async function (this: Zenko) {
+        const bucketName = this.getSaved<string>('bucketName');
+        assert.ok(bucketName, 'No bucketName saved from a previous step');
+
+        const { traceparent, traceId } = generateTraceContext();
+        const client = this.createS3Client();
+        injectTraceparent(client, traceparent);
+        await client.send(new PutObjectCommand({
+            Bucket: bucketName,
+            Key: TRACED_OBJECT_KEY,
+            Body: 'otel-trace-payload',
+        }));
+
+        this.addToSaved('jaegerTraceId', traceId);
+    },
+);
+
+Then('the injected trace should be found in Jaeger',
+    { timeout: JAEGER_POLL_TIMEOUT + 10000 },
+    async function (this: Zenko) {
+        const endpoint = this.parameters.JaegerQueryEndpoint;
+        assert.ok(endpoint, 'JaegerQueryEndpoint missing from world parameters');
+        const traceId = this.getSaved<string>('jaegerTraceId');
+        assert.ok(traceId, 'No jaegerTraceId saved from a previous step');
+
+        const trace = await pollJaegerForTrace(endpoint, traceId);
+        this.addToSaved('jaegerTrace', trace);
+    },
+);
+
+Then('the trace should contain spans from service {string}',
+    async function (this: Zenko, service: string) {
+        const trace = this.getSaved<JaegerTrace>('jaegerTrace');
+        assert.ok(trace, 'No trace saved from the previous step');
+
+        assert.ok(
+            traceHasSpansFromService(trace, service),
+            `Trace ${trace.traceID} does not contain spans from service "${service}". ` +
+            `Services in trace: ${[...new Set(
+                Object.values(trace.processes).map(p => p.serviceName),
+            )].join(', ')}`,
+        );
+    },
+);

--- a/tests/functional/ctst/world/Zenko.ts
+++ b/tests/functional/ctst/world/Zenko.ts
@@ -103,6 +103,7 @@ export interface ZenkoWorldParameters extends ClientOptions {
     SorbetdRestoreTimeout: string;
     UtilizationServiceHost: string;
     UtilizationServicePort: string;
+    JaegerQueryEndpoint: string;
     [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary

- Deploy Jaeger all-in-one (memory-only, OTLP-enabled, pinned to `1.76.0`)
  in the kind CI cluster alongside existing dependencies (Keycloak,
  Prometheus, etc.)
- Enable tracing on the Zenko CR (`spec.tracing`, ratio `"0"`) so the
  cluster runs in production-mode (no ambient traces). The test sends
  a single PUT through the existing S3 ingress with a W3C `traceparent`
  header injected via SDK middleware. Cloudserver's parent-based sampler
  honors the header → only that one request is traced.
- Add a `@PreMerge` CTST scenario that asserts the trace appears in
  Jaeger and contains spans from both **connector-cloudserver** and
  **connector-vault**

## What changed

| File | What |
|------|------|
| `solution/deps.yaml` | Bump the component images this test needs to run against OTEL/CRR-capable builds: `vault` `8.11.6 → 8.11.7` and `cloudserver` `9.3.9 → 9.4.0-preview.2` (OTEL support — parent-based sampler), `backbeat` `9.4.0 → 9.5.0-preview.1`, and `s3utils` `1.17.12 → 1.19.0`. **The s3utils bump is required transitively, not unrelated:** the preview cloudserver stores CRR bucket metadata in the new arsenal-8.5 (multi-CRR) format, which s3utils 1.17.12 (arsenal 8.2.36) cannot deserialize — `count-items` crashes in `getBucketAttributes`, which hangs the `@Quotas` CTST scenarios and blocks this suite from completing. 1.19.0 pins arsenal 8.5.0 to match cloudserver. |
| `configs/zenko.yaml` | Add `spec.tracing` (enabled, ratio `"0"`, jaeger endpoint) |
| `configs/jaeger.yaml` | Jaeger Deployment + Service (pinned `1.76.0`, memory-only, requests/limits) |
| `install-kind-dependencies.sh` | `kubectl apply -f configs/jaeger.yaml` |
| `setup-e2e-env.sh` | Port-forward Jaeger query API + `JaegerQueryEndpoint` in world params |
| `world/Zenko.ts` | `JaegerQueryEndpoint` world parameter |
| `features/otel-tracing.feature` | New `@PreMerge` scenario |
| `steps/otel-tracing.ts` | Generates W3C `traceparent`, adds an SDK middleware that injects the header on the CTST S3 client, polls `GET /api/traces/<id>` until the trace appears, asserts cloudserver + vault spans |

## Why

Parent ticket [OS-1072](https://scality.atlassian.net/browse/OS-1072)
tracks adding OpenTelemetry tracing across the Zenko stack. This PR
adds CI coverage to verify that traces actually propagate end-to-end
(cloudserver → vault) once tracing is enabled.

Note on trust boundary: production runs metalk8s nginx which strips
incoming `traceparent` headers; Zenko CI uses upstream
`kubernetes/ingress-nginx` which forwards them. So in CI the test
injects via the regular ingress; the production trust-boundary
(external `traceparent` is dropped at the edge) is metalk8s-specific
and out of scope for this CI test.

Issue: ZENKO-5258

[OS-1072]: https://scality.atlassian.net/browse/OS-1072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
