### PR TITLE
Cap ctst-end2end-sharded test step at 190 min

### DIFF
--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -597,6 +597,7 @@ jobs:
         working-directory: ./.github/scripts/end2end
       - name: Run CTST end to end tests
         run: bash .github/scripts/end2end/run-e2e-ctst.sh "@PreMerge and not @PRA"
+        timeout-minutes: 190
       - name: Debug wait
         uses: ./.github/actions/debug-wait
         timeout-minutes: 60


### PR DESCRIPTION
## What

Add `timeout-minutes: 190` to the `Run CTST end to end tests` step of the `ctst-end2end-sharded` job in `.github/workflows/end2end.yaml`. One-line change.

## Why

The job has no job-level timeout and the test step has no per-step timeout, so it inherits GitHub's 360-min (6 h) default. When the CTST suite hangs, the only thing that stops it is **job-level cancellation** at 6 h — which grants the `if: always()` `Archive and publish artifacts` step only a ~5-minute grace window before the runner is SIGTERM'd, so the archive uploads partial logs or nothing. A **per-step** `timeout-minutes` fails only that step; the job is not cancelled and continues to the archive step, which runs with full remaining budget.

## Why 190

This step is a **hard backstop**. The graceful stop is now done in-process by an 180-min cucumber-level time budget (**ZENKO-5309**), which lets cucumber finish and write its reports before this timeout would hard-kill it. So the ordering is: 180 min (graceful) < 190 min (hard backstop) < the old 360-min job cap.

190 still sits well above the observed max duration of passing runs — over the last ~400 runs, the passing step ran 61–155 min (p50 91, p95 129, max 155) — so it won't kill legitimately-slow passing runs.

Scope: `ctst-end2end-sharded` only — the other e2e jobs finish in 20–53 min and aren't prone to the multi-hour hang.

Issue: ZENKO-5306
