### PR TITLE
Disable mongodb-exporter per-collection metrics

### DIFF
--- a/solution-base/mongodb/charts/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
+++ b/solution-base/mongodb/charts/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
@@ -332,7 +332,7 @@ spec:
               {{- if .Values.auth.usePasswordFiles }}
               export MONGODB_ROOT_PASSWORD="$(cat "${MONGODB_ROOT_PASSWORD_FILE}")"
               {{- end }}
-              /bin/mongodb_exporter --collect-all --compatible-mode --web.listen-address ":{{ .Values.metrics.containerPorts.metrics }}" --mongodb.uri mongodb://$(echo $MONGODB_ROOT_USER):$(echo $MONGODB_ROOT_PASSWORD | sed -r "s/@/%40/g;s/:/%3A/g")@localhost:{{ .Values.common.containerPorts.mongodb }}/admin{{ ternary "?ssl=true" "" $.Values.metrics.useTLS }} {{ .Values.metrics.extraArgs }}
+              /bin/mongodb_exporter --compatible-mode --web.listen-address ":{{ .Values.metrics.containerPorts.metrics }}" --mongodb.uri mongodb://$(echo $MONGODB_ROOT_USER):$(echo $MONGODB_ROOT_PASSWORD | sed -r "s/@/%40/g;s/:/%3A/g")@localhost:{{ .Values.common.containerPorts.mongodb }}/admin{{ ternary "?ssl=true" "" $.Values.metrics.useTLS }} {{ .Values.metrics.extraArgs }}
           {{- end }}
           volumeMounts:
             - name: empty-dir

--- a/solution-base/mongodb/charts/mongodb-sharded/templates/mongos/mongos-dep-sts.yaml
+++ b/solution-base/mongodb/charts/mongodb-sharded/templates/mongos/mongos-dep-sts.yaml
@@ -306,7 +306,7 @@ spec:
               {{- if .Values.auth.usePasswordFiles }}
               export MONGODB_ROOT_PASSWORD="$(cat "${MONGODB_ROOT_PASSWORD_FILE}")"
               {{- end }}
-              /bin/mongodb_exporter --collect-all --compatible-mode --web.listen-address ":{{ .Values.metrics.containerPorts.metrics }}" --mongodb.uri mongodb://$(echo $MONGODB_ROOT_USER):$(echo $MONGODB_ROOT_PASSWORD | sed -r "s/@/%40/g;s/:/%3A/g")@localhost:{{ .Values.common.containerPorts.mongodb }}/admin{{ ternary "?ssl=true" "" $.Values.metrics.useTLS }} {{ .Values.metrics.extraArgs }}
+              /bin/mongodb_exporter --compatible-mode --web.listen-address ":{{ .Values.metrics.containerPorts.metrics }}" --mongodb.uri mongodb://$(echo $MONGODB_ROOT_USER):$(echo $MONGODB_ROOT_PASSWORD | sed -r "s/@/%40/g;s/:/%3A/g")@localhost:{{ .Values.common.containerPorts.mongodb }}/admin{{ ternary "?ssl=true" "" $.Values.metrics.useTLS }} {{ .Values.metrics.extraArgs }}
           {{- end }}
           volumeMounts:
             - name: empty-dir

--- a/solution-base/mongodb/charts/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
+++ b/solution-base/mongodb/charts/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
@@ -339,7 +339,7 @@ spec:
               {{- if $.Values.auth.usePasswordFiles }}
               export MONGODB_ROOT_PASSWORD="$(cat "${MONGODB_ROOT_PASSWORD_FILE}")"
               {{- end }}
-              /bin/mongodb_exporter --collect-all --compatible-mode --web.listen-address ":{{ $.Values.metrics.containerPorts.metrics }}" --mongodb.uri mongodb://$(echo $MONGODB_ROOT_USER):$(echo $MONGODB_ROOT_PASSWORD | sed -r "s/@/%40/g;s/:/%3A/g")@localhost:{{ $.Values.common.containerPorts.mongodb }}/admin{{ ternary "?ssl=true" "" $.Values.metrics.useTLS }} {{ $.Values.metrics.extraArgs }}
+              /bin/mongodb_exporter --compatible-mode --web.listen-address ":{{ $.Values.metrics.containerPorts.metrics }}" --mongodb.uri mongodb://$(echo $MONGODB_ROOT_USER):$(echo $MONGODB_ROOT_PASSWORD | sed -r "s/@/%40/g;s/:/%3A/g")@localhost:{{ $.Values.common.containerPorts.mongodb }}/admin{{ ternary "?ssl=true" "" $.Values.metrics.useTLS }} {{ $.Values.metrics.extraArgs }}
           {{- end }}
           volumeMounts:
             - name: empty-dir

