### PR TITLE
Poll until the cascade settles, then assert it stays settled

### DIFF
--- a/tests/functional/ctst/features/replication/crrCascade.feature
+++ b/tests/functional/ctst/features/replication/crrCascade.feature
@@ -18,8 +18,8 @@ Feature: CRR Cascade Replication
         When an object "cascade-obj" of 0 bytes is put in location "crr-location-a"
         Then the object should replicate to location "crr-location-b" within 280 seconds
         And the object should replicate to location "crr-location-c" within 280 seconds
-        When I wait 15 seconds
-        Then the cascade replication states should be settled
+        Then the cascade replication states should settle within 120 seconds
+        And the cascade replication states should stay settled for 15 seconds
 
     @2.16.0
     @PreMerge
@@ -37,8 +37,8 @@ Feature: CRR Cascade Replication
         Then the object should replicate to location "crr-location-b" within 280 seconds
         And the object should replicate to location "crr-location-c" within 280 seconds
         And the object at location "crr-location-a" should never have replication status PENDING within 30 seconds
-        When I wait 15 seconds
-        Then the cascade replication states should be settled
+        Then the cascade replication states should settle within 120 seconds
+        And the cascade replication states should stay settled for 15 seconds
 
         Examples:
             | description      | objectName                | bodySize |
@@ -63,8 +63,8 @@ Feature: CRR Cascade Replication
         When tags are put on the object "cascade-tag-loop-obj" in location "crr-location-a"
         Then the object at location "crr-location-c" should have the expected tags within 280 seconds
         And the object at location "crr-location-a" should never have replication status PENDING within 30 seconds
-        When I wait 15 seconds
-        Then the cascade replication states should be settled
+        Then the cascade replication states should settle within 120 seconds
+        And the cascade replication states should stay settled for 15 seconds
 
     @2.16.0
     @PreMerge
@@ -93,5 +93,5 @@ Feature: CRR Cascade Replication
         And replication is configured from location "crr-location-b" to "crr-location-a"
         When an object "bidirectional-obj" of 42 bytes is put in location "crr-location-a"
         Then the object should replicate to location "crr-location-b" within 280 seconds
-        When I wait 15 seconds
-        Then the cascade replication states should be settled
+        Then the cascade replication states should settle within 120 seconds
+        And the cascade replication states should stay settled for 15 seconds

--- a/tests/functional/ctst/steps/crrCascade.ts
+++ b/tests/functional/ctst/steps/crrCascade.ts
@@ -214,34 +214,63 @@ Then(
     },
 );
 
