### PR TITLE
Stop CTST gracefully at a cucumber-level time budget

### DIFF
--- a/tests/functional/ctst/common/hooks.ts
+++ b/tests/functional/ctst/common/hooks.ts
@@ -53,6 +53,19 @@ AfterAll(async function () {
     await stopDLQConsumer();
 });
 
+// Fail any scenario that starts past the global time budget, so the run stops
+// (and writes its reports) before the step timeout hard-kills it.
+const ctstMaxRuntimeMs = 180 * 60 * 1000;
+const ctstStartMs = Date.now();
+Before((scenario: ITestCaseHookParameter) => {
+    if (Date.now() > ctstStartMs + ctstMaxRuntimeMs) {
+        throw new Error(
+            `CTST global time budget (${ctstMaxRuntimeMs / 60000} min) exceeded; failing scenario `
+            + `"${scenario.pickle.name}" (started too late to run within the budget)`,
+        );
+    }
+});
+
 Before(async function (this: Zenko, scenario: ITestCaseHookParameter) {
     this.resetSaved();
     Identity.resetIdentity();


### PR DESCRIPTION
## What

Add an in-process **time budget** so CTST stops gracefully before the GitHub step timeout would hard-kill it. Touches only `tests/functional/ctst/common/hooks.ts` and `.github/scripts/end2end/run-e2e-ctst.sh`.

## Why

The only stop for a hung `ctst-end2end-sharded` run is the step `timeout-minutes`, which **hard-kills** the process. cucumber-js v13 installs no signal handler and has no whole-run timeout, so on a kill it never reaches `testRunFinished` — `report.xml` is written empty (`Error parsing report.xml: no element found`), teardown is skipped, and the archive step has nothing to publish.

## How

- `run-e2e-ctst.sh` exports `CTST_DEADLINE_EPOCH_MS` (default 180 min, via `CTST_MAX_RUNTIME_MIN`) and a marker path, and clears any stale marker.
- An early `Before` hook (registered before the expensive `@Quotas`/count-items hooks) skips any scenario that starts past the deadline — returning `'skipped'` short-circuits the remaining hooks/steps — and drops the marker file.
- cucumber then finishes normally: it writes `report.xml`/`report.html`/`report.ndjson` and runs teardown. The runner script exits 1 if the marker is present, so a timed-out run is still red while keeping a clean report.

When `CTST_DEADLINE_EPOCH_MS` is unset (local runs), the hook is a no-op.

## Relationship to ZENKO-5306

Companion to the step-level timeout. ZENKO-5306 lowers the step `timeout-minutes` to 190 as a hard backstop: 180 min (graceful, this PR) < 190 min (hard backstop) < the old 360-min job cap.

`tsc --build`, `eslint`, and `bash -n` pass.

Issue: ZENKO-5309
