### PR TITLE
ctst: skip trailing 1s sleep when poll condition is met

### DIFF
--- a/tests/functional/ctst/steps/azureArchive.ts
+++ b/tests/functional/ctst/steps/azureArchive.ts
@@ -52,30 +52,26 @@ function getAzureCreds(
  * @returns {string} name of the tar blob
  */
 async function isObjectRehydrated(zenko: Zenko, objectName: string) {
-    let found = false;
-    const {
-        tarName,
-    } = await findObjectPackAndManifest(
+    const { tarName } = await findObjectPackAndManifest(
         zenko,
         zenko.getSaved<string>('bucketName'),
         objectName || zenko.getSaved<string>('objectName'),
     );
-    const start = new Date();
     assert(tarName);
-    while (!found) {
-        found = await AzureHelper.blobExists(
+    const start = Date.now();
+    //wait for 1 minute max
+    while (Date.now() - start <= 60000) {
+        const found = await AzureHelper.blobExists(
             zenko.parameters.AzureArchiveContainer,
             `rehydrate/${tarName}`,
             getAzureCreds(zenko),
         );
-        await Utils.sleep(1000);
-
-        //wait for 1 minute max
-        if (new Date().getTime() - start.getTime() > 60000) {
-            return undefined;
+        if (found) {
+            return tarName;
         }
+        await Utils.sleep(1000);
     }
-    return tarName;
+    return undefined;
 }
 
 /**

--- a/tests/functional/ctst/steps/utils/kubernetes.ts
+++ b/tests/functional/ctst/steps/utils/kubernetes.ts
@@ -260,7 +260,6 @@ export async function waitForZenkoToStabilize(
     // So, this function will first wait till we detect a reconciliation
     // (deploymentInProgress = true), and then wait for the status to be available
     const startTime = Date.now();
-    let status = false;
     let deploymentFailure: ZenkoStatusValue = {
         lastTransitionTime: '',
         message: '',
@@ -287,7 +286,7 @@ export async function waitForZenkoToStabilize(
     world.logger.debug('Waiting for Zenko to stabilize');
     const zenkoClient = createKubeCustomObjectClient(world);
 
-    while (!status && Date.now() - startTime < timeout) {
+    while (Date.now() - startTime < timeout) {
         const zenkoCR = await zenkoClient.getNamespacedCustomObject({
             group: 'zenko.io',
             version: 'v1alpha2',
@@ -342,19 +341,16 @@ export async function waitForZenkoToStabilize(
             deploymentInProgress.status === 'False' &&
             available.status === 'True'
         ) {
-            status = true;
+            return;
         }
 
         await Utils.sleep(1000);
     }
 
-    if (!status) {
-        throw new Error('Zenko did not stabilize');
-    }
+    throw new Error('Zenko did not stabilize');
 }
 
 export async function waitForDataServicesToStabilize(world: Zenko, timeout = 15 * 60 * 1000, namespace = 'default') {
-    let allRunning = false;
     const startTime = Date.now();
     const annotationKey = 'operator.zenko.io/dependencies';
     const dataServices = ['connector-cloudserver-config', 'backbeat-config'];
@@ -379,8 +375,8 @@ export async function waitForDataServicesToStabilize(world: Zenko, timeout = 15 
         deployments: deployments.map(deployment => deployment.metadata?.name),
     });
 
-    while (!allRunning && Date.now() - startTime < timeout) {
-        allRunning = true;
+    while (Date.now() - startTime < timeout) {
+        let allRunning = true;
 
         // get the deployments in the array, and check in loop if they are ready
         for (const deployment of deployments) {
@@ -414,14 +410,13 @@ export async function waitForDataServicesToStabilize(world: Zenko, timeout = 15 
             }
         }
 
+        if (allRunning) {
+            return true;
+        }
         await Utils.sleep(1000);
     }
 
-    if (!allRunning) {
-        throw new Error('Data services did not stabilize');
-    }
-
-    return allRunning;
+    throw new Error('Data services did not stabilize');
 }
 
 export async function displayCRStatus(world: Zenko, namespace = 'default') {

--- a/tests/functional/ctst/steps/utils/utils.ts
+++ b/tests/functional/ctst/steps/utils/utils.ts
@@ -484,24 +484,16 @@ async function verifyObjectLocation(this: Zenko, objectName: string,
     if (versionId) {
         this.addCommandParameter({ versionId });
     }
-    let conditionOk = false;
-
     const startTime = Date.now();
     const timeoutMs = 5 * 60 * 1000;
-    while (!conditionOk) {
-        if (Date.now() - startTime > timeoutMs) {
-            throw new Error(
-                `verifyObjectLocation timed out after ${timeoutMs / 1000}s ` +
-                `waiting for object "${objName}" to reach status "${objectTransitionStatus}" ` +
-                `with storage class "${storageClass}"`
-            );
-        }
+    while (Date.now() - startTime <= timeoutMs) {
         const res = await S3.headObject(this.getCommandParameters());
         if (res.err?.includes('NotFound')) {
             await Utils.sleep(1000);
             continue;
-        } else if (res.err) {
-            break;
+        }
+        if (res.err) {
+            throw new Error(`verifyObjectLocation: headObject failed for "${objName}": ${res.err}`);
         }
         assert(res.stdout);
         const parsed = safeJsonParse<{
@@ -510,19 +502,23 @@ async function verifyObjectLocation(this: Zenko, objectName: string,
         }>(res.stdout);
         assert(parsed.ok);
         const expectedClass = storageClass !== '' ? storageClass : undefined;
-        if (parsed.result?.StorageClass === expectedClass) {
-            conditionOk = true;
-        }
+        let ok = parsed.result?.StorageClass === expectedClass;
         if (objectTransitionStatus == 'restored') {
-            const isRestored = !!parsed.result?.Restore &&
+            ok = ok && !!parsed.result?.Restore &&
                 parsed.result.Restore.includes('ongoing-request="false", expiry-date=');
-            conditionOk = conditionOk && isRestored;
         } else if (objectTransitionStatus == 'cold') {
-            conditionOk = conditionOk && !parsed.result?.Restore;
+            ok = ok && !parsed.result?.Restore;
+        }
+        if (ok) {
+            return;
         }
         await Utils.sleep(1000);
     }
-    assert(conditionOk);
+    throw new Error(
+        `verifyObjectLocation timed out after ${timeoutMs / 1000}s ` +
+        `waiting for object "${objName}" to reach status "${objectTransitionStatus}" ` +
+        `with storage class "${storageClass}"`
+    );
 }
 
 async function restoreObject(this: Zenko, objectName: string, days: number) {


### PR DESCRIPTION
## Summary

Several CTST polling helpers wait one extra interval after the success condition is met, before the `while` loop re-evaluates and exits. Every successful call pays that sleep as a flat tax. This PR guards the sleep with the success flag so we exit immediately.

## What changes

- `verifyObjectLocation` — used by the `object "*" should be "*" and have storage class "*"` step (~80 call sites across feature files)
- `isObjectRehydrated` — used by "blob for object X must be rehydrated"
- `waitForZenkoToStabilize` / `waitForDataServicesToStabilize` — deploy stabilization

## Why it saves time

Each call previously sleeps 1s after success → 1s/call × hundreds of invocations per CI run, all pure overhead. With these guards, every successful poll returns as soon as the matching response arrives. No behavior change on the unhappy path: the sleep still paces retries when the condition isn't yet met.

Out of scope: `addTransitionWorkflow` also sleeps 5s on success, but its comment indicates that's intentional propagation wait — left as-is.

Issue: ZENKO-5271