### PR TITLE
Guard the step budgets that come from the feature file

### DIFF
--- a/tests/functional/ctst/common/utils.ts
+++ b/tests/functional/ctst/common/utils.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import { exec } from 'child_process';
 import http from 'http';
 import { createHash } from 'crypto';
@@ -17,6 +18,14 @@ import { ITestCaseHookParameter } from '@cucumber/cucumber';
 import { AWSCredentials, Utils } from 'cli-testing';
 import { createBucketWithConfiguration, putObject } from '../steps/utils/utils';
 import { createJobAndWaitForCompletion } from '../steps/utils/kubernetes';
+
+export function assertBudgetFitsStepTimeout(budgetSeconds: number, stepTimeoutMs: number): void {
+    assert.ok(
+        budgetSeconds * 1000 < stepTimeoutMs,
+        `budget of ${budgetSeconds}s does not fit the step timeout of ${stepTimeoutMs / 1000}s: `
+        + 'raise the step timeout, or the step will be killed before it can report',
+    );
+}
 
 /**
  * This helper will dynamically extract a property from a CLI result

--- a/tests/functional/ctst/steps/crrCascade.ts
+++ b/tests/functional/ctst/steps/crrCascade.ts
@@ -15,6 +15,10 @@ import { Identity, IdentityEnum, Utils } from 'cli-testing';
 import Zenko from 'world/Zenko';
 
 const REPLICATE_STEP_TIMEOUT_MS = 300_000;
+const LOOP_GUARD_STEP_TIMEOUT_MS = 120_000;
+const SETTLE_STEP_TIMEOUT_MS = 180_000;
+const HOLD_STEP_TIMEOUT_MS = 60_000;
+const CONVERGE_STEP_TIMEOUT_MS = 600_000;
 const POLL_MS = 3_000;
 const STABILITY_INTERVAL_MS = 1_000;
 
@@ -188,8 +192,9 @@ Then(
 
 Then(
     'the object at location {string} should never have replication status PENDING within {int} seconds',
-    { timeout: 120_000 },
+    { timeout: LOOP_GUARD_STEP_TIMEOUT_MS },
     async function (this: Zenko, location: string, waitSeconds: number) {
+        assertBudgetFitsStepTimeout(waitSeconds, LOOP_GUARD_STEP_TIMEOUT_MS);
         const cascadeBuckets = this.getSaved<Record<string, string>>('cascadeBuckets');
         const objectName = this.getSaved<string>('cascadeObjectName');
         const bucket = cascadeBuckets[location];
@@ -242,8 +247,9 @@ async function cascadeUnsettledReason(world: Zenko): Promise<string | undefined>
 
 Then(
     'the cascade replication states should settle within {int} seconds',
-    { timeout: 180_000 },
+    { timeout: SETTLE_STEP_TIMEOUT_MS },
     async function (this: Zenko, settleSeconds: number) {
+        assertBudgetFitsStepTimeout(settleSeconds, SETTLE_STEP_TIMEOUT_MS);
         const deadline = Date.now() + settleSeconds * 1000;
         let unsettled: string | undefined;
         while (Date.now() < deadline) {
@@ -259,8 +265,9 @@ Then(
 
 Then(
     'the cascade replication states should stay settled for {int} seconds',
-    { timeout: 60_000 },
+    { timeout: HOLD_STEP_TIMEOUT_MS },
     async function (this: Zenko, holdSeconds: number) {
+        assertBudgetFitsStepTimeout(holdSeconds, HOLD_STEP_TIMEOUT_MS);
         const deadline = Date.now() + holdSeconds * 1000;
         while (Date.now() < deadline) {
             await Utils.sleep(STABILITY_INTERVAL_MS);
@@ -300,8 +307,9 @@ When('the object {string} is concurrently written {int} times to every cascade l
 
 Then(
     'all cascade locations should converge to the same metadata marker within {int} seconds',
-    { timeout: 600_000 },
+    { timeout: CONVERGE_STEP_TIMEOUT_MS },
     async function (this: Zenko, timeoutSeconds: number) {
+        assertBudgetFitsStepTimeout(timeoutSeconds, CONVERGE_STEP_TIMEOUT_MS);
         const cascadeBuckets = this.getSaved<Record<string, string>>('cascadeBuckets');
         const objectName = this.getSaved<string>('cascadeObjectName');
         const writtenMarkers = new Set(this.getSaved<string[]>('cascadeWrittenMarkers') ?? []);

--- a/tests/functional/ctst/steps/crrCascade.ts
+++ b/tests/functional/ctst/steps/crrCascade.ts
@@ -10,10 +10,11 @@ import {
     StorageClass,
 } from '@aws-sdk/client-s3';
 import assert from 'assert';
+import { assertBudgetFitsStepTimeout } from 'common/utils';
 import { Identity, IdentityEnum, Utils } from 'cli-testing';
 import Zenko from 'world/Zenko';
 
-const STEP_TIMEOUT_MS = 300_000;
+const REPLICATE_STEP_TIMEOUT_MS = 300_000;
 const POLL_MS = 3_000;
 const STABILITY_INTERVAL_MS = 1_000;
 
@@ -111,12 +112,9 @@ When('tags are put on the object {string} in location {string}',
 
 Then(
     'the object at location {string} should have the expected tags within {int} seconds',
-    { timeout: STEP_TIMEOUT_MS },
+    { timeout: REPLICATE_STEP_TIMEOUT_MS },
     async function (this: Zenko, location: string, timeoutSeconds: number) {
-        assert.ok(
-            timeoutSeconds * 1000 < STEP_TIMEOUT_MS,
-            `budget of ${timeoutSeconds}s exceeds the step timeout of ${STEP_TIMEOUT_MS / 1000}s`,
-        );
+        assertBudgetFitsStepTimeout(timeoutSeconds, REPLICATE_STEP_TIMEOUT_MS);
         const bucket = this.getSaved<Record<string, string>>('cascadeBuckets')[location];
         const objectName = this.getSaved<string>('cascadeObjectName');
         const tagValue = this.getSaved<string>('cascadeTagValue');
@@ -143,12 +141,9 @@ Then(
 
 Then(
     'the object should replicate to location {string} within {int} seconds',
-    { timeout: STEP_TIMEOUT_MS },
+    { timeout: REPLICATE_STEP_TIMEOUT_MS },
     async function (this: Zenko, location: string, timeoutSeconds: number) {
-        assert.ok(
-            timeoutSeconds * 1000 < STEP_TIMEOUT_MS,
-            `budget of ${timeoutSeconds}s exceeds the step timeout of ${STEP_TIMEOUT_MS / 1000}s`,
-        );
+        assertBudgetFitsStepTimeout(timeoutSeconds, REPLICATE_STEP_TIMEOUT_MS);
         const bucket = this.getSaved<Record<string, string>>('cascadeBuckets')[location];
         const objectName = this.getSaved<string>('cascadeObjectName');
         const deadline = Date.now() + timeoutSeconds * 1000;

--- a/tests/functional/ctst/steps/replication.ts
+++ b/tests/functional/ctst/steps/replication.ts
@@ -11,7 +11,7 @@ import assert from 'assert';
 import Zenko from '../world/Zenko';
 import { createAndRunPod, getLocationConfigs, getZenkoVersion } from 'steps/utils/kubernetes';
 import { getObject, headObject, putBucketReplicationRaw } from 'steps/utils/utils';
-import { safeJsonParse } from 'common/utils';
+import { assertBudgetFitsStepTimeout, safeJsonParse } from 'common/utils';
 import { replicationLockTags } from 'common/hooks';
 import { CRRAccountInfo } from './crrCascade';
 
@@ -237,6 +237,7 @@ type RuleRow = {
     deleteMarkerReplication?: string;
 };
 
+const REPLICATION_OUTCOME_STEP_TIMEOUT_MS = 600_000;
 const DEFAULT_ROLE = 'arn:aws:iam::root:role/s3-replication-role';
 
 function buildConfigFromRows(world: Zenko, srcBucket: string, rows: RuleRow[]): object {
@@ -466,8 +467,9 @@ Then('the replication configuration request should be rejected with {string}',
     });
 
 Then('the object replication should {string} within {int} seconds',
-    { timeout: 600_000 },
+    { timeout: REPLICATION_OUTCOME_STEP_TIMEOUT_MS },
     async function (this: Zenko, expectedOutcome: 'succeed' | 'fail' | 'never happen', timeoutSec: number) {
+        assertBudgetFitsStepTimeout(timeoutSec, REPLICATION_OUTCOME_STEP_TIMEOUT_MS);
         const objectName = this.getSaved<string>('objectName');
         const srcBucket = this.getSaved<string>('bucketName');
         const locations = this.getSaved<string[]>('replicationLocations') || [];


### PR DESCRIPTION
Follow-up to #2486, which guarded two steps this way. This does the remaining five.

A step that takes `within {int} seconds` from the feature file and enforces it against a fixed cucumber timeout gets killed at that timeout when the budget does not fit, losing its own failure message. `assertBudgetFitsStepTimeout` now lives in `common/utils.ts` and takes the timeout as an argument; all seven steps call it on entry, and each timeout is named after the step it governs.

Every budget in `features/` already fits. The tightest is the replication outcome step, 500s against 600s.

Steps whose budget is a constant in the same file stay in ZENKO-5344.

Issue: ZENKO-5344