### PR TITLE
Set default memory resources for the ZooKeeper quorum

### DIFF
--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -131,7 +131,7 @@ zenko-operator:
   sourceRegistry: ghcr.io/scality
   dashboard: zenko-operator/zenko-operator-dashboards
   image: zenko-operator
-  tag: v1.8.13
+  tag: v1.8.14
   envsubst: ZENKO_OPERATOR_TAG
 zookeeper:
   sourceRegistry: ghcr.io/adobe/zookeeper-operator

--- a/solution/zenkoversion.yaml
+++ b/solution/zenkoversion.yaml
@@ -138,6 +138,9 @@ spec:
         limitCPU: 3
       cruiseControl:
         limitMemory: 3Gi
+    zookeeperResources:
+      requestMemory: 1Gi
+      limitMemory: 1Gi
   featureFlags:
     lifecycleOptimization: true
     manageKafkaTopics: true


### PR DESCRIPTION
**What does this PR do, and why do we need it?**

Bumps zenko-operator to v1.8.14 and sets `defaults.zookeeperResources` in `solution/zenkoversion.yaml`, alongside the existing `defaults.kafkaResources`. Without it the quorum pods run BestEffort and the zookeeper image sizes its JVM heap as a percentage of the host memory instead of the container limit (RD-1962 finding, confirmed fleet-wide on ~240 sosreports).

**Which issue does this PR fix?**

Fixes ZENKO-5316.

**Special notes for your reviewers**:

zenko-operator v1.8.14 (scality/zenko-operator#624) is what applies the field to the ZookeeperCluster; the bump commit lands before the field is set. Sizing rationale and fleet data: see the review thread.

Issue: ZENKO-5316