--- a/solution-base/mongodb/patches/mongodb-exporter-disable-collect-all.patch
+++ b/solution-base/mongodb/patches/mongodb-exporter-disable-collect-all.patch
@@ -1,0 +1,39 @@
+diff --git a/solution-base/mongodb/charts/mongodb-sharded/templates/config-server/config-server-statefulset.yaml b/solution-base/mongodb/charts/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
+index 067acaa1..8700d119 100644
+--- a/solution-base/mongodb/charts/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
++++ b/solution-base/mongodb/charts/mongodb-sharded/templates/config-server/config-server-statefulset.yaml
+@@ -332,7 +332,7 @@ spec:
+               {{- if .Values.auth.usePasswordFiles }}
+               export MONGODB_ROOT_PASSWORD="$(cat "${MONGODB_ROOT_PASSWORD_FILE}")"
+               {{- end }}
+-              /bin/mongodb_exporter --collect-all --compatible-mode --web.listen-address ":{{ .Values.metrics.containerPorts.metrics }}" --mongodb.uri mongodb://$(echo $MONGODB_ROOT_USER):$(echo $MONGODB_ROOT_PASSWORD | sed -r "s/@/%40/g;s/:/%3A/g")@localhost:{{ .Values.common.containerPorts.mongodb }}/admin{{ ternary "?ssl=true" "" $.Values.metrics.useTLS }} {{ .Values.metrics.extraArgs }}
++              /bin/mongodb_exporter --compatible-mode --web.listen-address ":{{ .Values.metrics.containerPorts.metrics }}" --mongodb.uri mongodb://$(echo $MONGODB_ROOT_USER):$(echo $MONGODB_ROOT_PASSWORD | sed -r "s/@/%40/g;s/:/%3A/g")@localhost:{{ .Values.common.containerPorts.mongodb }}/admin{{ ternary "?ssl=true" "" $.Values.metrics.useTLS }} {{ .Values.metrics.extraArgs }}
+           {{- end }}
+           volumeMounts:
+             - name: empty-dir
+diff --git a/solution-base/mongodb/charts/mongodb-sharded/templates/mongos/mongos-dep-sts.yaml b/solution-base/mongodb/charts/mongodb-sharded/templates/mongos/mongos-dep-sts.yaml
+index 8ed0c05d..84ec89e3 100644
+--- a/solution-base/mongodb/charts/mongodb-sharded/templates/mongos/mongos-dep-sts.yaml
++++ b/solution-base/mongodb/charts/mongodb-sharded/templates/mongos/mongos-dep-sts.yaml
+@@ -306,7 +306,7 @@ spec:
+               {{- if .Values.auth.usePasswordFiles }}
+               export MONGODB_ROOT_PASSWORD="$(cat "${MONGODB_ROOT_PASSWORD_FILE}")"
+               {{- end }}
+-              /bin/mongodb_exporter --collect-all --compatible-mode --web.listen-address ":{{ .Values.metrics.containerPorts.metrics }}" --mongodb.uri mongodb://$(echo $MONGODB_ROOT_USER):$(echo $MONGODB_ROOT_PASSWORD | sed -r "s/@/%40/g;s/:/%3A/g")@localhost:{{ .Values.common.containerPorts.mongodb }}/admin{{ ternary "?ssl=true" "" $.Values.metrics.useTLS }} {{ .Values.metrics.extraArgs }}
++              /bin/mongodb_exporter --compatible-mode --web.listen-address ":{{ .Values.metrics.containerPorts.metrics }}" --mongodb.uri mongodb://$(echo $MONGODB_ROOT_USER):$(echo $MONGODB_ROOT_PASSWORD | sed -r "s/@/%40/g;s/:/%3A/g")@localhost:{{ .Values.common.containerPorts.mongodb }}/admin{{ ternary "?ssl=true" "" $.Values.metrics.useTLS }} {{ .Values.metrics.extraArgs }}
+           {{- end }}
+           volumeMounts:
+             - name: empty-dir
+diff --git a/solution-base/mongodb/charts/mongodb-sharded/templates/shard/shard-data-statefulset.yaml b/solution-base/mongodb/charts/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
+index d0339061..0be27f4a 100644
+--- a/solution-base/mongodb/charts/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
++++ b/solution-base/mongodb/charts/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
+@@ -339,7 +339,7 @@ spec:
+               {{- if $.Values.auth.usePasswordFiles }}
+               export MONGODB_ROOT_PASSWORD="$(cat "${MONGODB_ROOT_PASSWORD_FILE}")"
+               {{- end }}
+-              /bin/mongodb_exporter --collect-all --compatible-mode --web.listen-address ":{{ $.Values.metrics.containerPorts.metrics }}" --mongodb.uri mongodb://$(echo $MONGODB_ROOT_USER):$(echo $MONGODB_ROOT_PASSWORD | sed -r "s/@/%40/g;s/:/%3A/g")@localhost:{{ $.Values.common.containerPorts.mongodb }}/admin{{ ternary "?ssl=true" "" $.Values.metrics.useTLS }} {{ $.Values.metrics.extraArgs }}
++              /bin/mongodb_exporter --compatible-mode --web.listen-address ":{{ $.Values.metrics.containerPorts.metrics }}" --mongodb.uri mongodb://$(echo $MONGODB_ROOT_USER):$(echo $MONGODB_ROOT_PASSWORD | sed -r "s/@/%40/g;s/:/%3A/g")@localhost:{{ $.Values.common.containerPorts.mongodb }}/admin{{ ternary "?ssl=true" "" $.Values.metrics.useTLS }} {{ $.Values.metrics.extraArgs }}
+           {{- end }}
+           volumeMounts:
+             - name: empty-dir

