### PR TITLE
Hash both kafka and kafka-connect subtrees in BUILD_TREE_HASH

### DIFF
--- a/solution/kafka_build_vars.sh
+++ b/solution/kafka_build_vars.sh
@@ -21,5 +21,5 @@ KAFKA_CONNECT_TAG=$(yq eval '.kafka-connect.tag' deps.yaml)
 JMX_JAVAAGENT_IMAGE=$(get_image_from_deps jmx-javaagent)
 JMX_JAVAAGENT_TAG=$(yq eval '.jmx-javaagent.tag' deps.yaml)
 MONGODB_CONNECTOR_TAG=$(yq eval '.mongodb-connector.tag' deps.yaml)
-BUILD_TREE_HASH=$(git rev-parse HEAD:solution/kafka)
+BUILD_TREE_HASH=$(git rev-parse HEAD:solution/kafka HEAD:solution/kafka-connect | sha1sum | cut -d' ' -f1)
 EOF


### PR DESCRIPTION
## Summary

- `solution/kafka_build_vars.sh:24` now hashes both `solution/kafka` and `solution/kafka-connect` into the shared `BUILD_TREE_HASH` suffix used by both image tags. Same 40-char hex format, drop-in for all consumers.

## Context

`BUILD_TREE_HASH` was previously `git rev-parse HEAD:solution/kafka` — a tree hash covering only the kafka subtree. The same value is used as the suffix in both image tags:

- `${KAFKA_IMAGE}:${KAFKA_TAG}-${BUILD_TREE_HASH}` (kafka image)
- `${KAFKA_CONNECT_IMAGE}:${KAFKA_CONNECT_TAG}-${BUILD_TREE_HASH}` (kafka-connect image)

Touched in `.github/workflows/end2end.yaml:346,361`, `solution/zenkoversion.yaml:99,102`, `.github/scripts/end2end/configure-e2e*.sh`, `solution/build.sh:88`.

Because the hash didn't include `solution/kafka-connect`, any change to that subtree (Dockerfile edits, new plugins, build-arg additions) silently overwrote the existing kafka-connect image at the same tag in the registry. Surfaced during [ZENKO-5274](https://scality.atlassian.net/browse/ZENKO-5274) (the SMT plugin being baked into a kafka-connect image whose tag was unchanged from `development/2.14`).

## Approach

Combine the tree hashes of both subtrees via `sha1sum`. Considered a per-image hash variable (so the kafka image would only re-tag when `solution/kafka` changes); rejected because the existing infrastructure assumes a single shared `BUILD_TREE_HASH` suffix across both images.

Issue: ZENKO-5275

[ZENKO-5274]: https://scality.atlassian.net/browse/ZENKO-5274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