### PR TITLE
Adapt release workflow test mocks to action-gh-release v3.0.2

### DIFF
--- a/tests/workflows/release.spec.ts
+++ b/tests/workflows/release.spec.ts
@@ -247,9 +247,11 @@ test.each([
                 .listReleases({ owner: 'scality', repo: 'Zenko' } as any)
                 // First call from release notes generation, to get the previous release
                 .reply({ status: 200, data: [{ tag_name: '2.3.6', id: 122 }] })
-                // Second call from release notes generation, to get the previous release
-                .reply({ status: 200, data: [{ tag_name: '2.3.6', id: 122 }] })
-                // Third call made by action-gh-release@v3's canonicalizeCreatedRelease
+                // Next three calls from action-gh-release@v3's findTagFromReleases, which lists
+                // releases after getReleaseByTag returns 404 (retrying maxRetries=3 times);
+                // none may contain the target tag, or v3 updates instead of creating.
+                .reply({ status: 200, data: [{ tag_name: '2.3.6', id: 122 }], repeat: 3 })
+                // Last call made by action-gh-release@v3's canonicalizeCreatedRelease
                 // (recentReleasesByTag scans allReleases to reconcile duplicate drafts).
                 .reply({
                     status: 200, data: [{ tag_name: '2.3.6', id: 122 }, {


### PR DESCRIPTION
**What does this PR do, and why do we need it?**

The `check-workflows` job fails on every PR based on development/2.14+ since 2026-07-13: `softprops/action-gh-release` v3.0.2 (picked up automatically via the floating `@v3` tag in `release.yaml`) changed its GitHub API call sequence. Its `findTagFromReleases` now falls back to listing releases when `getReleaseByTag` returns 404 — GitHub does not expose draft releases through get-by-tag — and retries the listing up to 3 times. These extra `listReleases` calls eventually consumed the sequenced mock reply containing the draft release (intended for the post-creation `canonicalizeCreatedRelease` scan), so the action believed a release already existed and issued a `PATCH /releases/123` with `draft: true` that no mock matches. The unmatched request hangs until undici's headers timeout, and the 5 "Promote artifacts" tests in `release.spec.ts` each died on the 120s jest timeout.

This PR replaces the sequenced `listReleases` replies with a single repeated draft-free reply, making the mocks independent of how many listing calls the action makes. The action then creates the release as before and discovers the created draft through the second `getReleaseByTag` reply alone (`pickCanonicalRelease` falls back to it when listings contain no match), before publishing it via the existing `updateRelease` mock.

**Which issue does this PR fix?**

Fixes ZENKO-5317.

**Special notes for your reviewers**:

- The exact call sequence was confirmed with a `DEBUG=nock*` trace: the release-notes step makes one `listReleases` call (the old mock comments claiming two were inaccurate), and the action's fallback makes three.

Issue: ZENKO-5317