### PR TITLE
Lower fluentbit tail Refresh_Interval to capture short-lived pod logs

### DIFF
--- a/.github/scripts/end2end/configs/fluentbit.yaml
+++ b/.github/scripts/end2end/configs/fluentbit.yaml
@@ -13,6 +13,7 @@ data:
         Tag          <basename>
         Tag_Regex    /var/log/containers/(?<basename>[^/]+)$
         Path         /var/log/containers/*.log
+        Refresh_Interval 1
         DB           /var/lib/fluent-bit/flb_kube.db
         Mem_Buf_Limit 16MB
         Skip_Long_Lines On


### PR DESCRIPTION
## What

Add `Refresh_Interval 1` to the fluentbit `tail` `[INPUT]` in `.github/scripts/end2end/configs/fluentbit.yaml`. One-line change.

## Why

CI runs a fluentbit DaemonSet specifically to capture container logs to a persistent volume **before pod deletion** (it's why fluentbit logs survive when `kind export logs` doesn't). But the `tail` input uses the default `Refresh_Interval` of **60 s** to discover new log files. Short-lived Kubernetes Job pods — notably `ops-count-items` (`s3utils countItems.js`, ~30 s) — can be created and deleted between two discovery scans, so fluentbit never tails them and their logs are **never captured**.

This blocked a real investigation: in a hung `ctst-end2end-sharded` run only 4 `ops-count-items` pod logs were captured (the early/longer-lived ones) and none of the failed ones — exactly the pods needed for root cause. Archive-time collection can't recover logs that were never tailed.

Scanning every 1 s reliably picks up short-lived Job pods, with negligible overhead on the kind cluster.

Issue: ZENKO-5307
