### PR TITLE
Make parse-deps tests tolerant of playground images in deps.yaml

### DIFF
--- a/tests/workflows/parse-deps.spec.ts
+++ b/tests/workflows/parse-deps.spec.ts
@@ -19,22 +19,27 @@ describe('parseDeps', () => {
 
         expect(components.length).toBeGreaterThan(0);
 
-        // Every component should be a scality repo (but not scality/zenko)
         for (const c of components) {
-            expect(c.repo).toMatch(/^scality\//);
-            expect(c.repo).not.toBe('scality/zenko');
             expect(c.ref).toBeTruthy();
             expect(c.image).toBeTruthy();
+
+            if (c.repo === '') {
+                expect(c.image).toContain('playground');
+                continue;
+            }
+
+            expect(c.repo).toMatch(/^scality\//);
+            expect(c.repo).not.toBe('scality/zenko');
         }
     });
 
     it('includes known components', () => {
-        const { components } = parseDeps(depsFile, 'scality/zenko');
+        const testDeps = yamlToJson(path.join(__dirname, 'fixtures/test-deps.yaml'));
+        const { components } = parseDeps(testDeps, 'scality/zenko');
         const repos = components.map((c: { repo: string }) => c.repo);
 
         expect(repos).toContain('scality/sorbet');
         expect(repos).toContain('scality/backbeat');
-        expect(repos).toContain('scality/cloudserver');
     });
 
     it('filters out self-repo', () => {
@@ -89,13 +94,18 @@ describe('parseDeps', () => {
         expect(playground.image).toBe('scality/playground/my-sandbox');
     });
 
-    it('is non-empty and contains known short names', () => {
+    it('returns a non-empty repo list for the live deps.yaml', () => {
         const { repos } = parseDeps(depsFile, 'scality/zenko');
 
         expect(repos.length).toBeGreaterThan(0);
+    });
+
+    it('contains known short names', () => {
+        const testDeps = yamlToJson(path.join(__dirname, 'fixtures/test-deps.yaml'));
+        const { repos } = parseDeps(testDeps, 'scality/zenko');
+
         expect(repos).toContain('sorbet');
         expect(repos).toContain('backbeat');
-        expect(repos).toContain('cloudserver');
     });
 
     describe('repos array', () => {


### PR DESCRIPTION
## What

Make the `parseDeps` unit tests tolerant of playground images in `solution/deps.yaml`. No production code changes — only `tests/workflows/parse-deps.spec.ts`.

- `extracts scality components from deps.yaml`: still reads the live `solution/deps.yaml`, but now skips playground (empty-repo) components after asserting they are playground images; the `^scality/` invariant is enforced only on the rest.
- `includes known components` / `contains known short names`: the hard-coded `backbeat`/`cloudserver`/`sorbet` assertions move off the live `deps.yaml` onto the existing `fixtures/test-deps.yaml` (sorbet + backbeat). Against the live file we keep only robust invariants (non-empty list).

## Why

`parse-deps.js` intentionally supports playground images: an image like `ghcr.io/scality/playground/<user>/<component>` resolves to an empty `repo` so the action does not try to create a GitHub deployment or scope a token to a non-existent repo (there is a dedicated, passing fixture test for this).

But three tests asserted, against the *live* `solution/deps.yaml`, that every component is a `scality/*` repo and that `backbeat`/`cloudserver` are always present. The moment a component is pointed at a playground build, those assertions break and `check-workflows` turns red — with a misleading message ("extracts scality components" failing on a regex says nothing about a playground image being the cause). The playground special-case and these live-file assertions were introduced in the same change but never reconciled.

This decouples the two concerns: keep generic, robust invariants on the live file, and verify the concrete parsing behaviour against a controlled fixture.

## Failure this addresses

check-workflows failure on a branch that bumped backbeat/cloudserver to playground builds:
https://github.com/scality/Zenko/actions/runs/28172803930/job/83664423304

There, `parseDeps` correctly returned an empty repo for the two playground components, dropping `backbeat`/`cloudserver` from the results and failing the three name/`^scality/` assertions.

## Notes

`fixtures/test-deps.yaml` is shared with the act-js integration specs (`create-component-deployments`, `cleanup-workflow`), which expect exactly sorbet + backbeat deployments — this PR only reads it, so those tests are unaffected.

Issue: ZENKO-5305
