### PR TITLE
Increase robustness of transition tests by watching the dead letter queue

### DIFF
--- a/tests/functional/ctst/common/hooks.ts
+++ b/tests/functional/ctst/common/hooks.ts
@@ -1,6 +1,8 @@
 import {
     Before,
     After,
+    AfterAll,
+    BeforeAll,
     setParallelCanAssign,
     parallelCanAssignHelpers,
     ITestCaseHookParameter,
@@ -17,6 +19,7 @@ import {
     cleanupAccount,
 } from './utils';
 import { createKubeCustomObjectClient, waitForZenkoToStabilize } from 'steps/utils/kubernetes';
+import { startDLQConsumer, stopDLQConsumer } from 'steps/utils/kafka';
 
 import 'cli-testing/hooks/KeycloakSetup';
 import 'cli-testing/hooks/Logger';
@@ -39,6 +42,18 @@ const noParallelRun = atMostOnePicklePerTag([
 ]);
 
 setParallelCanAssign(noParallelRun);
+
+BeforeAll(async function () {
+    const kafkaHosts = process.env['KAFKA_HOST_PORT'];
+    const dlqTopic = process.env['KAFKA_DEAD_LETTER_TOPIC'];
+    if (kafkaHosts && dlqTopic) {
+        await startDLQConsumer(kafkaHosts, dlqTopic, Zenko.addToDLQBuffer);
+    }
+});
+
+AfterAll(async function () {
+    await stopDLQConsumer();
+});
 
 Before(async function (this: Zenko, scenario: ITestCaseHookParameter) {
     this.resetSaved();

--- a/tests/functional/ctst/features/azureArchive.feature
+++ b/tests/functional/ctst/features/azureArchive.feature
@@ -238,8 +238,7 @@ Feature: Azure Archive
     And object "retry-obj-2" should be "transitioning" and have the storage class "e2e-azure-archive"
     And manifest containing object "retry-obj-1" should "contain" object "retry-obj-2"
     When i restore object "retry-obj-1" for <restoreDays> days
-    Then blob for object "retry-obj-1" fails to rehydrate
-    And blob for object "retry-obj-2" fails to rehydrate
+    Then restoration of object "retry-obj-1" failed and ends up in DLQ
     Then object "retry-obj-1" should be "transitioning" and have the storage class "e2e-azure-archive"
     When i run sorbetctl to retry failed restore for "e2e-azure-archive" location
     Then object "retry-obj-1" should be "restored" and have the storage class "e2e-azure-archive"

--- a/tests/functional/ctst/steps/azureArchive.ts
+++ b/tests/functional/ctst/steps/azureArchive.ts
@@ -8,6 +8,7 @@ import util from 'util';
 import { exec } from 'child_process';
 import Zenko from 'world/Zenko';
 import { waitForDataServicesToStabilize, waitForZenkoToStabilize } from './utils/kubernetes';
+import { waitForDLQMessage } from './utils/kafka';
 
 type manifestEntry = {
     'archive-id': string,
@@ -308,22 +309,29 @@ Then('blob for object {string} must be rehydrated',
         assert.strictEqual(sent, true, `Failed to send BlobCreatedEvent for ${tarName}, object ${objectName}`);
     });
 
-/**
- * This is used to intentionally fail rehydration
- * To do that, we verify that the blob is rehydrated in azure
- * But we don't send the event to the queue so that
- * zenko is not aware of the rehydration and mark it as failed
- */
-Then('blob for object {string} fails to rehydrate',
+Then('restoration of object {string} failed and ends up in DLQ',
     async function (this: Zenko, objectName: string) {
         const tarName = await isObjectRehydrated(this, objectName);
+        assert(tarName);
+        // Skipping sending BlobCreatedEvent to queue,
+        // which fails the restore and eventually ends up in DLQ
+
+        const objName = objectName || this.getSaved<string>('objectName');
+        const bucketName = this.getSaved<string>('bucketName');
 
         // wait for restore to fail and end up in dead letter queue
-        const restoreTimeoutSeconds = parseInt(this.parameters.SorbetdRestoreTimeout);
-        await Utils.sleep(restoreTimeoutSeconds * 1000 + 1000);
-        assert(tarName);
-        // restoreTimeout is set to 30s in the config
-        await Utils.sleep(30000);
+        const restoreTimeoutMs = parseInt(this.parameters.SorbetdRestoreTimeout) * 1000;
+        if (isNaN(restoreTimeoutMs)) {
+            throw new Error('SorbetdRestoreTimeout world parameter is missing or not a valid integer');
+        }
+        const timeoutMs = restoreTimeoutMs + 30_000 + 1_000;
+
+        const seenDLQ = this.getSaved<Set<string>>('seenDLQMessages') ?? new Set<string>();
+        this.addToSaved('seenDLQMessages', seenDLQ);
+        const dlqMsg = await waitForDLQMessage(Zenko.dlqBuffer, 'restore', objName, bucketName, seenDLQ, timeoutMs);
+        this.logger.info('Found rehydration failure in DLQ', {
+            objectName: objName, reason: dlqMsg.reason,
+        });
     });
 
 Then('the storage class of object {string} must stay {string} for {int} seconds',

--- a/tests/functional/ctst/steps/utils/kafka.ts
+++ b/tests/functional/ctst/steps/utils/kafka.ts
@@ -1,4 +1,100 @@
 import { Utils } from 'cli-testing';
+import { Consumer, stringDeserializers } from '@platformatic/kafka';
+
+export interface DLQMessage {
+    op: string;
+    bucketName: string;
+    objectKey: string;
+    accountId: string;
+    eTag: string;
+    archiveInfo: Record<string, unknown>;
+    requestId: string;
+    originalMessage: string;
+    reason: string;
+    date: string;
+}
+
+export function dlqKey(op: string, bucketName: string, objectKey: string): string {
+    return `${op}:${bucketName}:${objectKey}`;
+}
+
+let dlqConsumerCleanup: (() => Promise<void>) | undefined;
+
+/**
+ * Starts a long-lived background Kafka consumer. Each arriving DLQ message is
+ * passed to `onMessage` — the caller owns the buffer. Call once from BeforeAll.
+ */
+export async function startDLQConsumer(
+    kafkaHosts: string, topic: string,
+    onMessage: (msg: DLQMessage) => void,
+): Promise<void> {
+    const consumer = new Consumer({
+        clientId: `zenko-e2e-dlq-${Utils.randomString()}`,
+        groupId: `zenko-e2e-dlq-${Utils.randomString()}`,
+        bootstrapBrokers: [kafkaHosts],
+        deserializers: stringDeserializers,
+    });
+    const stream = await consumer.consume({ topics: [topic], mode: 'earliest' });
+    void (async () => {
+        try {
+            for await (const msg of stream) {
+                try { onMessage(JSON.parse(msg.value) as DLQMessage); } catch { /* ignore malformed messages */ }
+            }
+        } catch { /* consumer disconnected — stop silently */ }
+    })();
+    dlqConsumerCleanup = async () => {
+        await stream.close().catch(() => {});
+        await consumer.close().catch(() => {});
+    };
+}
+
+/** Stops the background DLQ consumer. Call from AfterAll. */
+export async function stopDLQConsumer(): Promise<void> {
+    await dlqConsumerCleanup?.();
+}
+
+/**
+ * Synchronous, non-blocking check of a DLQ buffer.
+ * Returns the first unseen message matching (op, objectName, bucketName),
+ * or undefined if none has arrived yet. The caller is responsible for
+ * sleeping and retrying if needed.
+ *
+ * seenMessages prevents the same Kafka message being matched twice across
+ * retries — e.g. a failed-restore DLQ entry must not re-trigger a later
+ * "wait for successful restore" check on the same object.
+ */
+export function pollDLQBuffer(
+    buffer: Map<string, DLQMessage[]>,
+    op: string, objectName: string, bucketName: string,
+    seenMessages: Set<string>,
+): DLQMessage | undefined {
+    return buffer.get(dlqKey(op, bucketName, objectName))
+        ?.find(m => !seenMessages.has(m.requestId));
+}
+
+/**
+ * Blocks until a matching DLQ message appears or timeoutMs elapses.
+ * Used when a test step explicitly expects a failure to land in the DLQ.
+ */
+export async function waitForDLQMessage(
+    buffer: Map<string, DLQMessage[]>,
+    op: string, objectName: string, bucketName: string,
+    seenMessages: Set<string>, timeoutMs: number,
+): Promise<DLQMessage> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        const msg = pollDLQBuffer(buffer, op, objectName, bucketName, seenMessages);
+        if (msg) {
+            seenMessages.add(msg.requestId);
+            return msg;
+        }
+        await Utils.sleep(500);
+    }
+    throw new Error(
+        `DLQ: no "${op}" message for object "${objectName}" in bucket "${bucketName}" ` +
+        `within ${timeoutMs / 1000}s`,
+    );
+}
 
 interface ConnectorInfo {
     info: {

--- a/tests/functional/ctst/steps/utils/utils.ts
+++ b/tests/functional/ctst/steps/utils/utils.ts
@@ -16,6 +16,7 @@ import assert from 'assert';
 import constants from 'common/constants';
 import { getLocationConfigs } from './kubernetes';
 import { S3Client } from '@aws-sdk/client-s3';
+import { pollDLQBuffer } from './kafka';
 
 enum AuthorizationType {
     ALLOW = 'Allow',
@@ -473,6 +474,8 @@ async function putBucketReplication(
     }
 }
 
+// Polls for transition status and checks the DLQ buffer on every iteration for early failure.
+// Relies on bucket names being randomized so a DLQ entry from a previous run cannot match.
 async function verifyObjectLocation(this: Zenko, objectName: string,
     objectTransitionStatus: string, storageClass: string) {
     const objName =
@@ -484,24 +487,32 @@ async function verifyObjectLocation(this: Zenko, objectName: string,
     if (versionId) {
         this.addCommandParameter({ versionId });
     }
-    let conditionOk = false;
 
-    const startTime = Date.now();
+    const op = objectTransitionStatus === 'restored' ? 'restore' : 'archive';
+    const bucketName = this.getSaved<string>('bucketName');
+    const seenDLQ = this.getSaved<Set<string>>('seenDLQMessages') ?? new Set<string>();
+    this.addToSaved('seenDLQMessages', seenDLQ);
+
     const timeoutMs = 5 * 60 * 1000;
-    while (!conditionOk) {
-        if (Date.now() - startTime > timeoutMs) {
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+        const dlqMsg = pollDLQBuffer(Zenko.dlqBuffer, op, objName, bucketName, seenDLQ);
+        if (dlqMsg) {
+            seenDLQ.add(dlqMsg.requestId);
+            this.logger.error('Found failure in dead letter queue', { dlqMsg });
             throw new Error(
-                `verifyObjectLocation timed out after ${timeoutMs / 1000}s ` +
-                `waiting for object "${objName}" to reach status "${objectTransitionStatus}" ` +
-                `with storage class "${storageClass}"`
+                `Transition failed for object "${objName}" in bucket "${bucketName}":` +
+                ` found in dead letter queue (op: ${dlqMsg.op}, reason: ${dlqMsg.reason})`,
             );
         }
+
         const res = await S3.headObject(this.getCommandParameters());
         if (res.err?.includes('NotFound')) {
             await Utils.sleep(1000);
             continue;
         } else if (res.err) {
-            break;
+            throw new Error(`HeadObject error for "${objName}": ${res.err}`);
         }
         assert(res.stdout);
         const parsed = safeJsonParse<{
@@ -510,19 +521,23 @@ async function verifyObjectLocation(this: Zenko, objectName: string,
         }>(res.stdout);
         assert(parsed.ok);
         const expectedClass = storageClass !== '' ? storageClass : undefined;
-        if (parsed.result?.StorageClass === expectedClass) {
-            conditionOk = true;
-        }
-        if (objectTransitionStatus == 'restored') {
-            const isRestored = !!parsed.result?.Restore &&
+        let conditionOk = parsed.result?.StorageClass === expectedClass;
+        if (objectTransitionStatus === 'restored') {
+            conditionOk = conditionOk && !!parsed.result?.Restore &&
                 parsed.result.Restore.includes('ongoing-request="false", expiry-date=');
-            conditionOk = conditionOk && isRestored;
-        } else if (objectTransitionStatus == 'cold') {
+        } else if (objectTransitionStatus === 'cold') {
             conditionOk = conditionOk && !parsed.result?.Restore;
         }
+        if (conditionOk) return;
+
         await Utils.sleep(1000);
     }
-    assert(conditionOk);
+
+    throw new Error(
+        `verifyObjectLocation timed out after ${timeoutMs / 1000}s ` +
+        `waiting for object "${objName}" to reach "${objectTransitionStatus}" ` +
+        `with storage class "${storageClass}"`,
+    );
 }
 
 async function restoreObject(this: Zenko, objectName: string, days: number) {

--- a/tests/functional/ctst/world/Zenko.ts
+++ b/tests/functional/ctst/world/Zenko.ts
@@ -1,4 +1,5 @@
 import { World, IWorldOptions, setWorldConstructor } from '@cucumber/cucumber';
+import { DLQMessage, dlqKey } from 'steps/utils/kafka';
 import axios, { AxiosRequestConfig, AxiosResponse, Method } from 'axios';
 import { AccessKey } from '@aws-sdk/client-iam';
 import { S3Client, S3ServiceException } from '@aws-sdk/client-s3';
@@ -135,6 +136,16 @@ export default class Zenko extends World<ZenkoWorldParameters> {
     static readonly PRIMARY_SITE_NAME = 'admin';
     static readonly SECONDARY_SITE_NAME = 'dradmin';
     static readonly PRA_INSTALL_COUNT_KEY = 'praInstallCount';
+    // Keyed by dlqKey(op, bucketName, objectKey). Array per key handles
+    // Kafka at-least-once delivery and retries of the same object.
+    static readonly dlqBuffer = new Map<string, DLQMessage[]>();
+
+    static addToDLQBuffer(msg: DLQMessage): void {
+        const key = dlqKey(msg.op, msg.bucketName, msg.objectKey);
+        const list = Zenko.dlqBuffer.get(key) ?? [];
+        list.push(msg);
+        Zenko.dlqBuffer.set(key, list);
+    }
 
     /**
      * @constructor


### PR DESCRIPTION
Increase robustness of transition tests by watching the dead letter queue : 

Checking DLQ on 2 situations :
- One for the very generic "should be transitioning" step that's used in many tests
- Another one more niche for restoring objects

This enable earlier returns in case of tests issues, and allow to rely on real logic instead of timeout for the second test.

Ran in a broken codespace where the python setup wasn't properly working, I did found the DLQ errors this way, then fix the codespace and the dlq errors were gone.

Also reviewed a test which logic wasn't very clear.

Issue: ZENKO-4906