### PR TITLE
feat(mongodb): set indexBuildMinAvailableDiskSpaceMB to 10 GiB

### DIFF
--- a/solution-base/build.sh
+++ b/solution-base/build.sh
@@ -63,6 +63,7 @@ MONGODB_SHARDSERVER_RAM_LIMIT="MONGODB_SHARDSERVER_RAM_LIMIT"
 MONGODB_SHARDSERVER_EXTRA_FLAGS="MONGODB_SHARDSERVER_EXTRA_FLAGS"
 MONGODB_SHARDSERVER_RAM_REQUEST="MONGODB_SHARDSERVER_RAM_REQUEST"
 MONGODB_MONGOS_RAM_REQUEST="MONGODB_MONGOS_RAM_REQUEST"
+MONGODB_INDEX_BUILD_MIN_DISK_SPACE_MB=10000
 
 function flatten_source_images()
 {
@@ -127,10 +128,10 @@ function render_mongodb_sharded_yamls()
         --set 'shardsvr.persistence.selector.matchLabels.app\.kubernetes\.io/part-of=zenko' \
         --set 'configsvr.persistence.selector.matchLabels.app\.kubernetes\.io/name=mongodb-sharded-config' \
         --set 'configsvr.persistence.selector.matchLabels.app\.kubernetes\.io/part-of=zenko' \
-        --set "configsvr.mongodbExtraFlags={--setParameter rollbackTimeLimitSecs=259200}" \
+        --set "configsvr.mongodbExtraFlags={--setParameter rollbackTimeLimitSecs=259200,--setParameter indexBuildMinAvailableDiskSpaceMB=${MONGODB_INDEX_BUILD_MIN_DISK_SPACE_MB}}" \
         --set mongos.resources.requests.memory=${MONGODB_MONGOS_RAM_REQUEST} \
         --set mongos.resources.limits.memory=${MONGODB_MONGOS_RAM_LIMIT} \
-        --set "shardsvr.dataNode.mongodbExtraFlags={${MONGODB_SHARDSERVER_EXTRA_FLAGS}}" \
+        --set "shardsvr.dataNode.mongodbExtraFlags={${MONGODB_SHARDSERVER_EXTRA_FLAGS},--setParameter indexBuildMinAvailableDiskSpaceMB=${MONGODB_INDEX_BUILD_MIN_DISK_SPACE_MB}}" \
         --set shardsvr.dataNode.resources.limits.memory=${MONGODB_SHARDSERVER_RAM_LIMIT} \
         --set shardsvr.dataNode.resources.requests.memory=${MONGODB_SHARDSERVER_RAM_REQUEST} \
         --set existingSecret=${MONGODB_NAME}-db-creds \


### PR DESCRIPTION
## Summary

Add `--setParameter indexBuildMinAvailableDiskSpaceMB=10000` (10 GiB) to the mongod startup flags of config servers and shard data servers in the rendered `mongodb-sharded` manifests (`solution-base/build.sh`).

The MongoDB default (500 MB) is far below the transient disk peak of a real lifecycle index build — spill files plus the partial index B-tree can transiently use tens of GB on a 100M-document bucket. With this parameter (7.1+ semantics; we ship MongoDB 8.0.13) raised to 10 GiB, mongod refuses to start new index builds and kills in-flight ones while the volume still has comfortable headroom, rather than at the last 500 MB.

This supersedes the Artesca installer-side implementation from scality/artesca#5228 (ARTESCA-17683): per review feedback there, this is purely MongoDB behavior and belongs in zenko-base, where every consumer of the rendered manifests benefits.

## Implementation notes

- The flag is added as a second `mongodbExtraFlags` list item: next to the existing `rollbackTimeLimitSecs=259200` constant on configsvr, and next to the `MONGODB_SHARDSERVER_EXTRA_FLAGS` placeholder on shardsvr. Consumers substitute that placeholder with plain string replacement (Artesca `read_manifest`, CI `sed`), so a partial-value placeholder keeps working unchanged.
- mongos and shard arbiters are left untouched — they host no data and build no indexes.
- Verified by diffing the rendered `deploy/mongodb-sharded-*.yaml` against `development/2.15`: the only changes are the 59 expected `MONGODB_EXTRA_FLAGS` values (13 configsvr + 46 shard-data StatefulSets across the 13 topology files), e.g.:

```diff
             - name: MONGODB_EXTRA_FLAGS
-              value: "--setParameter rollbackTimeLimitSecs=259200"
+              value: "--setParameter rollbackTimeLimitSecs=259200 --setParameter indexBuildMinAvailableDiskSpaceMB=10000"
```

## Related

- ARTESCA-17683 / scality/artesca#5228 — superseded installer-side implementation
- ZENKO-5286 / BB-783 — Backbeat `putBucketIndexesFailed` metric on the failure path
- ZENKO-5285 — alert on index creation failures
- ARSN-588 — functional test exercising the disk-space refusal path

Issue: ZENKO-5295
