### PR TITLE
Pre-pull solution images on the kind nodes before deploying Zenko

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -38,6 +38,10 @@ for i in $(seq 0 $array_length); do
         # We don't want to run `run-e2e-test.sh` because it is used for linting here, user will run it manually if needed after deployment
         [[ "$run_command" == *"run-e2e-test.sh"* ]] && exit 0
         [[ "$run_command" == *"deploy-metadata.sh"* && "${ENABLE_RING_TESTS}" == "false" ]] && exit 0
+        # Pre-pulling the solution images guards the deploy timeout on CI
+        # runners, which always start with an empty image cache: locally the
+        # kubelet pulls what is missing, as before
+        [[ "$run_command" == *"prepull-images"* || "$run_command" == *"PREPULL_"* ]] && exit 0
 
         # Inject env 'generated' from previous steps
         source "$GITHUB_ENV"

--- a/.github/actions/deploy/action.yaml
+++ b/.github/actions/deploy/action.yaml
@@ -28,6 +28,18 @@ runs:
       shell: bash
       run: bash create-pull-image-secret.sh
       working-directory: ./.github/scripts/end2end
+    - name: Start solution image pre-pull
+      shell: bash
+      run: |
+        log=/tmp/prepull-images.log
+        marker=/tmp/prepull-images.done
+        {
+            echo "PREPULL_LOG=${log}"
+            echo "PREPULL_MARKER=${marker}"
+        } >> "$GITHUB_ENV"
+        PREPULL_MARKER=${marker} nohup bash prepull-images.sh > "${log}" 2>&1 &
+        echo "pre-pull running in the background (pid $!)"
+      working-directory: ./.github/scripts/end2end
     - name: Cache Helm repositories and charts
       uses: actions/cache@v5
       with:
@@ -56,6 +68,15 @@ runs:
       run: ./.github/scripts/end2end/deploy-zkop.sh
       env:
         OPERATOR_IMAGE_TAG: ${{ inputs.zkop_tag }}
+    - name: Wait for solution image pre-pull
+      shell: bash
+      run: |
+        for _ in $(seq 1 60); do
+            [ -f "${PREPULL_MARKER}" ] && break
+            sleep 5
+        done
+        [ -f "${PREPULL_MARKER}" ] || echo "::warning::pre-pull still running, deploying anyway"
+        cat "${PREPULL_LOG}" || true
     - name: Deploy Zenko Instance
       shell: bash
       run: bash deploy-zenko.sh end2end default

