### PR TITLE
Bump cloudserver 9.4.2, backbeat 9.5.1, zkop 1.8.16 + Redis limits

### DIFF
--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -16,7 +16,7 @@ cloudserver:
   sourceRegistry: ghcr.io/scality
   dashboard: cloudserver/cloudserver-dashboards
   image: cloudserver
-  tag: 9.4.0-preview.6
+  tag: 9.4.2
   envsubst: CLOUDSERVER_TAG
 drctl:
   sourceRegistry: ghcr.io/scality

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -131,7 +131,7 @@ zenko-operator:
   sourceRegistry: ghcr.io/scality
   dashboard: zenko-operator/zenko-operator-dashboards
   image: zenko-operator
-  tag: v1.8.15
+  tag: v1.8.16
   envsubst: ZENKO_OPERATOR_TAG
 zookeeper:
   sourceRegistry: ghcr.io/adobe/zookeeper-operator

--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -6,7 +6,7 @@ backbeat:
   dashboard: backbeat/backbeat-dashboards
   image: backbeat
   policy: backbeat/backbeat-policies
-  tag: 9.5.0-preview.9
+  tag: 9.5.1
   envsubst: BACKBEAT_TAG
 busybox:
   image: busybox

--- a/solution/zenkoversion.yaml
+++ b/solution/zenkoversion.yaml
@@ -141,6 +141,13 @@ spec:
     zookeeperResources:
       requestMemory: 1Gi
       limitMemory: 1Gi
+    redisResources:
+      db:
+        requestMemory: 32Mi
+        limitMemory: 256Mi
+      exporter:
+        requestMemory: 32Mi
+        limitMemory: 256Mi
   featureFlags:
     lifecycleOptimization: true
     manageKafkaTopics: true


### PR DESCRIPTION
Bumps three components to their latest released versions, moving cloudserver and backbeat off preview tags onto proper releases:

- cloudserver `9.4.0-preview.6` -> `9.4.2`
- backbeat `9.5.0-preview.9` -> `9.5.1`
- zenko-operator `v1.8.15` -> `v1.8.16`

It also sets memory requests/limits for the Redis containers. Until ZKOP-554, Redis ran with no memory limit at all and there was no way to configure one. That change added `spec.defaults.redisResources` to the ZenkoVersion CR, so this PR uses it to set 32Mi request / 256Mi limit on both the `db` and `exporter` containers.

Notes:
- Ordering matters: the `redisResources` field only exists from zenko-operator 1.8.16, which is why the operator bump and the ZenkoVersion change ship together. Applying the ZenkoVersion change against an older operator would leave the field ignored.
- The 32Mi/256Mi values are deliberately conservative. Zenko's Redis instance only holds ephemeral metrics/cache data, so the working set is small; 256Mi leaves plenty of headroom while still capping a runaway. Worth a sanity check against what you have seen in the field.

Issue: ZENKO-5350