### PR TITLE
Resynchronise count-items in the Quotas restore scenarios

### DIFF
--- a/.github/scripts/end2end/configs/zenko.yaml
+++ b/.github/scripts/end2end/configs/zenko.yaml
@@ -86,6 +86,9 @@ spec:
       replicas: 1
       ingress:
         hostname: ${ZENKO_SUR_INGRESS}
+  s3utils:
+    metrics:
+      scrapeInterval: "5s"
   management:
     provider: InCluster
     oidc:

--- a/tests/functional/ctst/features/quotas/Quotas.feature
+++ b/tests/functional/ctst/features/quotas/Quotas.feature
@@ -184,6 +184,7 @@ Feature: Quota Management for APIs
         And a transition workflow to "e2e-cold" location
         And an upload size of <uploadSize> B for the object ""
         Then object "" should be "transitioned" and have the storage class "e2e-cold"
+        When the "count-items" cronjobs completes without error
         Given a bucket quota set to <bucketQuota> B
         And an account quota set to <accountQuota> B
         And a <userType> type
@@ -218,6 +219,7 @@ Feature: Quota Management for APIs
         And a transition workflow to "e2e-cold" location
         And an upload size of <uploadSize> B for the object "obj-1"
         Then object "obj-1" should be "transitioned" and have the storage class "e2e-cold"
+        When the "count-items" cronjobs completes without error
         Given a bucket quota set to <bucketQuota> B
         And an account quota set to <accountQuota> B
         And a <userType> type


### PR DESCRIPTION
Two quota restore scenarios fail when the hourly `count-items` cron snapshots at the wrong moment — 2 of 30 runs in the July census, surfacing as a 429 where the scenario expects success.

**Why.** Both scenarios upload the object and transition it to `e2e-cold` *before* setting any quota, and cloudserver skips utilization accounting entirely while no quota exists. A cron snapshot taken in that window therefore records the object as still hot; nothing corrects it, and the later restore reserves another 100 B on top — 200 > 101, rejected. Of 10 census reports analysed, the 2 whose window crossed the top of the hour failed and the other 8 passed.

**First commit** adds the resync step this file already uses twice (`:122`, `:158`) after the transition, so the accounting describes a cold object before any quota goes in. No new step definition.

**Second commit** makes that cheap. `count-items` only exits once Prometheus has scraped its final metrics, and the operator gives its ServiceMonitor a 60 s interval, so every invocation idled for up to a minute. Scraping that one target every 5 s removes the wait; `spec.s3utils.metrics` has a single consumer in the operator, so nothing else changes cadence and production keeps its 60 s.

**Measured in a later 30-run census**: 10.7 s per invocation, so the 12 added invocations cost **~2.1 min** — 2.6 % of the suite. At the old 60 s interval they would have cost ~12.6 min. Quota failures went from 5 in the July census to **0 in 30 runs** (that run also carried the SCUBA-339/340/341 fixes, so the credit is shared).

Issue: ZENKO-5338