### PR TITLE
feat(mongodb): alert on createIndexes command failures

### DIFF
--- a/monitoring/mongodb/alerts.test.yaml
+++ b/monitoring/mongodb/alerts.test.yaml
@@ -671,3 +671,30 @@ tests:
                 It does not have the expected number of SECONDARY members. Please ensure that all
                 instances are running properly.
               summary: MongoDB replica set out of sync
+
+  - name: MongoDbCreateIndexesFailed
+    interval: 1m
+    input_series:
+      - series: mongodb_ss_metrics_commands_createIndexes_failed{namespace="zenko", pod="data-db-mongodb-sharded-shard0-data-0"}
+        values: 0 0 0 0 0 1 1 1 1 1 1 1
+      - series: mongodb_ss_metrics_commands_createIndexes_failed{namespace="zenko", pod="data-db-mongodb-sharded-shard0-data-1"}
+        values: 0x11
+      - series: mongodb_ss_metrics_commands_createIndexes_failed{namespace="zenko", pod="data-db-mongodb-sharded-shard1-data-0"}
+        values: 0x11
+    alert_rule_test:
+      - alertname: MongoDbCreateIndexesFailed
+        eval_time: 4m
+        exp_alerts: []
+      - alertname: MongoDbCreateIndexesFailed
+        eval_time: 6m
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              namespace: zenko
+              pod: data-db-mongodb-sharded-shard0-data-0
+            exp_annotations:
+              description: "MongoDB pod `data-db-mongodb-sharded-shard0-data-0` reported failed createIndexes commands in the last 5 minutes."
+              summary: MongoDB index creation failure
+      - alertname: MongoDbCreateIndexesFailed
+        eval_time: 16m
+        exp_alerts: []

--- a/monitoring/mongodb/alerts.yaml
+++ b/monitoring/mongodb/alerts.yaml
@@ -270,6 +270,16 @@ groups:
       description: "MongoDB pod `{{ $labels.pod }}` has been in the 'STARTUP2' state for more than 1 hour. Please ensure that the instance is running properly."
       summary: MongoDB node in STARTUP2 state for too long
 
+  - alert: MongoDbCreateIndexesFailed
+    expr: |
+      increase(mongodb_ss_metrics_commands_createIndexes_failed{namespace="${namespace}", pod=~"${service}.*"}[5m]) > 0
+    for: 0m
+    labels:
+      severity: warning
+    annotations:
+      description: "MongoDB pod `{{ $labels.pod }}` reported failed createIndexes commands in the last 5 minutes."
+      summary: MongoDB index creation failure
+
   - alert: MongoDbRSNotSynced
     expr: |
       count by (rs_nm, statefulset) (


### PR DESCRIPTION
## Summary
- Add `MongoDbCreateIndexesFailed` Prometheus alert (`monitoring/mongodb/alerts.yaml`) on `mongodb_ss_metrics_commands_createIndexes_failed` from mongodb_exporter (Percona, exposes `serverStatus.metrics.commands.*`).
- Fires when any MongoDB pod records a failed `createIndexes` command in a 10-minute window. Catches index-build refusals such as MongoDB 7.1+ `indexBuildMinAvailableDiskSpaceMB` rejections, and any other `createIndexes` failures regardless of which client triggered them.
- Companion fixture added to `alerts.test.yaml`.

A narrower Backbeat-side alert on the same scenario lives in the lifecycle conductor under [BB-784](https://scality.atlassian.net/browse/BB-784) (Backbeat PR #2753). Part of the [Empty bucket feature epic](https://scality.atlassian.net/browse/ARTESCA-16740).

The compaction/fragmentation alert (also part of ZENKO-5285's description) is deferred — needs more thought on the right signal.

Issue: ZENKO-5285

[BB-784]: https://scality.atlassian.net/browse/BB-784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