### PR TITLE
Bump scuba to 1.1.24

### DIFF
--- a/solution/deps.yaml
+++ b/solution/deps.yaml
@@ -106,7 +106,7 @@ scuba:
   sourceRegistry: ghcr.io/scality
   dashboard: scuba/scuba-dashboards
   image: scuba
-  tag: 1.1.0-preview.9
+  tag: 1.1.24
   envsubst: SCUBA_TAG
 sorbet:
   sourceRegistry: ghcr.io/scality


### PR DESCRIPTION
(Claude wrote 3 pages for this but... it's just a bump :stuck_out_tongue:)

The bump includes:
- many commits not by us, that were analyzed in ZENKO-5347 and shouldn't impact us
- recent commits by us, to reduce CTST flakiness and some actual issues esp with inflights