### PR TITLE
Keep the cascade step budgets under their timeout, and report the last observed status

### DIFF
--- a/tests/functional/ctst/features/replication/crrCascade.feature
+++ b/tests/functional/ctst/features/replication/crrCascade.feature
@@ -16,8 +16,8 @@ Feature: CRR Cascade Replication
         And replication is configured from location "crr-location-b" to "crr-location-c"
         And replication is configured from location "crr-location-a" to "crr-location-b"
         When an object "cascade-obj" of 0 bytes is put in location "crr-location-a"
-        Then the object should replicate to location "crr-location-b" within 300 seconds
-        And the object should replicate to location "crr-location-c" within 300 seconds
+        Then the object should replicate to location "crr-location-b" within 280 seconds
+        And the object should replicate to location "crr-location-c" within 280 seconds
         When I wait 15 seconds
         Then the cascade replication states should be settled
 
@@ -34,8 +34,8 @@ Feature: CRR Cascade Replication
         And replication is configured from location "crr-location-b" to "crr-location-c"
         And replication is configured from location "crr-location-c" to "crr-location-a"
         When an object "<objectName>" of <bodySize> bytes is put in location "crr-location-a"
-        Then the object should replicate to location "crr-location-b" within 300 seconds
-        And the object should replicate to location "crr-location-c" within 300 seconds
+        Then the object should replicate to location "crr-location-b" within 280 seconds
+        And the object should replicate to location "crr-location-c" within 280 seconds
         And the object at location "crr-location-a" should never have replication status PENDING within 30 seconds
         When I wait 15 seconds
         Then the cascade replication states should be settled
@@ -58,10 +58,10 @@ Feature: CRR Cascade Replication
         And replication is configured from location "crr-location-b" to "crr-location-c"
         And replication is configured from location "crr-location-c" to "crr-location-a"
         When an object "cascade-tag-loop-obj" of 42 bytes is put in location "crr-location-a"
-        Then the object should replicate to location "crr-location-b" within 300 seconds
-        And the object should replicate to location "crr-location-c" within 300 seconds
+        Then the object should replicate to location "crr-location-b" within 280 seconds
+        And the object should replicate to location "crr-location-c" within 280 seconds
         When tags are put on the object "cascade-tag-loop-obj" in location "crr-location-a"
-        Then the object at location "crr-location-c" should have the expected tags within 300 seconds
+        Then the object at location "crr-location-c" should have the expected tags within 280 seconds
         And the object at location "crr-location-a" should never have replication status PENDING within 30 seconds
         When I wait 15 seconds
         Then the cascade replication states should be settled
@@ -92,6 +92,6 @@ Feature: CRR Cascade Replication
         And replication is configured from location "crr-location-a" to "crr-location-b"
         And replication is configured from location "crr-location-b" to "crr-location-a"
         When an object "bidirectional-obj" of 42 bytes is put in location "crr-location-a"
-        Then the object should replicate to location "crr-location-b" within 300 seconds
+        Then the object should replicate to location "crr-location-b" within 280 seconds
         When I wait 15 seconds
         Then the cascade replication states should be settled

--- a/tests/functional/ctst/steps/crrCascade.ts
+++ b/tests/functional/ctst/steps/crrCascade.ts
@@ -13,6 +13,8 @@ import assert from 'assert';
 import { Identity, IdentityEnum, Utils } from 'cli-testing';
 import Zenko from 'world/Zenko';
 
