### PR TITLE
Stop the cascade loop guard accusing the product, and stop it passing vacuously

### DIFF
--- a/tests/functional/ctst/features/replication/crrCascade.feature
+++ b/tests/functional/ctst/features/replication/crrCascade.feature
@@ -36,7 +36,7 @@ Feature: CRR Cascade Replication
         When an object "<objectName>" of <bodySize> bytes is put in location "crr-location-a"
         Then the object should replicate to location "crr-location-b" within 300 seconds
         And the object should replicate to location "crr-location-c" within 300 seconds
-        And the object at location "crr-location-a" should never have replication status PENDING within 30 seconds
+        And the object at location "crr-location-a" should not return to replication status PENDING within 30 seconds
         When I wait 15 seconds
         Then the cascade replication states should be settled
 
@@ -62,7 +62,7 @@ Feature: CRR Cascade Replication
         And the object should replicate to location "crr-location-c" within 300 seconds
         When tags are put on the object "cascade-tag-loop-obj" in location "crr-location-a"
         Then the object at location "crr-location-c" should have the expected tags within 300 seconds
-        And the object at location "crr-location-a" should never have replication status PENDING within 30 seconds
+        And the object at location "crr-location-a" should not return to replication status PENDING within 30 seconds
         When I wait 15 seconds
         Then the cascade replication states should be settled
 

--- a/tests/functional/ctst/steps/crrCascade.ts
+++ b/tests/functional/ctst/steps/crrCascade.ts
@@ -174,7 +174,7 @@ Then(
 );
 
 Then(
-    'the object at location {string} should never have replication status PENDING within {int} seconds',
+    'the object at location {string} should not return to replication status PENDING within {int} seconds',
     { timeout: 120_000 },
     async function (this: Zenko, location: string, waitSeconds: number) {
         const cascadeBuckets = this.getSaved<Record<string, string>>('cascadeBuckets');
@@ -203,6 +203,11 @@ Then(
             }
             await new Promise(resolve => setTimeout(resolve, 1000));
         }
+        assert.ok(
+            settledAs,
+            `Object at '${location}' never left ReplicationStatus=PENDING within ${waitSeconds}s, `
+            + 'so its outbound replication status was never written back',
+        );
     },
 );
 

--- a/tests/functional/ctst/steps/crrCascade.ts
+++ b/tests/functional/ctst/steps/crrCascade.ts
@@ -183,16 +183,24 @@ Then(
         const deadline = Date.now() + waitSeconds * 1000;
         Identity.useIdentity(IdentityEnum.ACCOUNT, location);
         const client = this.createS3Client();
+        // only a PENDING seen after the source settled means the cascade looped
+        let settledAs: string | undefined;
         while (Date.now() < deadline) {
             const result = await client.send(
                 new HeadObjectCommand({ Bucket: bucket, Key: objectName }),
             );
-            assert.notStrictEqual(
-                result.ReplicationStatus,
-                'PENDING',
-                `Object at '${location}' was found with ReplicationStatus=PENDING, ` +
-                'indicating the cascade loop wrote back to the source.',
-            );
+            if (settledAs === undefined) {
+                if (result.ReplicationStatus !== 'PENDING') {
+                    settledAs = result.ReplicationStatus ?? 'unset';
+                }
+            } else {
+                assert.notStrictEqual(
+                    result.ReplicationStatus,
+                    'PENDING',
+                    `Object at '${location}' returned to ReplicationStatus=PENDING after ` +
+                    `settling to '${settledAs}', indicating the cascade wrote back to the source.`,
+                );
+            }
             await new Promise(resolve => setTimeout(resolve, 1000));
         }
     },


### PR DESCRIPTION
Split out of #2480, which mixed three topics. This is the loop guard.

The step polls the source for 30s asserting it is never PENDING, to catch a cascade that writes back round the loop. It had a failure at each end.

**It accused the product of a bug it did not have.** The source is legitimately PENDING until its own outbound replication status is written back, so a PENDING observed *before* the source has settled says nothing about the loop. When replication was slow the guard failed there and reported a write-back that had not happened. It now waits for the source to reach a non-PENDING status first, and only judges PENDING observations after that.

**It passed when the object was PENDING the whole time.** With the gate above, an object that never settles never reaches the assertion — so a step named "should never have replication status PENDING" passed for an object that was PENDING for every single poll. That is the one outcome it could least afford to wave through: it means the outbound status was never written back at all. It now fails, with a message that says so rather than blaming the loop.

The step is renamed to `should not return to replication status PENDING`, which is what it actually asserts.

Worth a reviewer's eye: the window stays at the existing 30s. If the source's write-back turns out to be slower than that under churn, this converts a silent pass into a failure — it is one number in the feature file, and the failure message distinguishes "never settled" from "returned to PENDING" so which case fired is unambiguous.

Issue: ZENKO-5340