### PR TITLE
fix(check-workflows): mock action-artifacts capability probe endpoints

### DIFF
--- a/tests/workflows/archive-artifacts.spec.ts
+++ b/tests/workflows/archive-artifacts.spec.ts
@@ -133,6 +133,27 @@ beforeEach(async () => {
                             body: [],
                         },
                     },
+                    // action-artifacts@4.3.0+ probes these endpoints before each upload to detect
+                    // presigned/multipart upload capability. Reply 404 = capability unavailable,
+                    // which makes the action fall back to the basic upload path.
+                    presignUpload: {
+                        path: "/presign-upload/{name}/{file}",
+                        method: "get",
+                        parameters: {
+                            query: [],
+                            path: ["name", "file"],
+                            body: [],
+                        },
+                    },
+                    presignUploadPart: {
+                        path: "/presign-upload-part/{name}/{file}",
+                        method: "get",
+                        parameters: {
+                            query: ["partNumber", "uploadId"],
+                            path: ["name", "file"],
+                            body: [],
+                        },
+                    },
                 },
             },
         },
@@ -173,6 +194,8 @@ function commonMockApi(...extraMocks: any[]) {
         mockapi.mock.artifacts.root.uploadKindLogs().reply({ status: 200, data: {}, repeat: 10 }),
         mockapi.mock.artifacts.root.uploadMergedReport().reply({ status: 200, data: {}, repeat: 10 }),
         mockapi.mock.artifacts.root.uploadLogsArchive().reply({ status: 200, data: {}, repeat: 10 }),
+        mockapi.mock.artifacts.root.presignUpload().reply({ status: 404, data: {}, repeat: 10 }),
+        mockapi.mock.artifacts.root.presignUploadPart().reply({ status: 404, data: {}, repeat: 10 }),
         ...extraMocks,
     ];
 }


### PR DESCRIPTION
## Context

action-artifacts@4.3.0 added a capability probe that fires a GET to \`/presign-upload/capability-probe/probe.bin\` and \`/presign-upload-part/capability-probe/probe.bin\` before every upload, to detect presigned/multipart upload support. These endpoints are not yet deployed (pending PTFE-3137 and PTFE-3219).

When \`v4\` was pointed at 4.3.0, the \`check-workflows\` CI broke with \`ERR_NOCK_NO_MATCH\` because nock had no interceptor for the probe requests. The tag was rolled back as a temporary fix.

## Changes

Add \`presignUpload\` and \`presignUploadPart\` endpoints to the \`Mockapi\` definition in \`archive-artifacts.spec.ts\`, and mock them with 404 in \`commonMockApi()\`. A 404 response makes the action fall back to the standard upload path, keeping existing tests valid.

## How to validate

Once PTFE-3137 and PTFE-3219 are merged and \`action-artifacts\` is re-released with the probe:

1. Bump the \`v4\` tag to the new release
2. Re-run the CI on this PR — it should pass (the probe returns 404 in tests, action falls back to basic upload)