+const STEP_TIMEOUT_MS = 300_000;
+
 export interface CRRAccountInfo {
     AccessKeyId: string;
     SecretAccessKey: string;
@@ -107,8 +109,12 @@ When('tags are put on the object {string} in location {string}',
 
 Then(
     'the object at location {string} should have the expected tags within {int} seconds',
-    { timeout: 300_000 },
+    { timeout: STEP_TIMEOUT_MS },
     async function (this: Zenko, location: string, timeoutSeconds: number) {
+        assert.ok(
+            timeoutSeconds * 1000 < STEP_TIMEOUT_MS,
+            `budget of ${timeoutSeconds}s exceeds the step timeout of ${STEP_TIMEOUT_MS / 1000}s`,
+        );
         const bucket = this.getSaved<Record<string, string>>('cascadeBuckets')[location];
         const objectName = this.getSaved<string>('cascadeObjectName');
         const tagValue = this.getSaved<string>('cascadeTagValue');
@@ -135,8 +141,12 @@ Then(
 
 Then(
     'the object should replicate to location {string} within {int} seconds',
-    { timeout: 300_000 },
+    { timeout: STEP_TIMEOUT_MS },
     async function (this: Zenko, location: string, timeoutSeconds: number) {
+        assert.ok(
+            timeoutSeconds * 1000 < STEP_TIMEOUT_MS,
+            `budget of ${timeoutSeconds}s exceeds the step timeout of ${STEP_TIMEOUT_MS / 1000}s`,
+        );
         const bucket = this.getSaved<Record<string, string>>('cascadeBuckets')[location];
         const objectName = this.getSaved<string>('cascadeObjectName');
         const deadline = Date.now() + timeoutSeconds * 1000;

--- a/tests/functional/ctst/steps/crrCascade.ts
+++ b/tests/functional/ctst/steps/crrCascade.ts
@@ -153,11 +153,13 @@ Then(
         Identity.useIdentity(IdentityEnum.ACCOUNT, location);
         const client = this.createS3Client();
         const expectedContentLength = this.getSaved<number>('cascadeExpectedContentLength');
+        let lastStatus = 'unknown';
         while (Date.now() < deadline) {
             try {
                 const res = await client.send(
                     new HeadObjectCommand({ Bucket: bucket, Key: objectName }),
                 );
+                lastStatus = res.ReplicationStatus ?? 'unset';
                 if (res.ReplicationStatus === 'PENDING') {
                     await new Promise(resolve => setTimeout(resolve, 3000));
                     continue;
@@ -176,10 +178,14 @@ Then(
                 if (status !== 404) {
                     throw err;
                 }
+                lastStatus = 'not found';
                 await new Promise(resolve => setTimeout(resolve, 3000));
             }
         }
-        assert.fail(`Timeout: object '${objectName}' not found in bucket '${bucket}' after ${timeoutSeconds}s`);
+        assert.fail(
+            `Timeout: object '${objectName}' in bucket '${bucket}' did not replicate after `
+            + `${timeoutSeconds}s, last observed ReplicationStatus: ${lastStatus}`,
+        );
     },
 );
 


### PR DESCRIPTION
Split out of #2480, which mixed three topics. This is the diagnostics one.

**The failure message was wrong.** The replication step polls HEAD until the object reaches REPLICA and treats a 404 as "not there yet". On timeout it reported the object as *missing* — true only if the last HEAD had 404ed. An object sitting at PENDING for the whole budget was reported as absent, which sends the investigation looking for a lost object instead of a stalled replication. It now names what the last HEAD actually saw: a status, `unset` when the header is absent, or `not found` when it 404ed.

**The step could not report at all.** The feature file asked for exactly the step's own cucumber timeout, so cucumber killed the step at the same moment its deadline passed and the `assert.fail` never ran — the run showed a bare step timeout with no diagnostic.

Taking @DarkIsDude's suggestion: the timeout stays at 300s and the budgets drop to 280s, so the headroom lives in the feature file rather than in a raised timeout. The step asserts the relationship on entry, so `within 500 seconds` fails in milliseconds naming both numbers instead of silently losing the diagnostic again. No shared helper — it is two call sites in one file, and the value is per-step.

Out of scope: `all cascade locations should converge...` takes a 300s budget against a 600s timeout, so it already has headroom and is untouched.

The two commits are one failure mode from both sides: a better message that never runs is useless, and surviving long enough to print the wrong message is no better.

Issue: ZENKO-5340