--- a/tests/functional/ctst/features/mongodbExporter.feature
+++ b/tests/functional/ctst/features/mongodbExporter.feature
@@ -1,0 +1,13 @@
+Feature: MongoDB exporter metric scope
+
+    @2.14.0
+    @PreMerge
+    Scenario: MongoDB exporter exposes core metrics
+        Then prometheus should expose mongodb metric "mongodb_ss_connections"
+        And prometheus should expose mongodb metric "mongodb_dbstats_storageSize"
+
+    @2.14.0
+    @PreMerge
+    Scenario: MongoDB exporter does not expose per-collection metrics
+        Then prometheus should not expose mongodb metric "mongodb_collstats_storageSize"
+        And prometheus should not expose mongodb metric "mongodb_indexstats_accesses_ops"

--- a/tests/functional/ctst/steps/mongodbExporter.ts
+++ b/tests/functional/ctst/steps/mongodbExporter.ts
@@ -1,0 +1,61 @@
+import { Then } from '@cucumber/cucumber';
+import { Utils } from 'cli-testing';
+import { PrometheusDriver } from 'prometheus-query';
+import assert from 'assert';
+import Zenko from 'world/Zenko';
+
+const TIMEOUT_MS = 180_000;
+const POLL_MS = 1_000;
+
+// Negative-assertion stability window: we re-check across at least one
+// Prometheus scrape interval so a not-yet-scraped metric does not pass the
+// test trivially. Default scrape interval is 30s; 4 checks at 10s = 30s span.
+const STABILITY_CHECKS = 4;
+const STABILITY_INTERVAL_MS = 10_000;
+
+function makeProm(world: Zenko): PrometheusDriver {
+    return new PrometheusDriver({
+        endpoint: world.parameters.PrometheusEndpoint,
+        baseURL: '/api/v1',
+    });
+}
+
+Then(
+    'prometheus should expose mongodb metric {string}',
+    { timeout: TIMEOUT_MS },
+    async function (this: Zenko, metric: string) {
+        const prom = makeProm(this);
+        const deadline = Date.now() + TIMEOUT_MS - POLL_MS;
+        for (;;) {
+            const res = await prom.instantQuery(metric);
+            if (res.result.length > 0) {
+                return;
+            }
+            if (Date.now() > deadline) {
+                assert.fail(
+                    `Metric ${metric} never appeared (no series in /api/v1/query)`,
+                );
+            }
+            await Utils.sleep(POLL_MS);
+        }
+    },
+);
+
+Then(
+    'prometheus should not expose mongodb metric {string}',
+    { timeout: TIMEOUT_MS },
+    async function (this: Zenko, metric: string) {
+        const prom = makeProm(this);
+        for (let i = 0; i < STABILITY_CHECKS; i++) {
+            const res = await prom.instantQuery(metric);
+            assert.strictEqual(
+                res.result.length,
+                0,
+                `Expected ${metric} to be absent, got ${res.result.length} series`,
+            );
+            if (i < STABILITY_CHECKS - 1) {
+                await Utils.sleep(STABILITY_INTERVAL_MS);
+            }
+        }
+    },
+);


### PR DESCRIPTION
## Summary

The mongodb-sharded chart launches the `mongodb_exporter` sidecar with `--collect-all` hardcoded in its templates, which (per the Percona implementation) unconditionally enables every collector at runtime — including `collstats` and `indexstats`, which run **one MongoDB query per collection per scrape**. On clusters with many collections this dwarfs the actual cluster-level metrics the exporter is supposed to expose, with no operational benefit: no dashboard or alert in the metalk8s-monitoring stack consumes any per-collection metric.

