### PR TITLE
Stop the checkout token shadowing the app token in the e2e jobs

### DIFF
--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -381,6 +381,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false # otherwise, the token is not passed to the next steps
       - name: Install dependencies
         uses: ./.github/actions/install-end2end-dependencies
       - name: Wait for Docker daemon to be ready
@@ -449,6 +451,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false # otherwise, the token is not passed to the next steps
       - name: Install dependencies
         uses: ./.github/actions/install-end2end-dependencies
       - name: Wait for Docker daemon to be ready
@@ -515,6 +519,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false # otherwise, the token is not passed to the next steps
       - name: Install dependencies
         uses: ./.github/actions/install-end2end-dependencies
       - name: Wait for Docker daemon to be ready
@@ -569,6 +575,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false # otherwise, the token is not passed to the next steps
       - name: Install dependencies
         uses: ./.github/actions/install-end2end-dependencies
       - name: Wait for Docker daemon to be ready

--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -356,7 +356,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          persist-credentials: false # otherwise, the token is not passed to the next steps
+          persist-credentials: false
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:
@@ -382,7 +382,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          persist-credentials: false # otherwise, the token is not passed to the next steps
+          persist-credentials: false
       - name: Install dependencies
         uses: ./.github/actions/install-end2end-dependencies
       - name: Wait for Docker daemon to be ready
@@ -452,7 +452,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          persist-credentials: false # otherwise, the token is not passed to the next steps
+          persist-credentials: false
       - name: Install dependencies
         uses: ./.github/actions/install-end2end-dependencies
       - name: Wait for Docker daemon to be ready
@@ -520,7 +520,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          persist-credentials: false # otherwise, the token is not passed to the next steps
+          persist-credentials: false
       - name: Install dependencies
         uses: ./.github/actions/install-end2end-dependencies
       - name: Wait for Docker daemon to be ready
@@ -576,7 +576,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          persist-credentials: false # otherwise, the token is not passed to the next steps
+          persist-credentials: false
       - name: Install dependencies
         uses: ./.github/actions/install-end2end-dependencies
       - name: Wait for Docker daemon to be ready


### PR DESCRIPTION
`Setup Node environment` fails whenever the yarn cache misses. It is invisible today only because the cache almost always hits.

```
error Command failed.  Exit code: 128
Command: git   Arguments: ls-remote --tags --heads https://github.com/scality/cli-testing.git
remote: Repository not found.
```

## Why

`actions/checkout@v6` defaults to `persist-credentials: true`, which writes the Zenko-scoped `GITHUB_TOKEN` into a credentials file and attaches it to the repo:

```
git config --file .../git-credentials-<uuid>.config http.https://github.com/.extraheader AUTHORIZATION: basic ***
git config --local includeIf.gitdir:/home/runner/work/Zenko/Zenko/.git.path .../git-credentials-<uuid>.config
```

Every git command run from inside the working tree then sends that token to github.com — including the `git ls-remote` yarn issues for the private `cli-testing` dependency (`tests/functional/package.json:31`) — which shadows the App token `setup-node-env` configures via `url.…insteadOf`. The App token is scoped correctly (every caller passes `repositories: cli-testing`); it simply never gets used. GitHub answers 404 rather than 403 to avoid confirming a private repo exists.

On a cache hit yarn never contacts GitHub at all, which is why this stays hidden. In a 30-run census, **10 runs missed the cache and all 10 failed here; 20 hit it and all 20 passed.**

Left alone, the next change to `tests/functional/yarn.lock` invalidates the cache and gives every branch a guaranteed miss.

## Fix

`persist-credentials: false` on the checkout of the four jobs that use `setup-node-env`. This is not a new idea — `lint-functional-tests` already carries exactly this line, with the same comment, because it runs `yarn install` immediately and has no deploy step to hide behind. The other four were never updated.

Checked that nothing downstream relied on the persisted credentials: `install-end2end-dependencies`, `deploy`, `archive-artifacts` and `wait-docker-ready` run no git operations, and the only git call in the path is `deploy-metadata.sh:13`, which embeds its own token in the URL.

## Verification

A normal run passes either way, so this was verified with a temporary commit that busted the yarn cache key (since removed, and the lockfile is byte-identical to base). Run [31055160403](https://github.com/scality/Zenko/actions/runs/31055160403) concluded `success` with every job installing cold:

| job | Setup Node environment | log evidence |
|---|---|---|
| `lint-functional-tests` (control — already fixed) | success | `yarn cache is not found` |
| `end2end-pra` | success | `yarn cache is not found` |
| `end2end-2-shards-http` | success | `yarn cache is not found` |
| `end2end-sharded` | success | `yarn cache is not found` |
| `ctst-end2end-sharded` | success | `yarn cache is not found` |

The step took **149–171 s** against **45 s** warm, the 3–4x you would expect from a full cold install. Before this change, that same combination failed 10 out of 10 times.

Issue: ZENKO-5341