### PR TITLE
fix codespace yarn setup prompt

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -112,6 +112,7 @@
     "containerEnv": {
         "ZENKO_MONGODB_DATABASE": "zenko-database"
     },
+    "onCreateCommand": "sudo corepack disable",
     // Use 'postCreateCommand' to run commands after the container is created.
     "postCreateCommand": ".devcontainer/setup.sh"
 }


### PR DESCRIPTION
Issue: ZENKO-5301

Issue probably introduced when I changed the resources setup from python to typescript.

In codespace, after the cluster is deployed, we (the codespace, it's not the developer doing this manually 🧐 ) need to run the typescript resources setup script, but it's blocked with : 
<img width="621" height="80" alt="image" src="https://github.com/user-attachments/assets/bea2ade0-8c20-4158-a5dd-324b0b5ca167" />

This shouldn't require manual intervention, and anyways, this screenshot is from the codespace creation log, it's not an interactive shell, we can't 'Y' that thing