This PR drops `--collect-all` from the three statefulset templates via a new patch, and adds a small ctst e2e test (positive + negative) that locks the behavior in so a future regression fails CI.

## Context

Surfaced during the investigation of [ARTESCA-17291](https://scality.atlassian.net/browse/ARTESCA-17291) on a customer-style cluster. With ~1,600 collections, the exporter was generating ~145 `aggregate`/s against the shard. Tracking ticket: [ZENKO-5269](https://scality.atlassian.net/browse/ZENKO-5269). Sibling Vault work (separate fix on the IAM query side): [VAULT-718](https://scality.atlassian.net/browse/VAULT-718).

The current `solution-base/mongodb/patches/mongodb-exporter-configuration.patch` (added in [ZENKO-4734](https://scality.atlassian.net/browse/ZENKO-4734), originally derived from [ZENKO-4374](https://scality.atlassian.net/browse/ZENKO-4374)) sets `metrics.extraArgs` to an explicit collector list:
```
--collector.diagnosticdata --collector.replicasetstatus --collector.dbstats --collector.topmetrics --compatible-mode
```
The original intent was defensive — to make sure the collectors backbeat dashboards depend on (notably the legacy `mongodb_mongod_replset_oplog_head_timestamp` metric, which only appears with `--compatible-mode`) stay enabled across chart upgrades.

That patch alone is **ineffective at scoping** what gets collected: in `percona/mongodb_exporter`, the `--collect-all` flag is processed at runtime *after* CLI parsing and unconditionally overwrites every `Enable*` flag to `true` (see `exporter/exporter.go`):
```go
if e.opts.CollectAll {
    e.opts.EnableCollStats = true
    e.opts.EnableIndexStats = true
    // ...
}
```
So as long as the chart templates pass `--collect-all`, the explicit `extraArgs` list is redundant. CLI flag order does not matter; `--no-collector.collstats` does not work either.

## What changed

### 1. New chart patch: `mongodb-exporter-disable-collect-all.patch`

Removes the literal `--collect-all ` substring from the bash command in each of:
- `solution-base/mongodb/charts/mongodb-sharded/templates/mongos/mongos-dep-sts.yaml`
- `solution-base/mongodb/charts/mongodb-sharded/templates/config-server/config-server-statefulset.yaml`
- `solution-base/mongodb/charts/mongodb-sharded/templates/shard/shard-data-statefulset.yaml`

After this PR, the existing `extraArgs` patch becomes the actual source of truth for which collectors run.

### 2. New ctst feature: `mongodbExporter.feature` + `mongodbExporter.ts`

Two `@PreMerge @2.14.0` scenarios:
- **Positive:** `mongodb_ss_connections` and `mongodb_dbstats_storageSize` exist (sanity for server-status + dbstats collectors).
- **Negative:** `mongodb_collstats_storageSize` and `mongodb_indexstats_accesses_ops` do **not** exist (catches re-introduction of `--collect-all` or any other path that re-enables those collectors).

The new step file mirrors the Prometheus pattern already used by `steps/pra.ts` (`PrometheusDriver` from `prometheus-query`, `PrometheusEndpoint` world parameter). The negative assertion polls for stability across more than one Prometheus scrape interval so an unscraped metric does not pass the check trivially.

## Design decisions

- **New patch file vs. extending `mongodb-exporter-configuration.patch`** — kept separate. The two patches address two unrelated concerns (defensive collector enablement vs. removing `--collect-all`) and are independently revertable.
- **Leave `--compatible-mode` hardcoded** in the templates even though it is also in `extraArgs`. Smallest possible diff; harmless redundancy that matches the existing patch's defensive style.
- **No `--collector.collstats-limit=N` workaround.** That flag would also disable `dbstats`/`topmetrics` once the collection count exceeds N — those are used by dashboards. Removing `--collect-all` is more surgical.
- **Test in same PR, separate commit.** Bundling means the ratchet ships with the fix; reviewers can verify the negative scenario fails on a revert. Separate commit keeps the chart change and the test independently inspectable.

## Out of scope

- The `--mongodb.collstats-colls` / `--mongodb.indexstats-colls` namespace allowlist flags — we want collstats/indexstats fully off, not scoped.
- Asserting absence of `mongodb_top_*` — `--collector.topmetrics` is in `extraArgs` and we want it on (intentionally not asserted).
- The Vault `__entity` index/collation work (tracked separately in VAULT-718).

Issue: ZENKO-5269

[ARTESCA-17291]: https://scality.atlassian.net/browse/ARTESCA-17291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ZENKO-5269]: https://scality.atlassian.net/browse/ZENKO-5269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