### PR TITLE
🐛(ZENKO-5288) wrap kafka-server-start.sh to propagate broker exit code

### DIFF
--- a/solution/kafka/Dockerfile
+++ b/solution/kafka/Dockerfile
@@ -41,4 +41,14 @@ COPY log4j.properties ${KAFKA_HOME}/config/
 
 RUN chmod a+x ${KAFKA_HOME}/bin/*.sh
 
+RUN mv ${KAFKA_HOME}/bin/kafka-server-start.sh ${KAFKA_HOME}/bin/kafka-server-start-real.sh && \
+    { \
+      echo '#!/bin/bash'; \
+      echo '"$(dirname "$0")/kafka-server-start-real.sh" "$@"'; \
+      echo 'KAFKA_EXIT=$?'; \
+      echo 'printf "%d" "$KAFKA_EXIT" > /var/run/kafka-exit/code'; \
+      echo 'exit "$KAFKA_EXIT"'; \
+    } > ${KAFKA_HOME}/bin/kafka-server-start.sh && \
+    chmod +x ${KAFKA_HOME}/bin/kafka-server-start.sh
+
 CMD ["kafka-server-start.sh"]

--- a/solution/kafka/Dockerfile
+++ b/solution/kafka/Dockerfile
@@ -41,14 +41,8 @@ COPY log4j.properties ${KAFKA_HOME}/config/
 
 RUN chmod a+x ${KAFKA_HOME}/bin/*.sh
 
-RUN mv ${KAFKA_HOME}/bin/kafka-server-start.sh ${KAFKA_HOME}/bin/kafka-server-start-real.sh && \
-    { \
-      echo '#!/bin/bash'; \
-      echo '"$(dirname "$0")/kafka-server-start-real.sh" "$@"'; \
-      echo 'KAFKA_EXIT=$?'; \
-      echo 'printf "%d" "$KAFKA_EXIT" > /var/run/kafka-exit/code'; \
-      echo 'exit "$KAFKA_EXIT"'; \
-    } > ${KAFKA_HOME}/bin/kafka-server-start.sh && \
-    chmod +x ${KAFKA_HOME}/bin/kafka-server-start.sh
+RUN mv ${KAFKA_HOME}/bin/kafka-server-start.sh ${KAFKA_HOME}/bin/kafka-server-start-real.sh
+
+COPY --chmod=755 kafka-server-start.sh ${KAFKA_HOME}/bin/kafka-server-start.sh
 
 CMD ["kafka-server-start.sh"]

--- a/solution/kafka/kafka-server-start.sh
+++ b/solution/kafka/kafka-server-start.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+"$(dirname "$0")/kafka-server-start-real.sh" "$@"
+KAFKA_EXIT=$?
+printf "%d" "$KAFKA_EXIT" > /var/run/kafka-exit/code
+exit "$KAFKA_EXIT"


### PR DESCRIPTION
## Summary

- Rename \`kafka-server-start.sh\` to \`kafka-server-start-real.sh\` at image build time
- Add a new \`kafka-server-start.sh\` wrapper that captures Kafka's exit code and writes it to \`/var/run/kafka-exit/code\` before returning
- The \`kafka-scripts-patcher\` init container is removed from the operator as a result (see scality/zenko-operator#620)

## Context

Koperator's entrypoint calls \`kafka-server-start.sh\` then unconditionally runs \`rm /var/run/wait/do-not-exit-yet\` (exit 0), masking any non-zero exit code from the broker. By baking the wrapper into the image, we capture the exit code before that masking occurs, allowing the \`exit-code-propagator\` sidecar in the operator to set the pod phase to \`Failed\` when Kafka crashes.

An upstream fix has also been opened at https://github.com/adobe/koperator/pull/260. We should ship this fix now and remove it once the upstream one is merged, since without it crash debugging is difficult for the CS team.

Issue: ZENKO-5288