### PR TITLE
Bump backbeat to 9.5.0-preview.8 and sorbet to v1.2.7

### DIFF
--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -6,7 +6,7 @@ backbeat:
   dashboard: backbeat/backbeat-dashboards
   image: backbeat
   policy: backbeat/backbeat-policies
-  tag: 9.5.0-preview.7
+  tag: 9.5.0-preview.8
   envsubst: BACKBEAT_TAG
 busybox:
   image: busybox
@@ -113,7 +113,7 @@ sorbet:
   policy: sorbet/sorbet-policies
   dashboard: sorbet/sorbet-dashboards
   image: sorbet
-  tag: v1.2.6
+  tag: v1.2.7
   envsubst: SORBET_TAG
 stern: # tail any pod logs with pattern matchin
   tag: 1.33.0


### PR DESCRIPTION
Picks up the three upstream fixes from the CTST flakiness investigation, all released:

**backbeat 9.5.0-preview.8**
- BB-825: the queue populator could deadlock on rebalance, freezing the whole oplog pipeline (replication entries, bucket notifications) for ~5 minutes and leaving a disconnected pod behind until the liveness probe restarted it. This was the mechanism behind the two Replication CTST scenarios (49 of 257 end2end runs red over two months) and the Bucket notifications filter scenario (7 runs).
- BB-826: a replication status message produced while the status processor group had no member (e.g. during a rolling update) was skipped forever, leaving the object PENDING past any test timeout — the unrecoverable variant of the Replication flake.

**sorbet v1.2.7**
- SOR-289: generated archiveVersion values could exceed the JS float64-safe range, so cold GC/restore targeted a wrong version — dead-lettered DMF requests and leaked volume objects behind the DMF scenarios (Deletion of an archived/restored object, Overwriting of a cold object; ~40 of 257 runs). Also carries the other merged sorbet 1.2 work (otel tracing, stream fixes).

Together with cli-testing v1.3.1 (already merged), this addresses the root causes of ~91 of the 104 top-scenario CTST failures observed over the past two months.

Issue: ZENKO-5335