--- a/.github/scripts/end2end/prepull-images.sh
+++ b/.github/scripts/end2end/prepull-images.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# Warm the containerd cache of the kind worker nodes with the solution
+# images, so that the operator's rollout of the Zenko CR never waits on
+# a cold image pull: a single pull landing in the middle of the rollout
+# is enough to exceed the deploy timeout.
+#
+# Best effort by design: every failure is ignored, the kubelet then
+# pulls the image itself as it did before.
+
+set -u
+
+DOCKER_CONFIG_FILE="${HOME}/.docker/config.json"
+CLUSTER_NAME=${CLUSTER_NAME:-kind}
+PREPULL_MARKER=${PREPULL_MARKER:-/tmp/prepull-images.done}
+
+rm -f "${PREPULL_MARKER}"
+# the waiter must never be left hanging, whatever happens below
+trap 'touch "${PREPULL_MARKER}"' EXIT
+
+get_images() {
+    yq eval 'to_entries | .[] | select(.value.image != null) |
+        ((.value.sourceRegistry // "docker.io") + "/" + .value.image + ":" + (.value.tag // "latest"))' \
+        "$(git rev-parse --show-toplevel)/solution/deps.yaml" | sort -u
+}
+
+get_nodes() {
+    local nodes
+    nodes=$(kind get nodes --name "${CLUSTER_NAME}" 2>/dev/null)
+    # pods land on the workers; on a single node cluster, that node runs
+    # everything
+    if echo "${nodes}" | grep -qv control-plane; then
+        echo "${nodes}" | grep -v control-plane
+    else
+        echo "${nodes}"
+    fi
+}
+
+pull_one() {
+    local node=$1 image=$2
+    local auth=()
+
+    # containerd does not read the kubelet credentials, pass them along
+    # for the registries that need them
+    case "${image}" in
+        ghcr.io/*) [ -n "${GHCR_AUTH:-}" ] && auth=(--auth "${GHCR_AUTH}") ;;
+    esac
+
+    if docker exec "${node}" crictl pull "${auth[@]}" "${image}" >/dev/null 2>&1; then
+        echo "pulled  ${image} on ${node}"
+    else
+        echo "skipped ${image} on ${node} (pull failed, kubelet will retry)"
+    fi
+}
+export -f pull_one
+
+if [ -r "${DOCKER_CONFIG_FILE}" ]; then
+    GHCR_AUTH=$(jq -r '.auths["ghcr.io"].auth // empty' "${DOCKER_CONFIG_FILE}" 2>/dev/null)
+    export GHCR_AUTH
+fi
+
+images=$(get_images)
+nodes=$(get_nodes)
+
+if [ -z "${images}" ] || [ -z "${nodes}" ]; then
+    echo "nothing to pre-pull (images: $(echo "${images}" | grep -c . ), nodes: $(echo "${nodes}" | grep -c . ))"
+    exit 0
+fi
+
+echo "pre-pulling $(echo "${images}" | wc -l) images on $(echo "${nodes}" | wc -l) node(s)"
+start=${SECONDS}
+
+for node in ${nodes}; do
+    for image in ${images}; do
+        printf '%s %s\n' "${node}" "${image}"
+    done
+done | xargs -P 6 -L1 bash -c 'pull_one "$1" "$2"' _
+
+echo "pre-pull done in $((SECONDS - start))s"


### PR DESCRIPTION
### The problem

`Deploy Zenko Instance` waits for the Zenko CR to become ready with a ~610s budget. A **green** run already spends **596.6s** of it, so the step has about 2% headroom — and anything that perturbs the rollout fails the deploy.

Two facts make that perturbation routine rather than rare: every CI runner starts with an empty image cache, and each kind node keeps its own containerd store, so an image already pulled by one node is still cold on the others. The operator rolls components out strictly sequentially, so a single cold pull anywhere in that chain adds its full duration to the critical path.

That is exactly what happened in [run 30639790976 attempt 1](https://github.com/scality/Zenko/actions/runs/30639790976): three of four e2e jobs failed with `timed out waiting for the condition on zenkos/end2end` while the clusters were **healthy** — every pod Running, no restarts, no image-pull errors. The kube dump shows the lifecycle populator was scheduled onto the one node that had never pulled a backbeat image and paid a 38.9s pull of a 454MB image; the deploy then missed its budget by seconds. Nothing was wrong with the product.

### The fix

Warm the worker nodes' image caches before the CR is applied:

- `prepull-images.sh` enumerates the images from `solution/deps.yaml` with `yq` (the same idiom `install-kind-dependencies.sh` already uses) and fans `crictl pull` out over the worker nodes.
- It authenticates with the ghcr credentials from the docker config the kind nodes already mount — containerd does not read the kubelet's credentials, and the scality images are private, so this is required rather than optional.
- It runs in the background from the deploy action, right after the cluster is up, so it overlaps the ~6 minutes of helm installs that precede the CR; a wait step then gates the CR apply on it.
- Everything is best effort: pull failures are logged and ignored (the kubelet pulls as it does today), and the waiter gives up after 5 minutes rather than ever blocking the job.

This benefits every e2e job that uses the deploy action. The devcontainer, which replays these same steps via `.devcontainer/setup.sh`, skips both of them: a local cluster keeps its images between runs, so the kubelet pulling what is missing is the better trade there.

### Verification

Verified end to end on a real CI run of an identical `ctst-end2end-sharded` job ([run 30660465010](https://github.com/scality/Zenko/actions/runs/30660465010), from a WIP branch carrying this change):

- `pre-pulling 21 images on 2 node(s)` — the images are enumerated from `deps.yaml` and pre-pulled onto the workers only, the control-plane being left out as intended
- 42 pull lines for 21 images across 2 workers, **none skipped** — every pull succeeded, private ghcr images included, so the credentials taken from the docker config do work against the registry
- `pre-pull done in 96s`, roughly 5 minutes before the deploy needed the images: the work is entirely hidden inside the helm-install window, the wait step did not block and printed no warning
- `Deploy Zenko` took 16.7 min against 19.7 min on the reference run

Local testing against the CI node image (`kindest/node:v1.33.4`) with real containerd covered the rest: `crictl --auth` takes the base64 credential the docker config holds, a deliberately bogus image is logged as `skipped`, exits 0 and still releases the waiter, and without credentials the private pull fails — confirming the auth path is load-bearing rather than decorative.

### Not addressed here

The dominant cost is structural: the operator reconciles sequentially — the 14 backbeat deployments are created one at a time at a ~12s cadence (~170s) despite being independent — and readiness-probe cadence adds further fixed waits. Parallelising that would roughly halve the deploy and belongs in a zenko-operator ticket. Raising the deploy timeout is also deliberately left out, to first measure what pre-pulling recovers.

Issue: ZENKO-5336

