### PR TITLE
Bump vault with signatureAge of 0 fix

### DIFF
--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -125,7 +125,7 @@ vault:
   dashboard: vault2/vault-dashboards
   policy: vault2/vault-policies
   image: vault2
-  tag: 8.10.5
+  tag: 8.10.6
   envsubst: VAULT_TAG
 zenko-operator:
   sourceRegistry: ghcr.io/scality


### PR DESCRIPTION
Picks up the vault fix accepting falsy constant params in request context validation: a signatureAge of 0 was dropped from the request context, failing policy evaluation.

Issue: [ZENKO-5348](https://scality.atlassian.net/browse/ZENKO-5348)

[ZENKO-5348]: https://scality.atlassian.net/browse/ZENKO-5348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