### PR TITLE
Fix releasing workflow

### DIFF
--- a/.github/workflows/end2end.yaml
+++ b/.github/workflows/end2end.yaml
@@ -667,7 +667,7 @@ jobs:
       - ctst-end2end-sharded
     steps:
       - name: Upload final status
-        uses: scality/actions/upload_final_status@1.9.0
+        uses: scality/actions/upload_final_status@1.17.0
         with:
           ARTIFACTS_USER: ${{ secrets.ARTIFACTS_USER }}
           ARTIFACTS_PASSWORD: ${{ secrets.ARTIFACTS_PASSWORD }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,12 +63,25 @@ jobs:
       build-type: ${{ inputs.type }}
     secrets: inherit
 
+  # Write the .final_status marker, which is required by the artifacts server
+  # before allowing promotion.
+  update-artifact-status:
+    needs: build-iso
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Upload final status
+        uses: scality/actions/upload_final_status@1.17.0
+        with:
+          ARTIFACTS_USER: ${{ secrets.ARTIFACTS_USER }}
+          ARTIFACTS_PASSWORD: ${{ secrets.ARTIFACTS_PASSWORD }}
+          JOBS_RESULTS: success
+
   release:
     name: Release
     runs-on: ubuntu-24.04
     needs:
       - verify-release
-      - build-iso
+      - update-artifact-status
     env:
       TAG: ${{ needs.verify-release.outputs.tag }}
     steps:
@@ -148,6 +161,7 @@ jobs:
     needs:
       - verify-release
       - build-iso
+      - update-artifact-status
       - create-deployments
       - release
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,18 +1,24 @@
 ---
 name: release
-run-name: Release (${{ inputs.type }}) on ${{ github.ref_name }}
+run-name: >-
+  ${{ inputs.tag
+      && format('Release {0}', inputs.tag)
+      || format('Trigger {0} on {1}', inputs.type, github.ref_name) }}
 
 on:
   workflow_dispatch:
     inputs:
       type:
-        description: 'Release type'
+        description: Release type
         required: true
         type: choice
         options:
           - release
           - preview
           - rc
+      tag:
+        description: Release tag (empty to auto-compute)
+        required: false
 
 jobs:
   verify-release:
@@ -36,6 +42,14 @@ jobs:
           echo "tag=$VERSION_FULL" >> "$GITHUB_OUTPUT"
           echo "prerelease=${VERSION_PRERELEASE:+true}" >> "$GITHUB_OUTPUT"
 
+      # Guards against the branch state changing between the compute pass
+      # and this re-dispatch.
+      - name: Check if tag matches computed version
+        if: inputs.tag != ''
+        shell: bash
+        run: |
+          [ "${{ inputs.tag }}" = "${{ steps.version.outputs.tag }}" ]
+
       - name: Check if tag matches the branch name
         shell: bash
         run: |
@@ -56,7 +70,36 @@ jobs:
         run: |
           ! git show-ref --tags ${{ steps.version.outputs.tag }} --quiet
 
+  # First-pass entry point: `run-name` in the workflow header is evaluated
+  # before any job runs, so it can't show the resolved version. When the user
+  # dispatches without a tag, we compute it in verify-release and self-dispatch
+  # here with `tag` set — the second run's run-name resolves to
+  # "Release X.Y.Z". All other jobs gate on `inputs.tag != ''` so they run
+  # only in the second pass.
+  trigger-release:
+    if: inputs.tag == ''
+    needs: verify-release
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: write
+    steps:
+      - name: Trigger release with computed tag
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'release.yaml',
+              ref: context.ref,
+              inputs: {
+                type: '${{ inputs.type }}',
+                tag: '${{ needs.verify-release.outputs.tag }}',
+              },
+            });
+
   build-iso:
+    if: inputs.tag != ''
     needs: verify-release
     uses: ./.github/workflows/build-iso.yaml
     with:

--- a/tests/workflows/release.spec.ts
+++ b/tests/workflows/release.spec.ts
@@ -188,15 +188,24 @@ const Fail = { toString: () => "fail", value: () => 1 };
 //   hotfix/2.3.6:
 //     --release -> 2.3.6-1
 //     --rc      -> 2.3.6-1-rc.1
+// A non-empty `tag` sets the workflow_dispatch `tag` input and exercises the
+// second pass (build + release + promote). An empty `tag` leaves the input
+// unset and exercises the first pass, which either fails in verify-release
+// or (on success) fires the redispatch job.
 test.each([
     ['Promote artifacts', Pass, 'release', '2.3.7', ''],
     ['Promote artifacts', Pass, 'rc', '2.3.7-rc.1', ''],
     ['Promote artifacts', Pass, 'preview', '2.3.7-preview.1', ''],
     ['Promote artifacts', Pass, 'release', '2.3.6-1', withBranch('hotfix/2.3.6')],
     ['Promote artifacts', Pass, 'rc', '2.3.6-1-rc.1', withBranch('hotfix/2.3.6')],
-    ['Compute version', Fail, 'release', '', withBranch('improvement/ZENKO-1234')],
+    ['Compute version', Fail, 'release', '2.3.7', withBranch('improvement/ZENKO-1234')],
     ['Check if tag matches the branch name', Fail, 'release', '2.3.7', withBranch('q/2.3')],
     ['Check if tag has not already been created', Fail, 'release', '2.3.7', withRacingTag('2.3.7')],
+    // The following tests exercise the first pass (compute version + re-trigger)
+    ['Trigger release with computed tag', Pass, 'release', '', ''],
+    ['Compute version', Fail, 'release', '', withBranch('improvement/ZENKO-1234')],
+    ['Check if tag matches the branch name', Fail, 'release', '', withBranch('q/2.3')],
+    ['Check if tag has not already been created', Fail, 'release', '', withRacingTag('2.3.7')],
 ])("%s should %s when making %s %s%s", async (stepName, status, type, tag, ...configs) => {
 
     for(var c of configs.filter(c => !!c)) {
@@ -205,6 +214,9 @@ test.each([
     }
 
     act.setInput("type", type as string);
+    if (tag) {
+        act.setInput("tag", tag as string);
+    }
 
     const prerelease = type !== 'release';
 
@@ -222,6 +234,17 @@ test.each([
             mockapi.mock.artifacts.root
                 .upload()
                 .reply({ status: 200, data: "OK" }),
+
+            // Redispatch (first pass only): trigger-release triggers the second pass.
+            moctokit.rest.actions
+                .createWorkflowDispatch({
+                    owner: 'scality',
+                    repo: 'Zenko',
+                    workflow_id: 'release.yaml',
+                    ref: await currentBranch(),
+                    inputs: { type, tag: tag || '2.3.7' },
+                } as any)
+                .reply({ status: 204, data: {} } as any),
 
             // Mock artifact promotion: copy + set index
             mockapi.mock.artifacts.root
@@ -375,6 +398,15 @@ test.each([
                     },
                 }],
             } : {}),
+            'trigger-release': [{
+                // Need to explicitely pass token, the GITHUB_TOKEN does not seem to be set
+                uses: 'actions/github-script@v7',
+                mockWith: {
+                    with: {
+                        'github-token': "my-token",
+                    },
+                },
+            }],
             'update-artifact-status': [{
                 // upload_final_status@1.17.0 wraps action-artifacts@v4 in a
                 // composite that doesn't forward `token:`, so its nested

--- a/tests/workflows/release.spec.ts
+++ b/tests/workflows/release.spec.ts
@@ -371,10 +371,20 @@ test.each([
                     after: 'Compute version',
                     mockWith: {
                         name: 'Concurrent release creates the tag',
-                        run: 'git tag ' + racingTag,
+                        run: 'git tag --no-sign ' + racingTag,
                     },
                 }],
             } : {}),
+            'update-artifact-status': [{
+                // upload_final_status@1.17.0 wraps action-artifacts@v4 in a
+                // composite that doesn't forward `token:`, so its nested
+                // post-step (setDefaultIndex) can't authenticate. Thus we
+                // neutralize the step with `if: false` instead.
+                uses: 'scality/actions/upload_final_status@1.17.0',
+                mockWith: {
+                    if: 'false',
+                },
+            }],
             'release': [{
                 // Need to explicitely pass token, the GITHUB_TOKEN does not seem to be set
                 uses: 'softprops/action-gh-release@v3',


### PR DESCRIPTION
Recently improved release workflow was failing to promote artifact, as that artifact was not flagged as "build complete": add an extra step to do this, before proceeding with the release.

Also the new workflow could not show the version being released in the workflow runs name, as that version is computed and there is no way to _update_ the run name once it is started.
To work around that, the workflow will now retrigger itself with the tag once it has computed it: so there will be one "trigger on dev/x.y" run, and one "release x.y.z" run.
It could have been separate in 2 workflows, but keeping it in a single to avoid duplication (same validation in both cases) and keep the same experience as all other repos (you want a release, just run the release workflow as usual).

Issue: ZENKO-5279
