### PR TITLE
INTEGRATION [PR#2492 > development/2.14] 🐛(ZENKO-5346) remove duplicated word in ConsumerLagWarning description

### DIFF
--- a/monitoring/kafka/alerts.test.yaml
+++ b/monitoring/kafka/alerts.test.yaml
@@ -272,7 +272,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               description:  |
-                Kafka consumer lag has been more more than 300 seconds
+                Kafka consumer lag has been more than 300 seconds
                 or more than 1000 messages for 5 minutes.
 
                 Current time lag is 8m 20s.
@@ -289,7 +289,7 @@ tests:
         exp_alerts:
           - exp_annotations:
               description:  |
-                Kafka consumer lag has been more more than 300 seconds
+                Kafka consumer lag has been more than 300 seconds
                 or more than 1000 messages for 5 minutes.
 
                 Current time lag is 1m 0s.
@@ -303,7 +303,7 @@ tests:
               kafkaCluster: ${cluster}
           - exp_annotations:
               description:  |
-                Kafka consumer lag has been more more than 300 seconds
+                Kafka consumer lag has been more than 300 seconds
                 or more than 1000 messages for 5 minutes.
 
                 Current time lag is 8m 20s.

--- a/monitoring/kafka/alerts.yaml
+++ b/monitoring/kafka/alerts.yaml
@@ -127,7 +127,7 @@ groups:
     annotations:
       summary: 'Kafka: consumer lag is too high for {{ $labels.group }}'
       description: |
-        Kafka consumer lag has been more more than ${maxConsumerLagSecondsWarningThreshold} seconds
+        Kafka consumer lag has been more than ${maxConsumerLagSecondsWarningThreshold} seconds
         or more than ${maxConsumerLagMessagesWarningThreshold} messages for 5 minutes.
 
         Current time lag is {{ with printf "kafka_consumergroup_group_max_lag_seconds{namespace=\"${namespace}\",cluster_name=\"${cluster}\",group=\"%s\"}"

--- a/tests/ctst/features/azureArchive.feature
+++ b/tests/ctst/features/azureArchive.feature
@@ -273,26 +273,34 @@ Feature: Azure Archive
         |               Versioned |           2 |      30000 |      10 |
         |               Suspended |           2 |      30000 |      10 |
 
-    @2.7.0
-    @PreMerge
-    @Flaky
-    @AzureArchive
-    Scenario Outline: Pause and resume archiving to azure (PutObject before pause)
-    Given a "<versioningConfiguration>" bucket
-    And <objectCount> objects "obj" of size <objectSize> bytes
-    And a transition workflow to "e2e-azure-archive" location
-    And that lifecycle is "paused" for the "e2e-azure-archive" location
-    Then the storage class of object "obj-1" must stay "" for <timeout> seconds
-    And the storage class of object "obj-2" must stay "" for <timeout> seconds
-    Given that lifecycle is "resumed" for the "e2e-azure-archive" location
-    Then object "obj-1" should be "transitioning" and have the storage class "e2e-azure-archive"
-    And object "obj-2" should be "transitioning" and have the storage class "e2e-azure-archive"
+# This test is flaky, and doesn't make much sense as it is :
+# Put object, setup Transition workflow, Then pause that transition,
+# but by the time the transition is paused,
+# the object is often already transitioned, so the test is failing on this step :
+# the storage class of object "obj-1" must stay ""
+# We should put the object after pausing the transition, 
+# but then we end up making the same test as the scenario above : "PutObject after pause"
 
-    Examples:
-        | versioningConfiguration | objectCount | objectSize | timeout |
-        |           Non versioned |           2 |      30000 |      10 |
-        |               Versioned |           2 |      30000 |      10 |
-        |               Suspended |           2 |      30000 |      10 |
+    # @2.7.0
+    # @PreMerge
+    # @Flaky
+    # @AzureArchive
+    # Scenario Outline: Pause and resume archiving to azure (PutObject before pause)
+    # Given a "<versioningConfiguration>" bucket
+    # And <objectCount> objects "obj" of size <objectSize> bytes
+    # And a transition workflow to "e2e-azure-archive" location
+    # And that lifecycle is "paused" for the "e2e-azure-archive" location
+    # Then the storage class of object "obj-1" must stay "" for <timeout> seconds
+    # And the storage class of object "obj-2" must stay "" for <timeout> seconds
+    # Given that lifecycle is "resumed" for the "e2e-azure-archive" location
+    # Then object "obj-1" should be "transitioning" and have the storage class "e2e-azure-archive"
+    # And object "obj-2" should be "transitioning" and have the storage class "e2e-azure-archive"
+
+    # Examples:
+    #     | versioningConfiguration | objectCount | objectSize | timeout |
+    #     |           Non versioned |           2 |      30000 |      10 |
+    #     |               Versioned |           2 |      30000 |      10 |
+    #     |               Suspended |           2 |      30000 |      10 |
 
     @2.7.0
     @PreMerge


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #2492.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/2.14/bugfix/ZENKO-5346/fix-consumer-lag-alert-typo`, please follow this
procedure:

```bash
 git fetch
 git checkout w/2.14/bugfix/ZENKO-5346/fix-consumer-lag-alert-typo
 # <amend or cancel the changeset by _adding_ new commits>
 git push origin w/2.14/bugfix/ZENKO-5346/fix-consumer-lag-alert-typo
```

Please always comment pull request #2492 instead of this one.