### PR TITLE
feat(mongodb): alert when compaction is needed

### DIFF
--- a/monitoring/mongodb/alerts.test.yaml
+++ b/monitoring/mongodb/alerts.test.yaml
@@ -698,3 +698,37 @@ tests:
       - alertname: MongoDbCreateIndexesFailed
         eval_time: 16m
         exp_alerts: []
+
+  - name: MongoDbCompactionNeeded
+    interval: 5m
+    input_series:
+      # Compaction-needed DB: 4 GB reclaimable on a 10 GB filesystem (40% > 30%)
+      - series: mongodb_dbstats_fsTotalSize{namespace="zenko", pod="data-db-mongodb-sharded-shard0-data-0", database="needs-compaction"}
+        values: 1e10x13
+      - series: mongodb_dbstats_totalFreeStorageSize{namespace="zenko", pod="data-db-mongodb-sharded-shard0-data-0", database="needs-compaction"}
+        values: 4e9x13
+      # Healthy DB on same pod: 1 GB reclaimable on the same 10 GB filesystem (10% < 30%)
+      - series: mongodb_dbstats_fsTotalSize{namespace="zenko", pod="data-db-mongodb-sharded-shard0-data-0", database="healthy-db"}
+        values: 1e10x13
+      - series: mongodb_dbstats_totalFreeStorageSize{namespace="zenko", pod="data-db-mongodb-sharded-shard0-data-0", database="healthy-db"}
+        values: 1e9x13
+    alert_rule_test:
+      # for: 1h not yet satisfied
+      - alertname: MongoDbCompactionNeeded
+        eval_time: 10m
+        exp_alerts: []
+      - alertname: MongoDbCompactionNeeded
+        eval_time: 55m
+        exp_alerts: []
+      # for: 1h satisfied; only the needs-compaction DB fires
+      - alertname: MongoDbCompactionNeeded
+        eval_time: 65m
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              namespace: zenko
+              pod: data-db-mongodb-sharded-shard0-data-0
+              database: needs-compaction
+            exp_annotations:
+              description: "MongoDB pod `data-db-mongodb-sharded-shard0-data-0` database `needs-compaction` has accumulated reclaimable storage exceeding 0.3 of the filesystem capacity. Consider running compaction to recover disk space."
+              summary: MongoDB compaction needed

--- a/monitoring/mongodb/alerts.yaml
+++ b/monitoring/mongodb/alerts.yaml
@@ -27,6 +27,9 @@ x-inputs:
   - name: replicationLagOplogSizeThreshold
     type: config
     value: 0.5
+  - name: reclaimableStorageWarningThreshold
+    type: config
+    value: 0.3
 
 groups:
 - name: MongoDb
@@ -279,6 +282,17 @@ groups:
     annotations:
       description: "MongoDB pod `{{ $labels.pod }}` reported failed createIndexes commands in the last 5 minutes."
       summary: MongoDB index creation failure
+
+  - alert: MongoDbCompactionNeeded
+    expr: |
+      mongodb_dbstats_totalFreeStorageSize{namespace="${namespace}",pod=~"${service}.*"}
+        > ${reclaimableStorageWarningThreshold} * mongodb_dbstats_fsTotalSize{namespace="${namespace}",pod=~"${service}.*"}
+    for: 1h
+    labels:
+      severity: warning
+    annotations:
+      description: "MongoDB pod `{{ $labels.pod }}` database `{{ $labels.database }}` has accumulated reclaimable storage exceeding ${reclaimableStorageWarningThreshold} of the filesystem capacity. Consider running compaction to recover disk space."
+      summary: MongoDB compaction needed
 
   - alert: MongoDbRSNotSynced
     expr: |

--- a/solution-base/mongodb/charts/mongodb-sharded/values.yaml
+++ b/solution-base/mongodb/charts/mongodb-sharded/values.yaml
@@ -1815,7 +1815,7 @@ metrics:
   ## @param metrics.extraArgs String with extra arguments to the metrics exporter
   ## ref: https://github.com/percona/mongodb_exporter/blob/main/main.go
   ##
-  extraArgs: "--collector.diagnosticdata --collector.replicasetstatus --collector.dbstats --collector.topmetrics --compatible-mode"
+  extraArgs: "--collector.diagnosticdata --collector.replicasetstatus --collector.dbstats --collector.dbstatsfreestorage --collector.topmetrics --compatible-mode"
   ## @param metrics.resourcesPreset Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if metrics.resources is set (metrics.resources is recommended for production).
   ## More information: https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
   ##


### PR DESCRIPTION
Follow-up to [ZENKO-5285](https://scality.atlassian.net/browse/ZENKO-5285) (PR #2431), which bundled two alerts in its description and only shipped the first (createIndexes-failed). This adds the second — a fragmentation / compaction-needed signal — that @DarkIsDude explicitly asked be filed as a follow-up.

## Two commits, deliberately split

1. **`mongodb: enable dbstatsfreestorage collector in exporter`** — one-line `values.yaml` change adding `--collector.dbstatsfreestorage` to `metrics.extraArgs`. The chart's exporter no longer uses `--collect-all` (dropped in 8414833 for ZENKO-5281), so each sub-collector is opted into individually in `extraArgs` (already lists `dbstats`, `diagnosticdata`, `replicasetstatus`, `topmetrics`). Without `dbstatsfreestorage`, `freeStorageSize` / `totalFreeStorageSize` only appear as part of the clunky per-host `mongodb_dbstats_raw_<host>_*` expansion instead of as top-level `mongodb_dbstats_*` series.

2. **`mongodb: alert when compaction is needed`** — the alert proper.

## The alert

```promql
mongodb_dbstats_totalFreeStorageSize > 0.3 * mongodb_dbstats_fsTotalSize
for: 1h
```

Per-(pod, database) granularity. Severity warning. Threshold exposed as the `compactionFreeStorageRatioThreshold` x-input (default 0.3).

Expressing the threshold as a fraction of **filesystem capacity** (not of the DB's own storage) lets it scale across cluster sizes:

- 100 GB FS → fires around 30 GB reclaimable
- 1 TB FS → fires around 300 GB reclaimable
- 10 TB FS → fires around 3 TB reclaimable

## Heuristic notes

A previous draft combined three legs (FS-pressure + fragmentation ratio + absolute floor). @francoisferrand's review pointed out that the fragmentation-ratio leg added noise without much signal and the FS-pressure leg could mask real waste on under-used disks. The single fs-scaled threshold above folds both concerns into one condition.

Per-DB granularity means the alert tells you `pod={{ "{{ $labels.pod }}" }}` and `database={{ "{{ $labels.database }}" }}` but does **not** identify the specific collection. To find that, an operator runs `collStats` on the alerting DB. The exporter has a `--collector.collstats` flag that could expose per-collection visibility, but at Artesca-scale cardinality (thousands of buckets per DB) that's expensive — deferred.

## Safety against missing / zero values

- Missing metric for a `(pod, database)` tuple → PromQL produces empty → no alert.
- `totalFreeStorageSize = 0` (no fragmentation) → `0 > 0.3 * fsTotalSize` is always false.
- `fsTotalSize = 0` would degenerate (`0.3 * 0 = 0`, then any positive `freeStorage` would fire), but it's physically impossible for an attached PVC.

## Follow-up (not in this PR)

Matching `compactionFreeStorageRatioThreshold` config option in ZKOP, to expose the knob to ops. Not filed as a ticket yet; will track when this lands.

## Related

- [ZENKO-5293](https://scality.atlassian.net/browse/ZENKO-5293) — this ticket
- [ZENKO-5285](https://scality.atlassian.net/browse/ZENKO-5285) — parent alert ticket; createIndexes-failed half shipped in #2431
- [BB-784](https://scality.atlassian.net/browse/BB-784) — Backbeat-side LifecycleIndexCreationFailed (scality/backbeat#2753)
- [BB-783](https://scality.atlassian.net/browse/BB-783) — putBucketIndexesFailed metric (scality/backbeat#2751)
- Parent epic ARTESCA-16740 — Empty bucket feature

Issue: ZENKO-5293

[ZENKO-5285]: https://scality.atlassian.net/browse/ZENKO-5285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ZENKO-5293]: https://scality.atlassian.net/browse/ZENKO-5293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