### PR TITLE
mongodb: bump mongodb-sharded chart to 9.4.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,48 @@
 # Changelog
 
-## 9.4.4 (2025-07-23)
+## 9.4.14 (2026-04-25)
 
-* [bitnami/mongodb-sharded] :zap: :arrow_up: Update dependency references ([#35267](https://github.com/bitnami/charts/pull/35267))
+* [bitnami/mongodb-sharded] fix(mongos): use exact match in liveness pr… ([#36488](https://github.com/bitnami/charts/pull/36488))
+
+## <small>9.4.12 (2025-08-25)</small>
+
+* [bitnami/mongodb-sharded] :zap: :arrow_up: Update dependency references (#36167) ([2e5bcf4](https://github.com/bitnami/charts/commit/2e5bcf4b7624c06b906d46b1270be10b56c04243)), closes [#36167](https://github.com/bitnami/charts/issues/36167)
+
+## <small>9.4.11 (2025-08-15)</small>
+
+* [bitnami/mongodb-sharded] :zap: :arrow_up: Update dependency references (#35990) ([9142685](https://github.com/bitnami/charts/commit/91426851b498a46bf6b1aa120479d689043077fd)), closes [#35990](https://github.com/bitnami/charts/issues/35990)
+
+## <small>9.4.10 (2025-08-13)</small>
+
+* [bitnami/mongodb-sharded] :zap: :arrow_up: Update dependency references (#35819) ([45b0ce5](https://github.com/bitnami/charts/commit/45b0ce5ded33857ec0e09238be9fb00ae25eb489)), closes [#35819](https://github.com/bitnami/charts/issues/35819)
+
+## <small>9.4.9 (2025-08-08)</small>
+
+* [bitnami/mongodb-sharded] :zap: :arrow_up: Update dependency references (#35704) ([471d0c7](https://github.com/bitnami/charts/commit/471d0c79dfc6841dcbd02ba3328b4d057cbe4848)), closes [#35704](https://github.com/bitnami/charts/issues/35704)
+
+## <small>9.4.8 (2025-08-07)</small>
+
+* [bitnami/mongodb-sharded] :zap: :arrow_up: Update dependency references (#35623) ([e9ea8d6](https://github.com/bitnami/charts/commit/e9ea8d61cf462837749fce2c9451af44d257df32)), closes [#35623](https://github.com/bitnami/charts/issues/35623)
+
+## <small>9.4.7 (2025-08-07)</small>
+
+* [bitnami/mongodb-sharded] :zap: :arrow_up: Update dependency references (#35595) ([3ea04e8](https://github.com/bitnami/charts/commit/3ea04e8e9baa055d386366aed6529d67b1770f2e)), closes [#35595](https://github.com/bitnami/charts/issues/35595)
+
+## <small>9.4.6 (2025-08-07)</small>
+
+* [bitnami/mongodb-sharded] :zap: :arrow_up: Update dependency references (#35507) ([82aeffb](https://github.com/bitnami/charts/commit/82aeffb315ba75da60f5fb800d0b2c1b5bbb63a3)), closes [#35507](https://github.com/bitnami/charts/issues/35507)
+
+## <small>9.4.5 (2025-07-31)</small>
+
+* [bitnami/*] docs: update BSI warning on charts' notes (#35340) ([07483a5](https://github.com/bitnami/charts/commit/07483a5ed964b409266dc025e4b55bf2eb0f621c)), closes [#35340](https://github.com/bitnami/charts/issues/35340)
+* [bitnami/mongodb-sharded] :zap: :arrow_up: Update dependency references (#35367) ([fabdf0b](https://github.com/bitnami/charts/commit/fabdf0b5acb5b69eec68bbfb558d770e0db284e7)), closes [#35367](https://github.com/bitnami/charts/issues/35367)
+
+## <small>9.4.4 (2025-07-23)</small>
+
+* [bitnami/*] Adapt main README and change ascii (#35173) ([73d15e0](https://github.com/bitnami/charts/commit/73d15e03e04647efa902a1d14a09ea8657429cd0)), closes [#35173](https://github.com/bitnami/charts/issues/35173)
+* [bitnami/*] Adapt welcome message to BSI (#35170) ([e1c8146](https://github.com/bitnami/charts/commit/e1c8146831516fb35de736a6f3fd10e5e7a44286)), closes [#35170](https://github.com/bitnami/charts/issues/35170)
+* [bitnami/*] Add BSI to charts' READMEs (#35174) ([4973fd0](https://github.com/bitnami/charts/commit/4973fd08dd7e95398ddcc4054538023b542e19f2)), closes [#35174](https://github.com/bitnami/charts/issues/35174)
+* [bitnami/mongodb-sharded] :zap: :arrow_up: Update dependency references (#35267) ([1c7c0c4](https://github.com/bitnami/charts/commit/1c7c0c4bb955c4f607b9a407c1b1ea929052afdd)), closes [#35267](https://github.com/bitnami/charts/issues/35267)
 
 ## <small>9.4.3 (2025-07-15)</small>
 

--- a/Chart.lock
+++ b/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.31.0
-digest: sha256:c4c9af4e0ca23cf2c549e403b2a2bba2c53a3557cee23da09fa4cdf710044c2c
-generated: "2025-05-06T10:43:07.61130783+02:00"
+  version: 2.31.4
+digest: sha256:fc442e77200e1914dd46fe26490dcf62f44caa51db673c2f8e67d5319cd4c163
+generated: "2025-08-13T16:31:57.435877752Z"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,18 +2,17 @@
 # SPDX-License-Identifier: APACHE-2.0
 
 annotations:
-  category: Database
   images: |
     - name: mongodb-exporter
-      image: docker.io/bitnami/mongodb-exporter:0.45.0-debian-12-r5
+      image: docker.io/bitnami/mongodb-exporter:0.47.0-debian-12-r1
     - name: mongodb-sharded
-      image: docker.io/bitnami/mongodb-sharded:8.0.12-debian-12-r0
+      image: docker.io/bitnami/mongodb-sharded:8.0.13-debian-12-r0
     - name: os-shell
-      image: docker.io/bitnami/os-shell:12-debian-12-r49
+      image: docker.io/bitnami/os-shell:12-debian-12-r51
   licenses: Apache-2.0
   tanzuCategory: service
 apiVersion: v2
-appVersion: 8.0.12
+appVersion: 8.0.13
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
@@ -38,4 +37,4 @@ maintainers:
 name: mongodb-sharded
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/mongodb-sharded
-version: 9.4.4
+version: 9.4.14

--- a/README.md
+++ b/README.md
@@ -14,18 +14,22 @@ Disclaimer: The respective trademarks mentioned in the offering are owned by the
 helm install my-release oci://registry-1.docker.io/bitnamicharts/mongodb-sharded
 ```
 
-Looking to use MongoDBreg; Sharded in production? Try [VMware Tanzu Application Catalog](https://bitnami.com/enterprise), the commercial edition of the Bitnami catalog.
+## Why use Bitnami Secure Images?
 
-## ⚠️ Important Notice: Upcoming changes to the Bitnami Catalog
+Those are hardened, minimal CVE images built and maintained by Bitnami. Bitnami Secure Images are based on the cloud-optimized, security-hardened enterprise [OS Photon Linux](https://vmware.github.io/photon/). Why choose BSI images?
 
-Beginning August 28th, 2025, Bitnami will evolve its public catalog to offer a curated set of hardened, security-focused images under the new [Bitnami Secure Images initiative](https://news.broadcom.com/app-dev/broadcom-introduces-bitnami-secure-images-for-production-ready-containerized-applications). As part of this transition:
+- Hardened secure images of popular open source software with Near-Zero Vulnerabilities
+- Vulnerability Triage & Prioritization with VEX Statements, KEV and EPSS Scores
+- Compliance focus with FIPS, STIG, and air-gap options, including secure bill of materials (SBOM)
+- Software supply chain provenance attestation through in-toto
+- First class support for the internet’s favorite Helm charts
 
-- Granting community users access for the first time to security-optimized versions of popular container images.
-- Bitnami will begin deprecating support for non-hardened, Debian-based software images in its free tier and will gradually remove non-latest tags from the public catalog. As a result, community users will have access to a reduced number of hardened images. These images are published only under the “latest” tag and are intended for development purposes
-- Starting August 28th, over two weeks, all existing container images, including older or versioned tags (e.g., 2.50.0, 10.6), will be migrated from the public catalog (docker.io/bitnami) to the “Bitnami Legacy” repository (docker.io/bitnamilegacy), where they will no longer receive updates.
-- For production workloads and long-term support, users are encouraged to adopt Bitnami Secure Images, which include hardened containers, smaller attack surfaces, CVE transparency (via VEX/KEV), SBOMs, and enterprise support.
+Each image comes with valuable security metadata. You can view the metadata in [our public catalog here](https://app-catalog.vmware.com/bitnami/apps). Note: Some data is only available with [commercial subscriptions to BSI](https://bitnami.com/).
 
-These changes aim to improve the security posture of all Bitnami users by promoting best practices for software supply chain integrity and up-to-date deployments. For more details, visit the [Bitnami Secure Images announcement](https://github.com/bitnami/containers/issues/83267).
+![Alt text](https://github.com/bitnami/containers/blob/main/BSI%20UI%201.png?raw=true "Application details")
+![Alt text](https://github.com/bitnami/containers/blob/main/BSI%20UI%202.png?raw=true "Packaging report")
+
+If you are looking for our previous generation of images based on Debian Linux, please see the [Bitnami Legacy registry](https://hub.docker.com/u/bitnamilegacy).
 
 ## Introduction
 

--- a/solution-base/mongodb/Makefile
+++ b/solution-base/mongodb/Makefile
@@ -2,7 +2,7 @@ BITNAMI_REMOTE := bitnami-charts
 BITNAMI_REPO   := https://github.com/bitnami/charts.git
 
 CHART         := mongodb-sharded
-CHART_VERSION := 9.4.4
+CHART_VERSION := 9.4.14
 CHART_REF     := $(CHART)/$(CHART_VERSION)
 
 # Repo-relative path of the vendored chart (needed by `git subtree`).
@@ -16,6 +16,11 @@ LOCAL_CHART_PREFIX := charts/$(CHART)
 VENDOR_BRANCH := vendor/charts/$(CHART)
 
 HELM := helm
+
+# `git subtree split` / `merge` require running from the repository toplevel,
+# but `make -C solution-base/mongodb` runs recipes with cwd at this directory.
+# Resolve toplevel once and cd into it for the subtree commands.
+TOPLEVEL := $(shell git rev-parse --show-toplevel)
 
 .PHONY: create-remote fetch-remote update-vendor-branch vendor-sync deps
 
@@ -32,13 +37,13 @@ fetch-remote: create-remote
 
 update-vendor-branch: fetch-remote
 	-git branch -D $(VENDOR_BRANCH)
-	git subtree split --prefix=bitnami/$(CHART) $(CHART_REF) -b $(VENDOR_BRANCH)
+	cd $(TOPLEVEL) && git subtree split --prefix=bitnami/$(CHART) $(CHART_REF) -b $(VENDOR_BRANCH)
 
 # Maintainer-only: bump CHART_VERSION above, then `make vendor-sync` to merge
 # upstream into our prefix. Resolves merge conflicts against our local commits
 # the same way any git merge does.
 vendor-sync: update-vendor-branch
-	git subtree merge --prefix=$(REPO_CHART_PREFIX) $(VENDOR_BRANCH) --squash
+	cd $(TOPLEVEL) && git subtree merge --prefix=$(REPO_CHART_PREFIX) $(VENDOR_BRANCH) --squash
 	@$(MAKE) deps
 
 # Resolve and extract the `bitnami/common` library chart so it appears as a

--- a/solution-base/mongodb/charts/mongodb-sharded/charts/common/Chart.yaml
+++ b/solution-base/mongodb/charts/mongodb-sharded/charts/common/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   category: Infrastructure
   licenses: Apache-2.0
 apiVersion: v2
-appVersion: 2.31.0
+appVersion: 2.31.4
 description: A Library Helm Chart for grouping common logic between bitnami charts.
   This chart is not deployable by itself.
 home: https://bitnami.com
@@ -20,4 +20,4 @@ name: common
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/common
 type: library
-version: 2.31.0
+version: 2.31.4

--- a/solution-base/mongodb/charts/mongodb-sharded/charts/common/README.md
+++ b/solution-base/mongodb/charts/mongodb-sharded/charts/common/README.md
@@ -26,11 +26,20 @@ data:
 
 Looking to use our applications in production? Try [VMware Tanzu Application Catalog](https://bitnami.com/enterprise), the commercial edition of the Bitnami catalog.
 
+## ⚠️ Important Notice: Upcoming changes to the Bitnami Catalog
+
+Beginning August 28th, 2025, Bitnami will evolve its public catalog to offer a curated set of hardened, security-focused images under the new [Bitnami Secure Images initiative](https://news.broadcom.com/app-dev/broadcom-introduces-bitnami-secure-images-for-production-ready-containerized-applications). As part of this transition:
+
+- Granting community users access for the first time to security-optimized versions of popular container images.
+- Bitnami will begin deprecating support for non-hardened, Debian-based software images in its free tier and will gradually remove non-latest tags from the public catalog. As a result, community users will have access to a reduced number of hardened images. These images are published only under the “latest” tag and are intended for development purposes
+- Starting August 28th, over two weeks, all existing container images, including older or versioned tags (e.g., 2.50.0, 10.6), will be migrated from the public catalog (docker.io/bitnami) to the “Bitnami Legacy” repository (docker.io/bitnamilegacy), where they will no longer receive updates.
+- For production workloads and long-term support, users are encouraged to adopt Bitnami Secure Images, which include hardened containers, smaller attack surfaces, CVE transparency (via VEX/KEV), SBOMs, and enterprise support.
+
+These changes aim to improve the security posture of all Bitnami users by promoting best practices for software supply chain integrity and up-to-date deployments. For more details, visit the [Bitnami Secure Images announcement](https://github.com/bitnami/containers/issues/83267).
+
 ## Introduction
 
 This chart provides a common template helpers which can be used to develop new charts using [Helm](https://helm.sh) package manager.
-
-Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
 ## Prerequisites
 
@@ -62,7 +71,6 @@ The following table lists the helpers available in the library which are scoped 
 | `common.capabilities.job.apiVersion`                      | Return the appropriate apiVersion for job.                                                     | `.` Chart context                       |
 | `common.capabilities.cronjob.apiVersion`                  | Return the appropriate apiVersion for cronjob.                                                 | `.` Chart context                       |
 | `common.capabilities.daemonset.apiVersion`                | Return the appropriate apiVersion for daemonset.                                               | `.` Chart context                       |
-| `common.capabilities.cronjob.apiVersion`                  | Return the appropriate apiVersion for cronjob.                                                 | `.` Chart context                       |
 | `common.capabilities.deployment.apiVersion`               | Return the appropriate apiVersion for deployment.                                              | `.` Chart context                       |
 | `common.capabilities.statefulset.apiVersion`              | Return the appropriate apiVersion for statefulset.                                             | `.` Chart context                       |
 | `common.capabilities.ingress.apiVersion`                  | Return the appropriate apiVersion for ingress.                                                 | `.` Chart context                       |
@@ -107,8 +115,6 @@ The following table lists the helpers available in the library which are scoped 
 | Helper identifier                         | Description                                                                                                       | Expected Input                                                                                                                                                                   |
 | ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `common.ingress.backend`                  | Generate a proper Ingress backend entry depending on the API version                                              | `dict "serviceName" "foo" "servicePort" "bar"`, see the [Ingress deprecation notice](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/) for the syntax differences |
-| `common.ingress.supportsPathType`         | Prints "true" if the pathType field is supported                                                                  | `.` Chart context                                                                                                                                                                |
-| `common.ingress.supportsIngressClassname` | Prints "true" if the ingressClassname field is supported                                                          | `.` Chart context                                                                                                                                                                |
 | `common.ingress.certManagerRequest`       | Prints "true" if required cert-manager annotations for TLS signed certificates are set in the Ingress annotations | `dict "annotations" .Values.path.to.the.ingress.annotations`                                                                                                                     |
 
 ### Labels

--- a/solution-base/mongodb/charts/mongodb-sharded/charts/common/templates/_capabilities.tpl
+++ b/solution-base/mongodb/charts/mongodb-sharded/charts/common/templates/_capabilities.tpl
@@ -115,7 +115,7 @@ Return the appropriate apiVersion for Horizontal Pod Autoscaler.
 Return the appropriate apiVersion for Vertical Pod Autoscaler.
 */}}
 {{- define "common.capabilities.vpa.apiVersion" -}}
-{{- $kubeVersion := include "common.capabilities.kubeVersion" .context -}}
+{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
 {{- if and (not (empty $kubeVersion)) (semverCompare "<1.25-0" $kubeVersion) -}}
 {{- print "autoscaling/v1beta2" -}}
 {{- else -}}

--- a/solution-base/mongodb/charts/mongodb-sharded/charts/common/templates/_errors.tpl
+++ b/solution-base/mongodb/charts/mongodb-sharded/charts/common/templates/_errors.tpl
@@ -38,6 +38,7 @@ Usage:
 {{- define "common.errors.insecureImages" -}}
 {{- $relocatedImages := list -}}
 {{- $replacedImages := list -}}
+{{- $bitnamiLegacyImages := list -}}
 {{- $retaggedImages := list -}}
 {{- $globalRegistry := ((.context.Values.global).imageRegistry) -}}
 {{- $originalImages := .context.Chart.Annotations.images -}}
@@ -49,7 +50,10 @@ Usage:
     {{- if not (contains $registryName $originalImages) -}}
       {{- $relocatedImages = append $relocatedImages $fullImageName  -}}
     {{- else if not (contains .repository $originalImages) -}}
-      {{- $replacedImages = append $replacedImages $fullImageName  -}}
+      {{- $replacedImages = append $replacedImages $fullImageName -}}
+      {{- if contains "docker.io/bitnamilegacy/" $fullImageNameNoTag -}}
+        {{- $bitnamiLegacyImages = append $bitnamiLegacyImages $fullImageName -}}
+      {{- end -}}
     {{- end -}}
   {{- end -}}
   {{- if not (contains (printf "%s:%s" .repository .tag) $originalImages) -}}
@@ -58,14 +62,17 @@ Usage:
 {{- end -}}
 
 {{- if and (or (gt (len $relocatedImages) 0) (gt (len $replacedImages) 0)) (((.context.Values.global).security).allowInsecureImages) -}}
-  {{- print "\n\n⚠ SECURITY WARNING: Verifying original container images was skipped. Please note this Helm chart was designed, tested, and validated on multiple platforms using a specific set of Bitnami and Tanzu Application Catalog containers. Substituting other containers is likely to cause degraded security and performance, broken chart features, and missing environment variables.\n" -}}
+  {{- print "\n\n⚠ SECURITY WARNING: Verifying original container images was skipped. Please note this Helm chart was designed, tested, and validated on multiple platforms using a specific set of Bitnami and Bitnami Secure Images containers. Substituting other containers is likely to cause degraded security and performance, broken chart features, and missing environment variables.\n" -}}
 {{- else if (or (gt (len $relocatedImages) 0) (gt (len $replacedImages) 0)) -}}
   {{- $errorString := "Original containers have been substituted for unrecognized ones. Deploying this chart with non-standard containers is likely to cause degraded security and performance, broken chart features, and missing environment variables." -}}
   {{- $errorString = print $errorString "\n\nUnrecognized images:" -}}
   {{- range (concat $relocatedImages $replacedImages) -}}
     {{- $errorString = print $errorString "\n  - " . -}}
   {{- end -}}
-  {{- if or (contains "docker.io/bitnami/" $originalImages) (contains "docker.io/bitnamiprem/" $originalImages) -}}
+  {{- if and (eq (len $relocatedImages) 0) (eq (len $replacedImages) (len $bitnamiLegacyImages)) -}}
+    {{- $errorString = print "\n\n⚠ WARNING: " $errorString -}}
+    {{- print $errorString -}}
+  {{- else if or (contains "docker.io/bitnami/" $originalImages) (contains "docker.io/bitnamiprem/" $originalImages) (contains "docker.io/bitnamisecure/" $originalImages) -}}
     {{- $errorString = print "\n\n⚠ ERROR: " $errorString -}}
     {{- $errorString = print $errorString "\n\nIf you are sure you want to proceed with non-standard containers, you can skip container image verification by setting the global parameter 'global.security.allowInsecureImages' to true." -}}
     {{- $errorString = print $errorString "\nFurther information can be obtained at https://github.com/bitnami/charts/issues/30850" -}}
@@ -75,7 +82,7 @@ Usage:
     {{- print $errorString -}}
   {{- end -}}
 {{- else if gt (len $retaggedImages) 0 -}}
-  {{- $warnString := "\n\n⚠ WARNING: Original containers have been retagged. Please note this Helm chart was tested, and validated on multiple platforms using a specific set of Tanzu Application Catalog containers. Substituting original image tags could cause unexpected behavior." -}}
+  {{- $warnString := "\n\n⚠ WARNING: Original containers have been retagged. Please note this Helm chart was tested, and validated on multiple platforms using a specific set of Bitnami and Bitnami Secure Images containers. Substituting original image tags could cause unexpected behavior." -}}
   {{- $warnString = print $warnString "\n\nRetagged images:" -}}
   {{- range $retaggedImages -}}
     {{- $warnString = print $warnString "\n  - " . -}}

--- a/solution-base/mongodb/charts/mongodb-sharded/charts/common/templates/_ingress.tpl
+++ b/solution-base/mongodb/charts/mongodb-sharded/charts/common/templates/_ingress.tpl
@@ -28,26 +28,6 @@ service:
 {{- end -}}
 
 {{/*
-TODO: Remove as soon it is removed from the rest of the charts
-Print "true" if the API pathType field is supported
-Usage:
-{{ include "common.ingress.supportsPathType" . }}
-*/}}
-{{- define "common.ingress.supportsPathType" -}}
-{{- print "true" -}}
-{{- end -}}
-
-{{/*
-TODO: Remove as soon it is removed from the rest of the charts
-Returns true if the ingressClassname field is supported
-Usage:
-{{ include "common.ingress.supportsIngressClassname" . }}
-*/}}
-{{- define "common.ingress.supportsIngressClassname" -}}
-{{- print "true" -}}
-{{- end -}}
-
-{{/*
 Return true if cert-manager required annotations for TLS signed
 certificates are set in the Ingress annotations
 Ref: https://cert-manager.io/docs/usage/ingress/#supported-annotations

--- a/solution-base/mongodb/charts/mongodb-sharded/charts/common/templates/_names.tpl
+++ b/solution-base/mongodb/charts/mongodb-sharded/charts/common/templates/_names.tpl
@@ -28,10 +28,11 @@ If release name contains chart name it will be used as a full name.
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- $releaseName := regexReplaceAll "(-?[^a-z\\d\\-])+-?" (lower .Release.Name) "-" -}}
+{{- if contains $name $releaseName -}}
+{{- $releaseName | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" $releaseName $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -2,7 +2,9 @@ CHART NAME: {{ .Chart.Name }}
 CHART VERSION: {{ .Chart.Version }}
 APP VERSION: {{ .Chart.AppVersion }}
 
-NOTICE: Starting August 28th, 2025, only a limited subset of images/charts will remain available for free. Backup will be available for some time at the 'Bitnami Legacy' repository. More info at https://github.com/bitnami/containers/issues/83267
+⚠ WARNING: Since August 28th, 2025, only a limited subset of images/charts are available for free.
+    Subscribe to Bitnami Secure Images to receive continued support and security updates.
+    More info at https://bitnami.com and https://github.com/bitnami/containers/issues/83267
 
 ** Please be patient while the chart is being deployed **
 

--- a/templates/config-server/config-server-statefulset.yaml
+++ b/templates/config-server/config-server-statefulset.yaml
@@ -231,6 +231,7 @@ spec:
             exec:
               command:
                 - pgrep
+                - -x
                 - mongod
           {{- end }}
           {{- if .Values.configsvr.customReadinessProbe }}

--- a/templates/mongos/mongos-dep-sts.yaml
+++ b/templates/mongos/mongos-dep-sts.yaml
@@ -208,6 +208,7 @@ spec:
             exec:
               command:
                 - pgrep
+                - -x
                 - mongos
           {{- end }}
           {{- if .Values.mongos.customReadinessProbe }}

--- a/templates/shard/shard-arbiter-statefulset.yaml
+++ b/templates/shard/shard-arbiter-statefulset.yaml
@@ -209,8 +209,8 @@ spec:
             exec:
               command:
                 - pgrep
-                - -f
-                - mongodb
+                - -x
+                - mongod
           {{- end }}
           {{- if $.Values.shardsvr.arbiter.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" $.Values.shardsvr.arbiter.customReadinessProbe "context" $) | nindent 12 }}

--- a/templates/shard/shard-data-statefulset.yaml
+++ b/templates/shard/shard-data-statefulset.yaml
@@ -238,6 +238,7 @@ spec:
             exec:
               command:
                 - pgrep
+                - -x
                 - mongod
           {{- end }}
           {{- if $.Values.shardsvr.dataNode.customReadinessProbe }}

--- a/values.yaml
+++ b/values.yaml
@@ -92,7 +92,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: bitnami/mongodb-sharded
-  tag: 8.0.12-debian-12-r0
+  tag: 8.0.13-debian-12-r0
   digest: ""
   ## Specify a imagePullPolicy
   ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
@@ -259,7 +259,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/os-shell
-    tag: 12-debian-12-r49
+    tag: 12-debian-12-r51
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
@@ -1798,7 +1798,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mongodb-exporter
-    tag: 0.45.0-debian-12-r5
+    tag: 0.47.0-debian-12-r1
     digest: ""
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
## Summary

Bump the vendored `mongodb-sharded` chart from `9.4.4` → `9.4.14` to pick up the upstream `pgrep -x` liveness-probe fix ([bitnami/charts#36488](https://github.com/bitnami/charts/pull/36488)) — the chart-side fix for the mongos/configsvr startup race we hit in production.

## Why

The mongos `livenessProbe` ran `pgrep mongos`, which substring-matches `mongosh`. During simultaneous StatefulSet startup, the bitnami entrypoint runs `mongosh --host configsvr` to wait for the configsvr replica set; that call hangs indefinitely when the configsvr port is open but the replica set hasn't completed primary election. The real `mongos` never gets `exec`d, the probe stays green (matching the hung `mongosh`), readiness fails correctly but Kubernetes never restarts the container — the cluster deadlocks.

Upstream PR #36488 adds `-x` (exact name match) to that probe and consistency-hardens the matching three other probes (`mongod` on shard-data, shard-arbiter, config-server).

## What changes

- **`solution-base/mongodb/Makefile`** — `CHART_VERSION: 9.4.4 → 9.4.14`. Also incidentally fixes a latent Makefile bug from [ZENKO-5281](https://scality.atlassian.net/browse/ZENKO-5281): `git subtree split`/`merge` require running from the repository toplevel, but `make -C solution-base/mongodb` runs recipes with cwd at this directory. Resolved by adding `cd $(TOPLEVEL)` to the subtree commands. The bug was hidden during ZENKO-5281 because the original subtree was bootstrapped via manual git commands at the repo root, not via `make vendor-sync`.
- **`solution-base/mongodb/charts/mongodb-sharded/`** — `git subtree merge --squash` of upstream `mongodb-sharded/9.4.14`. Clean three-way merge against our 11 local-modification commits (no conflicts — upstream's pgrep change is in a region disjoint from our local edits). The squash commit reads:
  ```
  Squashed 'solution-base/mongodb/charts/mongodb-sharded/' changes from d2eb70018d..cd87843fdd
  git-subtree-split: cd87843fdd50168708d5acb661e1ab3ce7672a54
  ```
- **`solution-base/mongodb/charts/mongodb-sharded/charts/common/`** — `helm dependency build` resolved a newer `bitnami/common` (2.31.0 → 2.31.4). Minor refinements only.

## Verification

- `pgrep -x` is now in all four probe files (mongos, shard-data, shard-arbiter, config-server).
- `Chart.yaml`: `version: 9.4.14`, `appVersion: 8.0.13`.
- Local mods preserved (custom mongos entrypoint via configmap, `configServer.serviceName` helper, redirect-logs, etc.).
- `helm template` renders 20 manifests; `helm lint` passes.

## What does NOT change

- `solution-base/deps.yaml` — image refs point at `ghcr.io/scality/zenko/*` from ZENKO-5110, independent of the chart's `annotations.images`. The image bump (8.0.12 → 8.0.13) in upstream's `annotations.images` doesn't propagate here; Zenko's deployed images are governed by `deps.yaml` separately.
- `solution-base/build.sh` — untouched; the `charts/common/` directory layout it relies on is preserved.

## Follow-up

Unblocks [ARTESCA-17516](https://scality.atlassian.net/browse/ARTESCA-17516) (revert the installer-side workaround) once a Zenko build incorporating this lands.

Issue: ZENKO-5276

[ZENKO-5281]: https://scality.atlassian.net/browse/ZENKO-5281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