+// undefined when every location is in its expected state
+async function cascadeUnsettledReason(world: Zenko): Promise<string | undefined> {
+    const cascadeBuckets = world.getSaved<Record<string, string>>('cascadeBuckets');
+    const objectName = world.getSaved<string>('cascadeObjectName');
+    const sourceLocation = world.getSaved<string>('cascadeSourceLocation');
+
+    for (const [location, bucket] of Object.entries(cascadeBuckets)) {
+        Identity.useIdentity(IdentityEnum.ACCOUNT, location);
+        const res = await world.createS3Client().send(
+            new HeadObjectCommand({ Bucket: bucket, Key: objectName }),
+        );
+
+        const expectedStatus = location === sourceLocation ? 'COMPLETED' : 'REPLICA';
+        if (res.ReplicationStatus !== expectedStatus) {
+            return `Expected ReplicationStatus '${expectedStatus}' at '${location}', `
+                + `got '${res.ReplicationStatus}'`;
+        }
+
+        const pendingBackends = Object.entries(res.Metadata ?? {})
+            .filter(([key, value]) => key.endsWith('-replication-status') && value === 'PENDING');
+        if (pendingBackends.length > 0) {
+            return `Location '${location}' still has PENDING backends: ${
+                pendingBackends.map(([k, v]) => `${k}=${v}`).join(', ')
+            }`;
+        }
+    }
+    return undefined;
+}
+
 Then(
-    'the cascade replication states should be settled',
-    { timeout: 30_000 },
-    async function (this: Zenko) {
-        const cascadeBuckets = this.getSaved<Record<string, string>>('cascadeBuckets');
-        const objectName = this.getSaved<string>('cascadeObjectName');
-        const sourceLocation = this.getSaved<string>('cascadeSourceLocation');
+    'the cascade replication states should settle within {int} seconds',
+    { timeout: 180_000 },
+    async function (this: Zenko, settleSeconds: number) {
+        const deadline = Date.now() + settleSeconds * 1000;
+        let unsettled: string | undefined;
+        while (Date.now() < deadline) {
+            unsettled = await cascadeUnsettledReason(this);
+            if (unsettled === undefined) {
+                return;
+            }
+            await new Promise(resolve => setTimeout(resolve, 3000));
+        }
+        assert.fail(`cascade states did not settle within ${settleSeconds}s. ${unsettled}`);
+    },
+);
 
-        for (const [location, bucket] of Object.entries(cascadeBuckets)) {
-            Identity.useIdentity(IdentityEnum.ACCOUNT, location);
-            const res = await this.createS3Client().send(
-                new HeadObjectCommand({ Bucket: bucket, Key: objectName }),
-            );
-
-            const expectedStatus = location === sourceLocation ? 'COMPLETED' : 'REPLICA';
+Then(
+    'the cascade replication states should stay settled for {int} seconds',
+    { timeout: 60_000 },
+    async function (this: Zenko, holdSeconds: number) {
+        const deadline = Date.now() + holdSeconds * 1000;
+        while (Date.now() < deadline) {
+            await new Promise(resolve => setTimeout(resolve, 1000));
+            const changed = await cascadeUnsettledReason(this);
             assert.strictEqual(
-                res.ReplicationStatus,
-                expectedStatus,
-                `Expected ReplicationStatus '${expectedStatus}' at '${location}', got '${res.ReplicationStatus}'`,
-            );
-
-            const pendingBackends = Object.entries(res.Metadata ?? {})
-                .filter(([key, value]) => key.endsWith('-replication-status') && value === 'PENDING');
-            assert.strictEqual(
-                pendingBackends.length, 0,
-                `Location '${location}' still has PENDING backends after settling: ${
-                    pendingBackends.map(([k, v]) => `${k}=${v}`).join(', ')
-                }`,
+                changed, undefined,
+                `cascade states were not settled during the ${holdSeconds}s observation window. ${changed}`,
             );
         }
     },

--- a/tests/functional/ctst/steps/crrCascade.ts
+++ b/tests/functional/ctst/steps/crrCascade.ts
@@ -14,6 +14,8 @@ import { Identity, IdentityEnum, Utils } from 'cli-testing';
 import Zenko from 'world/Zenko';
 
 const STEP_TIMEOUT_MS = 300_000;
+const POLL_MS = 3_000;
+const STABILITY_INTERVAL_MS = 1_000;
 
 export interface CRRAccountInfo {
     AccessKeyId: string;
@@ -131,7 +133,7 @@ Then(
             if (found) {
                 return;
             }
-            await new Promise(resolve => setTimeout(resolve, 3000));
+            await Utils.sleep(POLL_MS);
         }
         assert.fail(
             `Timeout: tag 'cascade-test-tag=${tagValue}' not found at '${location}' after ${timeoutSeconds}s`,
@@ -161,7 +163,7 @@ Then(
                 );
                 lastStatus = res.ReplicationStatus ?? 'unset';
                 if (res.ReplicationStatus === 'PENDING') {
-                    await new Promise(resolve => setTimeout(resolve, 3000));
+                    await Utils.sleep(POLL_MS);
                     continue;
                 }
                 assert.strictEqual(
@@ -179,7 +181,7 @@ Then(
                     throw err;
                 }
                 lastStatus = 'not found';
-                await new Promise(resolve => setTimeout(resolve, 3000));
+                await Utils.sleep(POLL_MS);
             }
         }
         assert.fail(
@@ -209,7 +211,7 @@ Then(
                 `Object at '${location}' was found with ReplicationStatus=PENDING, ` +
                 'indicating the cascade loop wrote back to the source.',
             );
-            await new Promise(resolve => setTimeout(resolve, 1000));
+            await Utils.sleep(STABILITY_INTERVAL_MS);
         }
     },
 );
@@ -254,7 +256,7 @@ Then(
             if (unsettled === undefined) {
                 return;
             }
-            await new Promise(resolve => setTimeout(resolve, 3000));
+            await Utils.sleep(POLL_MS);
         }
         assert.fail(`cascade states did not settle within ${settleSeconds}s. ${unsettled}`);
     },
@@ -266,7 +268,7 @@ Then(
     async function (this: Zenko, holdSeconds: number) {
         const deadline = Date.now() + holdSeconds * 1000;
         while (Date.now() < deadline) {
-            await new Promise(resolve => setTimeout(resolve, 1000));
+            await Utils.sleep(STABILITY_INTERVAL_MS);
             const changed = await cascadeUnsettledReason(this);
             assert.strictEqual(
                 changed, undefined,
@@ -342,7 +344,7 @@ Then(
                 );
                 return;
             }
-            await new Promise(resolve => setTimeout(resolve, 3000));
+            await Utils.sleep(POLL_MS);
         }
 
         assert.fail(`Cascade locations did not converge to the same marker within ${timeoutSeconds}s`);


### PR DESCRIPTION
Reduced to one topic. The other two are split out as #2486 (diagnostics and step budgets) and #2487 (the loop guard).

The step waited a blind 15s and asserted once. That single observation had to be lucky twice: late enough for every location to have settled, and early enough that a loop writing back to the source had not already been overwritten. In the July census it was late by 21s — location C reached REPLICA *after* the assertion had failed — and the same shape can pass by observing a loop before its write-back lands.

So it now polls until every location reaches its expected state, then holds: keeps checking for a further window and fails if anything moves again. @SylvainSenechal — this is the two-phase version we landed on: the "nothing more happens while watching" part you wanted is the hold phase, and the polling only replaces the blind sleep before it.

**Now two steps**, per @DarkIsDude's point about the "and" in the name — they answer different questions and each carries its own budget:

```gherkin
Then the cascade replication states should settle within 120 seconds
And the cascade replication states should stay settled for 15 seconds
```

**The check moved out of the step body** into `cascadeUnsettledReason`, which both steps share.

**Error handling is unchanged.** An earlier revision of this PR retried failed reads to the deadline; that was scope creep and is removed. A failed read fails the step, exactly as before. The wider inconsistency in this file — `should have the expected tags` has no retry, `should replicate to location` retries only 404 — predates this PR and is better fixed deliberately than as a side effect here.

On the per-poll S3 client: left as is, per @SylvainSenechal — the client lifecycle wants its own refactor.

Not carried over: the budget guard from #2486. Its two steps and these two would be better off sharing one convention, but that is a follow-up once one of them lands rather than a reason to couple the PRs.

Issue: ZENKO-5340