### PR TITLE
re-attribute mocha hook failures in junit merge

### DIFF
--- a/.github/scripts/merge-junit-reports.py
+++ b/.github/scripts/merge-junit-reports.py
@@ -9,15 +9,39 @@ This ensures flaky test detection works properly in CI when tests are retried.
 
 import xml.etree.ElementTree as ET
 import os
+import re
 import sys
 from collections import defaultdict
 from copy import deepcopy
+
+# Mocha reports a failed hook as a synthetic testcase titled
+# '"<before|after> <each|all>" hook for "<test>"' and emits nothing for the
+# hook on a passing run. Capture "<test>" so the hook failure can be
+# re-attributed to the test it belongs to.
+HOOK_FOR_RE = re.compile(r'"(?:before|after) (?:each|all)" hook for "(.*)"')
 
 def get_suite_key(suite):
     """Generate a unique key for a testsuite based on name and package."""
     name = suite.get('name', '')
     package = suite.get('package', '')
     return f"{package}::{name}"
+
+def attribute_hook_failures(suite):
+    """Re-attribute mocha hook-failure testcases to their owning test.
+
+    The flaky-test detection in action-junit-report pairs a failure with a
+    later pass by (name, classname, file). A hook-failure entry can never have
+    a passing counterpart with the same key, so a single hook flake would fail
+    the build on every retry. mocha names a failed hook after the test it ran
+    for, so rewriting the entry to that test's name/classname lets a retried
+    pass cancel it out. A suite-level hook with no test to attach to keeps a
+    bare '"... hook"' title and is left as-is (does not happen in practice).
+    """
+    for tc in suite.findall('testcase'):
+        for attr in ('name', 'classname'):
+            value = tc.get(attr)
+            if value is not None:
+                tc.set(attr, HOOK_FOR_RE.sub(r'\1', value))
 
 def merge_testsuites(testsuites_list):
     """
@@ -101,6 +125,7 @@ def merge_reports(output_file, input_files):
     total_tests = total_failures = total_errors = total_skipped = 0
 
     for suite in merged_suites:
+        attribute_hook_failures(suite)
         root.append(suite)
         total_tests += int(suite.get('tests', 0))
         total_failures += int(suite.get('failures', 0))

--- a/tests/scripts/test_merge_junit_reports.py
+++ b/tests/scripts/test_merge_junit_reports.py
@@ -92,6 +92,131 @@ def test_merge_preserves_duplicate_testcases_for_flaky_detection(tmp_path, merge
     assert sum(1 for tc in flaky_cases if tc.find("failure") is not None) == 1
 
 
+def test_hook_failures_are_reattributed_to_owning_test(tmp_path, merge_module):
+    """Hook-failure entries are renamed to their owning test so a retried pass matches them."""
+    failed_attempt = tmp_path / "attempt1.xml"
+    passed_attempt = tmp_path / "attempt2.xml"
+    merged = tmp_path / "merged.xml"
+
+    # Attempt 1: both the beforeEach and afterEach for the test threw.
+    _write_xml(
+        failed_attempt,
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <testsuites>
+          <testsuite name="IAM user - Access Keys: " tests="2" failures="2" errors="0" skipped="0">
+            <testcase name='IAM user - Access Keys:  "before each" hook for "should create access keys"' classname='"before each" hook for "should create access keys"' time="0.03">
+              <failure message="EntityAlreadyExists">boom</failure>
+            </testcase>
+            <testcase name='IAM user - Access Keys:  "after each" hook for "should create access keys"' classname='"after each" hook for "should create access keys"' time="0.01">
+              <failure message="Cannot read properties of null">boom</failure>
+            </testcase>
+          </testsuite>
+        </testsuites>
+        """,
+    )
+
+    # Attempt 2 (retry): clean pass, no hook entries.
+    _write_xml(
+        passed_attempt,
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <testsuites>
+          <testsuite name="IAM user - Access Keys: " tests="1" failures="0" errors="0" skipped="0">
+            <testcase name="IAM user - Access Keys:  should create access keys" classname="should create access keys" time="0.02" />
+          </testsuite>
+        </testsuites>
+        """,
+    )
+
+    merge_module.merge_reports(str(merged), [str(failed_attempt), str(passed_attempt)])
+
+    suite = ET.parse(merged).getroot().find("testsuite")
+    testcases = suite.findall("testcase")
+
+    assert all("hook for" not in tc.get("name") for tc in testcases)
+    assert all("hook for" not in tc.get("classname") for tc in testcases)
+
+    owned = [
+        tc
+        for tc in testcases
+        if tc.get("name") == "IAM user - Access Keys:  should create access keys"
+        and tc.get("classname") == "should create access keys"
+    ]
+    assert len(owned) == 3
+    assert sum(1 for tc in owned if tc.find("failure") is not None) == 2
+
+
+def test_suite_level_hook_failure_reattributed_to_its_test(tmp_path, merge_module):
+    """A beforeAll/afterAll failure is named after the suite's first/last test, so it is rewritten too."""
+    failed_attempt = tmp_path / "attempt1.xml"
+    passed_attempt = tmp_path / "attempt2.xml"
+    merged = tmp_path / "merged.xml"
+
+    # Attempt 1: beforeAll threw, so the suite's tests never ran.
+    _write_xml(
+        failed_attempt,
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <testsuites>
+          <testsuite name="S: " tests="1" failures="1" errors="0" skipped="0">
+            <testcase name='S:  "before all" hook for "first test"' classname='"before all" hook for "first test"' time="0.01">
+              <failure message="setup failed">boom</failure>
+            </testcase>
+          </testsuite>
+        </testsuites>
+        """,
+    )
+
+    # Attempt 2 (retry): the suite runs, first test passes.
+    _write_xml(
+        passed_attempt,
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <testsuites>
+          <testsuite name="S: " tests="1" failures="0" errors="0" skipped="0">
+            <testcase name="S:  first test" classname="first test" time="0.02" />
+          </testsuite>
+        </testsuites>
+        """,
+    )
+
+    merge_module.merge_reports(str(merged), [str(failed_attempt), str(passed_attempt)])
+
+    testcases = ET.parse(merged).getroot().find("testsuite").findall("testcase")
+    assert all("hook for" not in tc.get("name") for tc in testcases)
+
+    owned = [tc for tc in testcases if tc.get("name") == "S:  first test"]
+    assert len(owned) == 2
+    assert sum(1 for tc in owned if tc.find("failure") is not None) == 1
+
+
+def test_bare_hook_without_owning_test_is_left_untouched(tmp_path, merge_module):
+    """A hook with no 'for "<test>"' suffix has no test to attach to and is unchanged."""
+    src = tmp_path / "src.xml"
+    merged = tmp_path / "merged.xml"
+
+    _write_xml(
+        src,
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <testsuites>
+          <testsuite name="S" tests="1" failures="1" errors="0" skipped="0">
+            <testcase name='S "before all" hook' classname='"before all" hook' time="0.01">
+              <failure message="setup failed">boom</failure>
+            </testcase>
+          </testsuite>
+        </testsuites>
+        """,
+    )
+
+    merge_module.merge_reports(str(merged), [str(src)])
+
+    tc = ET.parse(merged).getroot().find("testsuite").find("testcase")
+    assert tc.get("name") == 'S "before all" hook'
+    assert tc.get("classname") == '"before all" hook'
+
+
 def test_merge_keeps_distinct_suites_and_recomputes_totals(tmp_path, merge_module):
     first = tmp_path / "first.xml"
     second = tmp_path / "second.xml"


### PR DESCRIPTION
Mocha reports a failed beforeEach/afterEach as a synthetic testcase named '"<when>" hook for "<test>"' and emits nothing for the hook on a passing run. action-junit-report pairs a failure with a later pass by name/classname/file, so a hook-failure entry can never match its retry: a single hook flake fails the build on every rerun, and the only workaround is to manually delete the failed attempt's reports from the artifacts server.

Rewrite hook-failure testcases in the merge step to carry the name/classname of the test they belong to, so a retried pass cancels them out.

Issue: ZENKO-5296
