### PR TITLE
Fix the Days=0 expiration flake by publishing backlog metrics every 5s in CI

### DIFF
--- a/.github/scripts/end2end/configs/zenko.yaml
+++ b/.github/scripts/end2end/configs/zenko.yaml
@@ -25,6 +25,7 @@ spec:
       logLevel: debug
   backbeat:
     triggerExpirationsOneDayEarlierForTesting: ${EXPIRE_ONE_DAY_EARLIER}
+    backlogMetricsIntervalSeconds: 5
     lifecycleConductor:
       cronRule: "${BACKBEAT_LCC_CRON_RULE}"
     lifecycleBucketProcessor:

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -6,7 +6,7 @@ backbeat:
   dashboard: backbeat/backbeat-dashboards
   image: backbeat
   policy: backbeat/backbeat-policies
-  tag: 9.5.0-preview.8
+  tag: 9.5.0-preview.9
   envsubst: BACKBEAT_TAG
 busybox:
   image: busybox

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -131,7 +131,7 @@ zenko-operator:
   sourceRegistry: ghcr.io/scality
   dashboard: zenko-operator/zenko-operator-dashboards
   image: zenko-operator
-  tag: v1.8.14
+  tag: v1.8.15
   envsubst: ZENKO_OPERATOR_TAG
 zookeeper:
   sourceRegistry: ghcr.io/adobe/zookeeper-operator


### PR DESCRIPTION
The lifecycle conductor will not start a batch until its three backlog checks all report zero lag, and it can only see consumer progress through offsets published to ZooKeeper. The operator hardcoded that publication interval at 60s and `KafkaBacklogMetrics` discards nodes older than twice it, so on a completely idle cluster the conductor stays blind to "caught up" for 60-120s per batch:

```
20:59:55.170  starting new lifecycle batch
20:59:56.442  finished pushing lifecycle batch      <- 1.3s of actual work
21:00:00.086  skipping lifecycle batch due to previous operation still in progress
   ...                                                (~23 consecutive 5s ticks)
21:01:55.03   next batch starts                      <- ~115s of waiting
```

`Days=0 expiration` on a versioned bucket needs three sequential batches, so it paid that three times over: **319.6s end to end for about 4s of real work**, and it was the suite's top flake at 7/30.

## Change

Set `spec.backbeat.backlogMetricsIntervalSeconds: 5` in the CI CR, using the field added by ZKOP-569. The two bumps ahead of it are what make that possible:

- **zenko-operator v1.8.15** carries the CR field itself.
- **backbeat 9.5.0-preview.9** carries BB-831's fix, which is a prerequisite rather than housekeeping. Firing batches sooner moves the cold-status produce from a median of 99.5s after the workflow step to 24s, which lands it inside the window a rolling update leaves with no consumer-group member. Consumers that do not pin `fromOffset` discard anything produced in that window, so without the fix this change would archive objects to the cold backend with no metadata recording them — measured at 15.3% -> 33.8% of cold-status batches produced but never consumed (p = 7.9e-06), purely from the timing shift.

  The merged fix pins `earliest` on the transition-tasks, per-location cold-status and gc topics. Cold status is the one this PR depends on. The data-mover and notification topics deliberately stay on the default, since their group ids are per-instance and pinning them would make every new site or destination replay its topic.

Measured across a 30-run census:

| example | before | after |
|---|---|---|
| Non versioned | 96.9s | 27.3s |
| Suspended | 177.4s | 36.8s |
| Versioned | 319.6s | 38.9s |

The scenario went from **7/30 to 0/30**.

**The 180s budget is deliberately unchanged.** It still fails if the interval ever stops applying, since that path takes ~320s, so it keeps its regression-catching value. Earlier revisions proposed 420s and then 120s; both were wrong — the first hides regressions, the second sits barely above the observed tail for no benefit.

Issue: ZENKO-5337