### PR TITLE
ctst: parallelize cleanupAccount IAM operations

### DIFF
--- a/tests/functional/ctst/common/utils.ts
+++ b/tests/functional/ctst/common/utils.ts
@@ -242,83 +242,82 @@ export async function cleanupAccount(world: Zenko, accountName: string) {
     try {
         Identity.useIdentity(IdentityEnum.ACCOUNT, accountName);
 
-        // List and detach policies for each user
-        const allUsers = await listAllEntities<User>(IAM.listUsers, 'Users');
-        for (const user of allUsers) {
-            const allUserPolicies = await listAttachedPolicies<AttachedPolicy>(
-                params => IAM.listAttachedUserPolicies({ userName: user.UserName, ...params }),
-            );
-            for (const policy of allUserPolicies) {
-                const result = await IAM.detachUserPolicy({
-                    userName: user.UserName, policyArn: policy.PolicyArn });
-                if (result.err) {
-                    throw new Error(result.err);
-                }
-            }
-        }
+        const [allUsers, allGroups, allRoles] = await Promise.all([
+            listAllEntities<User>(IAM.listUsers, 'Users'),
+            listAllEntities<Group>(IAM.listGroups, 'Groups'),
+            listAllEntities<Role>(IAM.listRoles, 'Roles'),
+        ]);
 
-        // List and detach policies for each group
-        const allGroups = await listAllEntities<Group>(IAM.listGroups, 'Groups');
-        for (const group of allGroups) {
-            const allGroupPolicies = await listAttachedPolicies<AttachedPolicy>(
-                params => IAM.listAttachedGroupPolicies({ groupName: group.GroupName, ...params }),
-            );
-            for (const policy of allGroupPolicies) {
-                const result = await IAM.detachGroupPolicy({
-                    groupName: group.GroupName, policyArn: policy.PolicyArn });
-                if (result.err) {
-                    throw new Error(result.err);
-                }
-            }
-        }
+        // Detach attached policies from every user, group and role in parallel.
+        await Promise.all([
+            ...allUsers.map(async user => {
+                const policies = await listAttachedPolicies<AttachedPolicy>(
+                    params => IAM.listAttachedUserPolicies({ userName: user.UserName, ...params }),
+                );
+                await Promise.all(policies.map(async policy => {
+                    const result = await IAM.detachUserPolicy({
+                        userName: user.UserName, policyArn: policy.PolicyArn });
+                    if (result.err) {
+                        throw new Error(result.err);
+                    }
+                }));
+            }),
+            ...allGroups.map(async group => {
+                const policies = await listAttachedPolicies<AttachedPolicy>(
+                    params => IAM.listAttachedGroupPolicies({ groupName: group.GroupName, ...params }),
+                );
+                await Promise.all(policies.map(async policy => {
+                    const result = await IAM.detachGroupPolicy({
+                        groupName: group.GroupName, policyArn: policy.PolicyArn });
+                    if (result.err) {
+                        throw new Error(result.err);
+                    }
+                }));
+            }),
+            ...allRoles.map(async role => {
+                const policies = await listAttachedPolicies<AttachedPolicy>(
+                    params => IAM.listAttachedRolePolicies({ roleName: role.RoleName, ...params }),
+                );
+                await Promise.all(policies.map(async policy => {
+                    const result = await IAM.detachRolePolicy({
+                        roleName: role.RoleName, policyArn: policy.PolicyArn });
+                    if (result.err) {
+                        throw new Error(result.err);
+                    }
+                }));
+            }),
+        ]);
 
-        // List and detach policies for each role
-        const allRoles = await listAllEntities<Role>(IAM.listRoles, 'Roles');
-        for (const role of allRoles) {
-            const allRolePolicies = await listAttachedPolicies<AttachedPolicy>(
-                params => IAM.listAttachedRolePolicies({ roleName: role.RoleName, ...params }),
-            );
-            for (const policy of allRolePolicies) {
-                const result = await IAM.detachRolePolicy({
-                    roleName: role.RoleName, policyArn: policy.PolicyArn });
-                if (result.err) {
-                    throw new Error(result.err);
-                }
-            }
-        }
-
-        // Delete all policies
+        // Delete all policies in parallel.
         const allPolicies = await listAllEntities<Policy>(IAM.listPolicies, 'Policies');
-        for (const policy of allPolicies) {
+        await Promise.all(allPolicies.map(async policy => {
             const result = await IAM.deletePolicy({ policyArn: policy.Arn });
             if (result.err) {
                 throw new Error(result.err);
             }
-        }
+        }));
 
-        // Delete all roles
-        for (const role of allRoles) {
-            const result = await IAM.deleteRole({ roleName: role.RoleName });
-            if (result.err) {
-                throw new Error(result.err);
-            }
-        }
-
-        // Delete all groups
-        for (const group of allGroups) {
-            const result = await IAM.deleteGroup({ groupName: group.GroupName });
-            if (result.err) {
-                throw new Error(result.err);
-            }
-        }
-
-        // Delete all users
-        for (const user of allUsers) {
-            const result = await IAM.deleteUser({ userName: user.UserName });
-            if (result.err) {
-                throw new Error(result.err);
-            }
-        }
+        // Delete all roles, groups and users in parallel (independent now that policies are gone).
+        await Promise.all([
+            ...allRoles.map(async role => {
+                const result = await IAM.deleteRole({ roleName: role.RoleName });
+                if (result.err) {
+                    throw new Error(result.err);
+                }
+            }),
+            ...allGroups.map(async group => {
+                const result = await IAM.deleteGroup({ groupName: group.GroupName });
+                if (result.err) {
+                    throw new Error(result.err);
+                }
+            }),
+            ...allUsers.map(async user => {
+                const result = await IAM.deleteUser({ userName: user.UserName });
+                if (result.err) {
+                    throw new Error(result.err);
+                }
+            }),
+        ]);
 
         // Finally, delete the account
         await world.deleteAccount(accountName);


### PR DESCRIPTION
## Summary

`cleanupAccount` (used by the `@BP-ASSUME_ROLE_USER_CROSS_ACCOUNT` `After` hook) makes ~12 sequential IAM round-trips per invocation. The hook fires 1260 times per full e2e run for ~1066s cumulative wall-clock — one of the largest single contributors to suite runtime.

This change parallelizes the work within each phase using `Promise.all`:

- **Listing** users/groups/roles in one round-trip (3 → 1).
- **Detach phase**: all per-entity policy detaches across users, groups and roles fan out concurrently (outer + inner).
- **Delete-policies phase**: all `deletePolicy` calls in parallel.
- **Delete-entities phase**: all role/group/user deletions in parallel.

Phase ordering is preserved (detach → delete-policies → delete-entities → `deleteAccount`). `Promise.all` matches the existing throw-on-first-error semantics — a failed op rejects the phase, the outer `try/catch` logs a warning and the hook completes normally.

Typical per-scenario fan-out is small (1-2 users, 1 role, 1 policy), so backend concurrency stays modest.

## Expected impact

Cleanup path drops from ~600ms of serial round-trips per call to ~150ms. For the ~80% of invocations that need cleanup, ballpark **~8 min saved per full e2e run**.

Issue: ZENKO-5273